### PR TITLE
Rule redefinition deletes old rule completely

### DIFF
--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -62,19 +62,20 @@ public class LogicManager {
         this.typeResolver = new TypeResolver(logicCache, traversalEng, conceptMgr);
     }
 
-
     GraphManager graph() { return graphMgr; }
 
     public TypeResolver typeResolver() {
         return typeResolver;
     }
 
+    public void deleteAndInvalidateRule(Rule rule) {
+        rule.delete();
+        logicCache.rule().invalidate(rule.getLabel());
+    }
+
     public Rule putRule(String label, Conjunction<? extends Pattern> when, ThingVariable<?> then) {
         Rule rule = getRule(label);
-        if (rule != null) {
-            rule.delete();
-            logicCache.rule().invalidate(label);
-        }
+        if (rule != null) deleteAndInvalidateRule(rule);
         return logicCache.rule().get(label, l -> Rule.of(label, when, then, graphMgr, conceptMgr, this));
     }
 

--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -70,10 +70,9 @@ public class LogicManager {
     }
 
     public Rule putRule(String label, Conjunction<? extends Pattern> when, ThingVariable<?> then) {
-        RuleStructure structure = graphMgr.schema().rules().get(label);
-        if (structure != null) {
-            // overwriting a rule means we purge it and re-create the rule
-            structure.delete();
+        Rule rule = getRule(label);
+        if (rule != null) {
+            rule.delete();
             logicCache.rule().invalidate(label);
         }
         return logicCache.rule().get(label, l -> Rule.of(label, when, then, graphMgr, conceptMgr, this));

--- a/query/Undefiner.java
+++ b/query/Undefiner.java
@@ -254,7 +254,7 @@ public class Undefiner {
             }
             com.vaticle.typedb.core.logic.Rule r = logicMgr.getRule(rule.label());
             if (r == null) throw TypeDBException.of(RULE_NOT_FOUND, rule.label());
-            r.delete();
+            logicMgr.deleteAndInvalidateRule(r);
         }
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Undefining or overwriting a rule incompletely deletes the previous rule before writing the new rule. This leads to #6311 and 6309, and is fixed by deleting a Rule completely.

## What are the changes implemented in this PR?
* Putting a rule that overwrites an old one deletes the old Rule, not just the Rule Structure
* Undefining a rule invalidates rule cache for that element too