### PR TITLE
Concludable and Retrievable Subsumption Caching

### DIFF
--- a/common/poller/AbstractPoller.java
+++ b/common/poller/AbstractPoller.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.vaticle.typedb.core.common.poller;
+
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public class AbstractPoller<T> implements Poller<T> {
+
+    @Override
+    public Optional<T> poll() {
+        return Optional.empty();
+    }
+
+    @Override
+    public <U> Poller<U> flatMap(Function<T, FunctionalIterator<U>> flatMappingFn) {
+        return new FlatMappedPoller<>(this, flatMappingFn);
+    }
+
+}

--- a/common/poller/FlatMappedPoller.java
+++ b/common/poller/FlatMappedPoller.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.vaticle.typedb.core.common.poller;
+
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.Iterators;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public class FlatMappedPoller<T, U> extends AbstractPoller<U> {
+
+    private final Poller<T> source;
+    private final Function<T, FunctionalIterator<U>> flatMappingFn;
+    private FunctionalIterator<U> currentIterator;
+
+    public FlatMappedPoller(AbstractPoller<T> poller, Function<T, FunctionalIterator<U>> flatMappingFn) {
+        this.source = poller;
+        this.flatMappingFn = flatMappingFn;
+        currentIterator = Iterators.empty();
+    }
+
+    @Override
+    public Optional<U> poll() {
+        mayFetchIterator();
+        if (currentIterator.hasNext()) return Optional.of(currentIterator.next());
+        else return Optional.empty();
+    }
+
+    private void mayFetchIterator() {
+        Optional<T> nextSource;
+        while (!currentIterator.hasNext() && (nextSource = source.poll()).isPresent()) {
+            currentIterator = flatMappingFn.apply(nextSource.get());
+        }
+    }
+
+}

--- a/common/poller/Poller.java
+++ b/common/poller/Poller.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.vaticle.typedb.core.common.poller;
+
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public interface Poller<T> {
+
+    Optional<T> poll();
+
+    <U> Poller<U> flatMap(Function<T, FunctionalIterator<U>> flatMappingFn);
+
+}

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,7 +49,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "d805084d1bf1364330c36f581d3a1b024a419d7e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "6d5f05f8f07621bc8803d47404e225c85ec11bc6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/logic/resolvable/Unifier.java
+++ b/logic/resolvable/Unifier.java
@@ -19,17 +19,22 @@ package com.vaticle.typedb.core.logic.resolvable;
 
 import com.vaticle.typedb.common.collection.Pair;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.Iterators;
 import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.concept.Concept;
 import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.concept.thing.Attribute;
 import com.vaticle.typedb.core.concept.type.ThingType;
+import com.vaticle.typedb.core.concept.type.Type;
 import com.vaticle.typedb.core.traversal.common.Identifier.Variable;
 import com.vaticle.typedb.core.traversal.common.Identifier.Variable.Retrievable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -92,9 +97,9 @@ public class Unifier {
      * Un-unify a map of concepts, with given identifiers. These must include anonymous and labelled concepts,
      * as they may be mapped to from a named variable, and may have requirements that need to be met.
      */
-    public Optional<ConceptMap> unUnify(Map<Variable, Concept> concepts, Requirements.Instance instanceRequirements) {
+    public FunctionalIterator<ConceptMap> unUnify(Map<Variable, Concept> concepts, Requirements.Instance instanceRequirements) {
 
-        if (!unifiedRequirements.exactlySatisfiedBy(concepts)) return Optional.empty();
+        if (!unifiedRequirements.exactlySatisfiedBy(concepts)) return Iterators.empty();
 
         Map<Retrievable, Concept> reversedConcepts = new HashMap<>();
         for (Map.Entry<Variable, Set<Retrievable>> entry : reverseUnifier.entrySet()) {
@@ -106,12 +111,37 @@ public class Unifier {
             Concept concept = concepts.get(toReverse);
             for (Retrievable r : reversed) {
                 if (!reversedConcepts.containsKey(r)) reversedConcepts.put(r, concept);
-                if (!reversedConcepts.get(r).equals(concept)) return Optional.empty();
+                if (!reversedConcepts.get(r).equals(concept)) return Iterators.empty();
             }
         }
 
-        if (instanceRequirements.satisfiedBy(reversedConcepts)) return Optional.of(new ConceptMap(reversedConcepts));
-        else return Optional.empty();
+        if (instanceRequirements.satisfiedBy(reversedConcepts)) return cartesianUnrestrictedNamedTypes(reversedConcepts, instanceRequirements);
+        else return Iterators.empty();
+    }
+
+    private static FunctionalIterator<ConceptMap> cartesianUnrestrictedNamedTypes(Map<Retrievable, Concept> initialConcepts,
+                                                                                  Requirements.Instance instanceRequirements) {
+        Map<Retrievable, Concept> fixedConcepts = new HashMap<>();
+        List<Variable.Name> namedTypeNames = new ArrayList<>();
+        List<FunctionalIterator<Type>> namedTypeSupers = new ArrayList<>();
+        initialConcepts.forEach((id, concept) -> {
+            if (id.isName() && concept.isType() && !instanceRequirements.hasRestriction(id)) {
+                namedTypeNames.add(id.asName());
+                namedTypeSupers.add(concept.asType().getSupertypes().map(t -> t));
+            } else fixedConcepts.put(id, concept);
+        });
+
+        if (namedTypeNames.isEmpty()) {
+            return Iterators.single(new ConceptMap(fixedConcepts));
+        } else {
+            return Iterators.cartesian(namedTypeSupers).map(permutation -> {
+                Map<Retrievable, Concept> concepts = new HashMap<>(fixedConcepts);
+                for (int i = 0; i < permutation.size(); i++) {
+                    concepts.put(namedTypeNames.get(i), permutation.get(i));
+                }
+                return new ConceptMap(concepts);
+            });
+        }
     }
 
     public Map<Retrievable, Set<Variable>> mapping() {
@@ -332,6 +362,10 @@ public class Unifier {
                     }
                 }
                 return true;
+            }
+
+            public boolean hasRestriction(Retrievable var) {
+                return requireCompatible.containsKey(var);
             }
 
             @Override

--- a/reasoner/ExplanationProducer.java
+++ b/reasoner/ExplanationProducer.java
@@ -51,7 +51,6 @@ public class ExplanationProducer implements Producer<Explanation> {
     private int iteration;
     private boolean requiresReiteration;
     private boolean done;
-
     private Queue<Explanation> queue;
 
     public ExplanationProducer(Conjunction conjunction, ConceptMap bounds, Options.Query options,

--- a/reasoner/resolution/ResolverRegistry.java
+++ b/reasoner/resolution/ResolverRegistry.java
@@ -73,7 +73,6 @@ public class ResolverRegistry {
     private final ConcurrentMap<Rule, Actor.Driver<ConclusionResolver>> ruleConclusions; // by Rule not Rule.Conclusion because well defined equality exists
     private final Set<Actor.Driver<? extends Resolver<?>>> resolvers;
     private final TraversalEngine traversalEngine;
-    private final Planner planner;
     private final boolean resolutionTracing;
     private final AtomicBoolean terminated;
     private ActorExecutorGroup executorService;
@@ -88,7 +87,6 @@ public class ResolverRegistry {
         this.ruleConditions = new ConcurrentHashMap<>();
         this.ruleConclusions = new ConcurrentHashMap<>();
         this.resolvers = new ConcurrentSet<>();
-        this.planner = new Planner(conceptMgr, logicMgr);
         this.terminated = new AtomicBoolean(false);
         this.resolutionTracing = resolutionTracing;
     }
@@ -106,7 +104,7 @@ public class ResolverRegistry {
         LOG.debug("Creating Root.Conjunction for: '{}'", conjunction);
         Actor.Driver<RootResolver.Conjunction> resolver = Actor.driver(driver -> new RootResolver.Conjunction(
                 driver, conjunction, onAnswer, onFail, onException, this,
-                traversalEngine, conceptMgr, logicMgr, planner, resolutionTracing
+                traversalEngine, conceptMgr, logicMgr, resolutionTracing
         ), executorService);
         resolvers.add(resolver);
         if (terminated.get()) throw TypeDBException.of(RESOLUTION_TERMINATED); // guard races without synchronized
@@ -147,7 +145,7 @@ public class ResolverRegistry {
         LOG.debug("Register retrieval for rule condition actor: '{}'", ruleCondition);
         Actor.Driver<ConditionResolver> resolver = ruleConditions.computeIfAbsent(ruleCondition.rule(), (r) -> Actor.driver(
                 driver -> new ConditionResolver(driver, ruleCondition, this, traversalEngine,
-                                                conceptMgr, logicMgr, planner, resolutionTracing), executorService
+                                                conceptMgr, logicMgr, resolutionTracing), executorService
         ));
         resolvers.add(resolver);
         if (terminated.get()) throw TypeDBException.of(RESOLUTION_TERMINATED); // guard races without synchronized
@@ -208,7 +206,7 @@ public class ResolverRegistry {
     public Actor.Driver<ConjunctionResolver.Nested> nested(Conjunction conjunction) {
         LOG.debug("Creating Conjunction resolver for : {}", conjunction);
         Actor.Driver<ConjunctionResolver.Nested> resolver = Actor.driver(driver -> new ConjunctionResolver.Nested(
-                driver, conjunction, this, traversalEngine, conceptMgr, logicMgr, planner, resolutionTracing
+                driver, conjunction, this, traversalEngine, conceptMgr, logicMgr, resolutionTracing
         ), executorService);
         resolvers.add(resolver);
         if (terminated.get()) throw TypeDBException.of(RESOLUTION_TERMINATED); // guard races without synchronized
@@ -217,9 +215,12 @@ public class ResolverRegistry {
 
     public Actor.Driver<DisjunctionResolver.Nested> nested(Disjunction disjunction) {
         LOG.debug("Creating Disjunction resolver for : {}", disjunction);
-        return Actor.driver(driver -> new DisjunctionResolver.Nested(
+        Actor.Driver<DisjunctionResolver.Nested> resolver = Actor.driver(driver -> new DisjunctionResolver.Nested(
                 driver, disjunction, this, traversalEngine, conceptMgr, resolutionTracing
         ), executorService);
+        resolvers.add(resolver);
+        if (terminated.get()) throw TypeDBException.of(RESOLUTION_TERMINATED); // guard races without synchronized
+        return resolver;
     }
 
     private Map<Variable.Retrievable, Variable.Retrievable> identity(Resolvable<Conjunction> conjunctionResolvable) {
@@ -228,10 +229,13 @@ public class ResolverRegistry {
 
     public Actor.Driver<RootResolver.Explain> explainer(Conjunction conjunction, Consumer<Explain.Finished> requestAnswered,
                                                         Consumer<Integer> requestFailed, Consumer<Throwable> exception) {
-        return Actor.driver(driver -> new RootResolver.Explain(
+        Actor.Driver<RootResolver.Explain> resolver = Actor.driver(driver -> new RootResolver.Explain(
                 driver, conjunction, requestAnswered, requestFailed, exception,
-                this, traversalEngine, conceptMgr, logicMgr, planner, resolutionTracing
+                this, traversalEngine, conceptMgr, logicMgr, resolutionTracing
         ), executorService);
+        resolvers.add(resolver);
+        if (terminated.get()) throw TypeDBException.of(RESOLUTION_TERMINATED); // guard races without synchronized
+        return resolver;
     }
 
     public void setExecutorService(ActorExecutorGroup executorService) {

--- a/reasoner/resolution/answer/AnswerStateTest.java
+++ b/reasoner/resolution/answer/AnswerStateTest.java
@@ -50,7 +50,7 @@ public class AnswerStateTest {
         Map<Identifier.Variable.Retrievable, Concept> concepts = new HashMap<>();
         concepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         concepts.put(Identifier.Variable.name("y"), new MockConcept(1));
-        Partial.Compound<?, ?> partial = mapped.toUpstreamLookup(new ConceptMap(concepts), false);
+        Partial.Compound<?, ?> partial = mapped.toUpstreamLookup(new ConceptMap(concepts), false, false);
         Map<Identifier.Variable.Retrievable, Concept> expected = new HashMap<>();
         expected.put(Identifier.Variable.name("a"), new MockConcept(0));
         expected.put(Identifier.Variable.name("b"), new MockConcept(1));
@@ -76,7 +76,7 @@ public class AnswerStateTest {
         Map<Identifier.Variable.Retrievable, Concept> downstreamConcepts = new HashMap<>();
         downstreamConcepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         downstreamConcepts.put(Identifier.Variable.name("y"), new MockConcept(1));
-        Partial.Compound<?, ?> partial = mapped.toUpstreamLookup(new ConceptMap(downstreamConcepts), false);
+        Partial.Compound<?, ?> partial = mapped.toUpstreamLookup(new ConceptMap(downstreamConcepts), false, false);
 
         Map<Identifier.Variable.Retrievable, Concept> expectedWithInitial = new HashMap<>();
         expectedWithInitial.put(Identifier.Variable.name("a"), new MockConcept(0));
@@ -104,7 +104,7 @@ public class AnswerStateTest {
         Map<Identifier.Variable.Retrievable, Concept> downstreamConcepts = new HashMap<>();
         downstreamConcepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         downstreamConcepts.put(Identifier.Variable.name("y"), new MockConcept(1));
-        Partial.Compound<?, ?> partial = mapped.toUpstreamLookup(new ConceptMap(downstreamConcepts), false);
+        Partial.Compound<?, ?> partial = mapped.toUpstreamLookup(new ConceptMap(downstreamConcepts), false, false);
 
         Map<Identifier.Variable.Retrievable, Concept> expectedWithInitial = new HashMap<>();
         expectedWithInitial.put(Identifier.Variable.name("a"), new MockConcept(0));

--- a/reasoner/resolution/framework/AnswerCache.java
+++ b/reasoner/resolution/framework/AnswerCache.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.vaticle.typedb.core.reasoner.resolution.framework;
+
+import com.vaticle.typedb.core.common.exception.TypeDBException;
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.Iterators;
+import com.vaticle.typedb.core.common.poller.AbstractPoller;
+import com.vaticle.typedb.core.common.poller.Poller;
+import com.vaticle.typedb.core.concept.Concept;
+import com.vaticle.typedb.core.concept.answer.ConceptMap;
+import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState;
+import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState.Partial.Concludable;
+import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache.SubsumptionAnswerCache.ConceptMapCache;
+import com.vaticle.typedb.core.traversal.common.Identifier;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
+
+public abstract class AnswerCache<ANSWER, SUBSUMES> {
+
+    protected final List<ANSWER> answers;
+    private final Set<ANSWER> answersSet;
+    private boolean reexploreOnNewAnswers;
+    private boolean requiresReexploration;
+    protected FunctionalIterator<ANSWER> unexploredAnswers;
+    protected boolean complete;
+    protected final Map<SUBSUMES, ? extends AnswerCache<?, SUBSUMES>> cacheRegister;
+    protected final ConceptMap state;
+
+    protected AnswerCache(Map<SUBSUMES, ? extends AnswerCache<?, SUBSUMES>> cacheRegister, ConceptMap state) {
+        this.cacheRegister = cacheRegister;
+        this.state = state;
+        this.unexploredAnswers = Iterators.empty();
+        this.answers = new ArrayList<>(); // TODO: Replace answer list and deduplication set with a bloom filter
+        this.answersSet = new HashSet<>();
+        this.reexploreOnNewAnswers = false;
+        this.requiresReexploration = false;
+        this.complete = false;
+    }
+
+    public void add(ANSWER newAnswer) {
+        addIfAbsent(newAnswer);
+    }
+
+    public void addSource(FunctionalIterator<ANSWER> newAnswers) {
+        // assert !isComplete(); // Removed to allow additional answers to propagate upstream, which crucially may be
+        // carrying requiresReiteration flags
+        unexploredAnswers = unexploredAnswers.link(newAnswers);
+    }
+
+    public Poller<ANSWER> reader(boolean isSubscriber) {
+        return new Reader(isSubscriber);
+    }
+
+    public void setComplete() {
+        complete = true;
+        unexploredAnswers.recycle();
+    }
+
+    public boolean isComplete() {
+        return complete;
+    }
+
+    public void setRequiresReexploration() {
+        this.requiresReexploration = true;
+    }
+
+    public boolean requiresReexploration() {
+        return requiresReexploration;
+    }
+
+    public boolean isConceptMapCache() {
+        return false;
+    }
+
+    public ConceptMapCache asConceptMapCache() {
+        throw TypeDBException.of(ILLEGAL_CAST, this.getClass(), ConceptMapCache.class);
+    }
+
+    public boolean isConcludableAnswerCache() {
+        return false;
+    }
+
+    public ConcludableAnswerCache asConcludableAnswerCache() {
+        throw TypeDBException.of(ILLEGAL_CAST, this.getClass(), ConcludableAnswerCache.class);
+    }
+
+    protected Optional<ANSWER> get(int index, boolean isSubscriber) {
+        assert index >= 0;
+        if (index < answers.size()) {
+            return Optional.of(answers.get(index));
+        } else if (index == answers.size()) {
+            if (isComplete()) return Optional.empty();
+            Optional<ANSWER> nextAnswer = searchForAnswer(index, isSubscriber);
+            if (!nextAnswer.isPresent() && isSubscriber) reexploreOnNewAnswers = true;
+            return nextAnswer;
+        } else {
+            throw TypeDBException.of(ILLEGAL_STATE);
+        }
+    }
+
+    protected Optional<ANSWER> searchForAnswer(int index, boolean mayReadOverEagerly) {
+        return searchUnexploredForAnswer();
+    }
+
+    protected Optional<ANSWER> searchUnexploredForAnswer() {
+        while (unexploredAnswers.hasNext()) {
+            Optional<ANSWER> nextAnswer = addIfAbsent(unexploredAnswers.next());
+            if (nextAnswer.isPresent()) return nextAnswer;
+        }
+        return Optional.empty();
+    }
+
+    protected Optional<ANSWER> addIfAbsent(ANSWER answer) {
+        if (answersSet.contains(answer)) return Optional.empty();
+        answers.add(answer);
+        answersSet.add(answer);
+        if (reexploreOnNewAnswers) this.requiresReexploration = true;
+        return Optional.of(answer);
+    }
+
+    protected abstract List<SUBSUMES> answers();
+
+    public class Reader extends AbstractPoller<ANSWER> {
+
+        private final boolean mayReadOverEagerly;
+        private int index;
+
+        public Reader(boolean mayReadOverEagerly) {
+            this.mayReadOverEagerly = mayReadOverEagerly;
+            index = 0;
+        }
+
+        @Override
+        public Optional<ANSWER> poll() {
+            Optional<ANSWER> nextAnswer = get(index, mayReadOverEagerly);
+            if (nextAnswer.isPresent()) index++;
+            return nextAnswer;
+        }
+
+    }
+
+    public static class ConcludableAnswerCache extends AnswerCache<Concludable<?>, ConceptMap> {
+
+        public ConcludableAnswerCache(Map<ConceptMap, AnswerCache<?, ConceptMap>> cacheRegister, ConceptMap state) {
+            super(cacheRegister, state);
+        }
+
+        @Override
+        public boolean isConcludableAnswerCache() {
+            return true;
+        }
+
+        @Override
+        protected List<ConceptMap> answers() {
+            return iterate(answers).map(AnswerState::conceptMap).distinct().toList();
+        }
+
+    }
+
+    public static abstract class SubsumptionAnswerCache<ANSWER, SUBSUMES> extends AnswerCache<ANSWER, SUBSUMES> {
+
+        protected final Set<ConceptMap> subsumingConceptMaps;
+
+        protected SubsumptionAnswerCache(Map<SUBSUMES, ? extends AnswerCache<?, SUBSUMES>> cacheRegister, ConceptMap state) {
+            super(cacheRegister, state);
+            this.subsumingConceptMaps = subsumingConceptMaps(state);
+        }
+
+        private static Set<ConceptMap> subsumingConceptMaps(ConceptMap fromUpstream) {
+            Set<ConceptMap> subsumingCacheKeys = new HashSet<>();
+            Map<Identifier.Variable.Retrievable, Concept> concepts = new HashMap<>(fromUpstream.concepts());
+            powerSet(concepts.entrySet()).forEach(powerSet -> subsumingCacheKeys.add(toConceptMap(powerSet)));
+            subsumingCacheKeys.remove(fromUpstream);
+            return subsumingCacheKeys;
+        }
+
+        private static <T> Set<Set<T>> powerSet(Set<T> set) {
+            Set<Set<T>> powerSet = new HashSet<>();
+            powerSet.add(set);
+            set.forEach(el -> {
+                Set<T> s = new HashSet<>(set);
+                s.remove(el);
+                powerSet.addAll(powerSet(s));
+            });
+            return powerSet;
+        }
+
+        private static ConceptMap toConceptMap(Set<Map.Entry<Identifier.Variable.Retrievable, Concept>> conceptsEntrySet) {
+            HashMap<Identifier.Variable.Retrievable, Concept> map = new HashMap<>();
+            conceptsEntrySet.forEach(entry -> map.put(entry.getKey(), entry.getValue()));
+            return new ConceptMap(map);
+        }
+
+        @Override
+        protected Optional<ANSWER> searchForAnswer(int index, boolean mayReadOverEagerly) {
+            Optional<AnswerCache<?, ANSWER>> subsumingCache;
+            if ((subsumingCache = findCompleteSubsumingCache()).isPresent()) {
+                completeFromSubsumer(subsumingCache.get());
+                return get(index, mayReadOverEagerly);
+            } else {
+                return searchUnexploredForAnswer();
+            }
+        }
+
+        protected abstract Optional<AnswerCache<?, ANSWER>> findCompleteSubsumingCache();
+
+        private void completeFromSubsumer(AnswerCache<?, ANSWER> subsumingCache) {
+            setCompletedAnswers(subsumingCache.answers());
+            setComplete();
+            if (subsumingCache.requiresReexploration()) setRequiresReexploration();
+        }
+
+        private void setCompletedAnswers(List<ANSWER> completeAnswers) {
+            iterate(completeAnswers).filter(e -> subsumes(e, state)).toList().forEach(this::addIfAbsent);
+        }
+
+        protected abstract boolean subsumes(ANSWER answer, ConceptMap contained);
+
+        public static class ConceptMapCache extends SubsumptionAnswerCache<ConceptMap, ConceptMap> {
+
+            public ConceptMapCache(Map<ConceptMap, ? extends AnswerCache<?, ConceptMap>> cacheRegister,
+                                   ConceptMap state) {
+                super(cacheRegister, state);
+            }
+
+            @Override
+            protected Optional<AnswerCache<?, ConceptMap>> findCompleteSubsumingCache() {
+                for (ConceptMap subsumingCacheKey : subsumingConceptMaps) {
+                    if (cacheRegister.containsKey(subsumingCacheKey)) {
+                        AnswerCache<?, ConceptMap> subsumingCache;
+                        if ((subsumingCache = cacheRegister.get(subsumingCacheKey)).isComplete()) {
+                            // Gets the first complete cache we find. Getting the smallest could be more efficient.
+                            return Optional.of(subsumingCache);
+                        }
+                    }
+                }
+                return Optional.empty();
+            }
+
+            @Override
+            public boolean isConceptMapCache() {
+                return true;
+            }
+
+            @Override
+            public ConceptMapCache asConceptMapCache() {
+                return this;
+            }
+
+            @Override
+            protected List<ConceptMap> answers() {
+                return answers;
+            }
+
+            @Override
+            protected boolean subsumes(ConceptMap conceptMap, ConceptMap contained) {
+                return conceptMap.concepts().entrySet().containsAll(contained.concepts().entrySet());
+            }
+        }
+    }
+
+}

--- a/reasoner/resolution/framework/AnswerCache.java
+++ b/reasoner/resolution/framework/AnswerCache.java
@@ -47,7 +47,7 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
     protected final List<ANSWER> answers;
     private final Set<ANSWER> answersSet;
     private boolean reexploreOnNewAnswers;
-    private boolean requiresReexploration;
+    private boolean requiresReiteration;
     protected FunctionalIterator<ANSWER> unexploredAnswers;
     protected boolean complete;
     protected final Map<SUBSUMES, ? extends AnswerCache<?, SUBSUMES>> cacheRegister;
@@ -60,7 +60,7 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
         this.answers = new ArrayList<>(); // TODO: Replace answer list and deduplication set with a bloom filter
         this.answersSet = new HashSet<>();
         this.reexploreOnNewAnswers = false;
-        this.requiresReexploration = false;
+        this.requiresReiteration = false;
         this.complete = false;
     }
 
@@ -87,12 +87,12 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
         return complete;
     }
 
-    public void setRequiresReexploration() {
-        this.requiresReexploration = true;
+    public void setRequiresReiteration() {
+        this.requiresReiteration = true;
     }
 
-    public boolean requiresReexploration() {
-        return requiresReexploration;
+    public boolean requiresReiteration() {
+        return requiresReiteration;
     }
 
     public boolean isConceptMapCache() {
@@ -141,7 +141,7 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
         if (answersSet.contains(answer)) return Optional.empty();
         answers.add(answer);
         answersSet.add(answer);
-        if (reexploreOnNewAnswers) this.requiresReexploration = true;
+        if (reexploreOnNewAnswers) this.requiresReiteration = true;
         return Optional.of(answer);
     }
 
@@ -234,7 +234,7 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
         private void completeFromSubsumer(AnswerCache<?, ANSWER> subsumingCache) {
             setCompletedAnswers(subsumingCache.answers());
             setComplete();
-            if (subsumingCache.requiresReexploration()) setRequiresReexploration();
+            if (subsumingCache.requiresReiteration()) setRequiresReiteration();
         }
 
         private void setCompletedAnswers(List<ANSWER> completeAnswers) {

--- a/reasoner/resolution/framework/RequestState.java
+++ b/reasoner/resolution/framework/RequestState.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.vaticle.typedb.core.reasoner.resolution.framework;
+
+import com.vaticle.typedb.core.common.exception.TypeDBException;
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.poller.Poller;
+import com.vaticle.typedb.core.concept.answer.ConceptMap;
+import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState;
+import com.vaticle.typedb.core.reasoner.resolution.framework.Resolver.DownstreamManager;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.vaticle.typedb.common.util.Objects.className;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
+
+public abstract class RequestState {
+
+    protected final Request fromUpstream;
+    private final int iteration;
+
+    protected RequestState(Request fromUpstream, int iteration) {
+        this.fromUpstream = fromUpstream;
+        this.iteration = iteration;
+    }
+
+    public abstract Optional<? extends AnswerState.Partial<?>> nextAnswer();
+
+    public int iteration() {
+        return iteration;
+    }
+
+    public boolean isExploration() {
+        return false;
+    }
+
+    public Exploration asExploration() {
+        throw TypeDBException.of(ILLEGAL_CAST, className(this.getClass()), className(Exploration.class));
+    }
+
+    public interface Exploration {
+        void newAnswer(AnswerState.Partial<?> partial, boolean requiresReiteration);
+
+        DownstreamManager downstreamManager();
+
+        boolean singleAnswerRequired();
+    }
+
+    public abstract static class CachingRequestState<ANSWER, SUBSUMES> extends RequestState {
+
+        protected final AnswerCache<ANSWER, SUBSUMES> answerCache;
+        protected final boolean isSubscriber;
+        protected Poller<? extends AnswerState.Partial<?>> cacheReader;
+        protected final Set<ConceptMap> deduplicationSet;
+
+        protected CachingRequestState(Request fromUpstream, AnswerCache<ANSWER, SUBSUMES> answerCache, int iteration,
+                                      boolean deduplicate, boolean isSubscriber) {
+            super(fromUpstream, iteration);
+            this.answerCache = answerCache;
+            this.isSubscriber = isSubscriber;
+            this.deduplicationSet = deduplicate ? new HashSet<>() : null;
+            this.cacheReader = answerCache.reader(isSubscriber)
+                    .flatMap(a -> toUpstream(a)
+                            .filter(partial -> !deduplicate || !deduplicationSet.contains(partial.conceptMap())));
+        }
+
+        @Override
+        public Optional<? extends AnswerState.Partial<?>> nextAnswer() {
+            Optional<? extends AnswerState.Partial<?>> ans = cacheReader.poll();
+            if (ans.isPresent() && deduplicationSet != null) deduplicationSet.add(ans.get().conceptMap());
+            return ans;
+        }
+
+        protected abstract FunctionalIterator<? extends AnswerState.Partial<?>> toUpstream(ANSWER answer);
+
+        public AnswerCache<ANSWER, SUBSUMES> answerCache() {
+            return answerCache;
+        }
+
+    }
+
+}

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -320,7 +320,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         @Override
         protected FunctionalIterator<? extends Partial<?>> toUpstream(ConceptMap conceptMap) {
             return Iterators.single(fromUpstream.partialAnswer().asConcludable().asMatch().toUpstreamLookup(
-                    conceptMap, concludable.isInferredAnswer(conceptMap), answerCache.requiresReexploration()));
+                    conceptMap, concludable.isInferredAnswer(conceptMap), answerCache.requiresReiteration()));
         }
 
     }
@@ -355,7 +355,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         @Override
         public void newAnswer(Partial<?> partial, boolean requiresReiteration) {
             answerCache.add(partial.conceptMap());
-            if (requiresReiteration) answerCache.setRequiresReexploration();
+            if (requiresReiteration) answerCache.setRequiresReiteration();
         }
 
         @Override
@@ -366,7 +366,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         @Override
         protected FunctionalIterator<? extends Partial<?>> toUpstream(ConceptMap conceptMap) {
             return Iterators.single(fromUpstream.partialAnswer().asConcludable().asMatch().toUpstreamLookup(
-                    conceptMap, concludable.isInferredAnswer(conceptMap), answerCache.requiresReexploration()));
+                    conceptMap, concludable.isInferredAnswer(conceptMap), answerCache.requiresReiteration()));
         }
     }
 
@@ -379,7 +379,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
 
         @Override
         protected FunctionalIterator<? extends Partial<?>> toUpstream(Partial.Concludable<?> partial) {
-            return Iterators.single(partial.asExplain().toUpstreamInferred(answerCache.requiresReexploration()));
+            return Iterators.single(partial.asExplain().toUpstreamInferred(answerCache.requiresReiteration()));
         }
     }
 
@@ -411,7 +411,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         @Override
         public void newAnswer(Partial<?> partial, boolean requiresReiteration) {
             answerCache.add(partial.asConcludable());
-            if (requiresReiteration) answerCache.setRequiresReexploration();
+            if (requiresReiteration) answerCache.setRequiresReiteration();
         }
 
         @Override
@@ -421,7 +421,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
 
         @Override
         protected FunctionalIterator<? extends Partial<?>> toUpstream(Partial.Concludable<?> partial) {
-            return Iterators.single(partial.asExplain().toUpstreamInferred(answerCache.requiresReexploration()));
+            return Iterators.single(partial.asExplain().toUpstreamInferred(answerCache.requiresReiteration()));
         }
 
     }

--- a/reasoner/resolution/resolver/NegationResolver.java
+++ b/reasoner/resolution/resolver/NegationResolver.java
@@ -98,8 +98,8 @@ public class NegationResolver extends Resolver<NegationResolver> {
     }
 
     private void tryAnswer(Request fromUpstream, BoundsState boundsState) {
-        // TODO: if we wanted to accelerate the searching of a negation counter example,
-        // TODO: we could send multiple requests into the sub system at once!
+        // TODO: if we wanted to accelerate the searching of a negation counter example, we could send multiple
+        //  requests into the sub system at once!
 
         /*
         NOTE:

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -152,7 +152,7 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
         @Override
         protected FunctionalIterator<? extends Partial<?>> toUpstream(ConceptMap answer) {
             return Iterators.single(fromUpstream.partialAnswer().asRetrievable()
-                                            .aggregateToUpstream(answer, answerCache.requiresReexploration()));
+                                            .aggregateToUpstream(answer, answerCache.requiresReiteration()));
         }
     }
 }

--- a/reasoner/resolution/resolver/RootResolver.java
+++ b/reasoner/resolution/resolver/RootResolver.java
@@ -21,7 +21,6 @@ import com.vaticle.typedb.core.common.iterator.Iterators;
 import com.vaticle.typedb.core.concept.ConceptManager;
 import com.vaticle.typedb.core.logic.LogicManager;
 import com.vaticle.typedb.core.logic.resolvable.Concludable;
-import com.vaticle.typedb.core.reasoner.resolution.Planner;
 import com.vaticle.typedb.core.reasoner.resolution.ResolverRegistry;
 import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState;
 import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState.Partial;
@@ -57,11 +56,10 @@ public interface RootResolver<TOP extends Top> {
 
         public Conjunction(Driver<Conjunction> driver, com.vaticle.typedb.core.pattern.Conjunction conjunction,
                            Consumer<Finished> onAnswer, Consumer<Integer> onFail, Consumer<Throwable> onException,
-                           ResolverRegistry registry,
-                           TraversalEngine traversalEngine, ConceptManager conceptMgr, LogicManager logicMgr,
-                           Planner planner, boolean resolutionTracing) {
+                           ResolverRegistry registry, TraversalEngine traversalEngine, ConceptManager conceptMgr,
+                           LogicManager logicMgr, boolean resolutionTracing) {
             super(driver, Conjunction.class.getSimpleName() + "(pattern:" + conjunction + ")",
-                  registry, traversalEngine, conceptMgr, logicMgr, planner, resolutionTracing);
+                  registry, traversalEngine, conceptMgr, logicMgr, resolutionTracing);
             this.conjunction = conjunction;
             this.onAnswer = onAnswer;
             this.onFail = onFail;
@@ -111,8 +109,8 @@ public interface RootResolver<TOP extends Top> {
 
         @Override
         protected void nextAnswer(Request fromUpstream, RequestState requestState, int iteration) {
-            if (requestState.hasDownstreamProducer()) {
-                requestFromDownstream(requestState.nextDownstreamProducer(), fromUpstream, iteration);
+            if (requestState.downstreamManager().hasDownstream()) {
+                requestFromDownstream(requestState.downstreamManager().nextDownstream(), fromUpstream, iteration);
             } else {
                 submitFail(iteration);
             }
@@ -127,8 +125,8 @@ public interface RootResolver<TOP extends Top> {
         @Override
         boolean tryAcceptUpstreamAnswer(AnswerState upstreamAnswer, Request fromUpstream, int iteration) {
             RequestState requestState = requestStates.get(fromUpstream);
-            if (!requestState.hasProduced(upstreamAnswer.conceptMap())) {
-                requestState.recordProduced(upstreamAnswer.conceptMap());
+            if (!requestState.deduplicationSet().contains(upstreamAnswer.conceptMap())) {
+                requestState.deduplicationSet().add(upstreamAnswer.conceptMap());
                 answerToUpstream(upstreamAnswer, fromUpstream, iteration);
                 return true;
             } else {
@@ -143,9 +141,8 @@ public interface RootResolver<TOP extends Top> {
 
         @Override
         RequestState requestStateForIteration(RequestState requestStatePrior, int iteration) {
-            return new RequestState(iteration, requestStatePrior.produced());
+            return new RequestState(iteration, requestStatePrior.deduplicationSet());
         }
-
     }
 
     class Disjunction extends DisjunctionResolver<Disjunction> implements RootResolver<Finished> {
@@ -175,8 +172,8 @@ public interface RootResolver<TOP extends Top> {
 
         @Override
         protected void nextAnswer(Request fromUpstream, RequestState requestState, int iteration) {
-            if (requestState.hasDownstreamProducer()) {
-                requestFromDownstream(requestState.nextDownstreamProducer(), fromUpstream, iteration);
+            if (requestState.downstreamManager().hasDownstream()) {
+                requestFromDownstream(requestState.downstreamManager().nextDownstream(), fromUpstream, iteration);
             } else {
                 submitFail(iteration);
             }
@@ -207,8 +204,8 @@ public interface RootResolver<TOP extends Top> {
         @Override
         protected boolean tryAcceptUpstreamAnswer(AnswerState upstreamAnswer, Request fromUpstream, int iteration) {
             RequestState requestState = requestStates.get(fromUpstream);
-            if (!requestState.hasProduced(upstreamAnswer.conceptMap())) {
-                requestState.recordProduced(upstreamAnswer.conceptMap());
+            if (!requestState.deduplicationSet().contains(upstreamAnswer.conceptMap())) {
+                requestState.deduplicationSet().add(upstreamAnswer.conceptMap());
                 answerToUpstream(upstreamAnswer, fromUpstream, iteration);
                 return true;
             } else {
@@ -226,7 +223,7 @@ public interface RootResolver<TOP extends Top> {
 
         @Override
         protected RequestState requestStateForIteration(RequestState requestStatePrior, int newIteration) {
-            return new RequestState(newIteration, requestStatePrior.produced());
+            return new RequestState(newIteration, requestStatePrior.deduplicationSet());
         }
     }
 
@@ -241,11 +238,11 @@ public interface RootResolver<TOP extends Top> {
 
         private final Set<Explanation> submittedExplanations;
 
-        public Explain(Driver<Explain> driver, com.vaticle.typedb.core.pattern.Conjunction conjunction, Consumer<Top.Explain.Finished> onAnswer,
-                       Consumer<Integer> onFail, Consumer<Throwable> onException, ResolverRegistry registry,
-                       TraversalEngine traversalEngine, ConceptManager conceptMgr, LogicManager logicMgr, Planner planner,
-                       boolean resolutionTracing) {
-            super(driver, "Explain(" + conjunction + ")", registry, traversalEngine, conceptMgr, logicMgr, planner, resolutionTracing);
+        public Explain(Driver<Explain> driver, com.vaticle.typedb.core.pattern.Conjunction conjunction,
+                       Consumer<Top.Explain.Finished> onAnswer, Consumer<Integer> onFail,
+                       Consumer<Throwable> onException, ResolverRegistry registry, TraversalEngine traversalEngine,
+                       ConceptManager conceptMgr, LogicManager logicMgr, boolean resolutionTracing) {
+            super(driver, "Explain(" + conjunction + ")", registry, traversalEngine, conceptMgr, logicMgr, resolutionTracing);
             this.conjunction = conjunction;
             this.onAnswer = onAnswer;
             this.onFail = onFail;
@@ -272,8 +269,8 @@ public interface RootResolver<TOP extends Top> {
 
         @Override
         protected void nextAnswer(Request fromUpstream, RequestState requestState, int iteration) {
-            if (requestState.hasDownstreamProducer()) {
-                requestFromDownstream(requestState.nextDownstreamProducer(), fromUpstream, iteration);
+            if (requestState.downstreamManager().hasDownstream()) {
+                requestFromDownstream(requestState.downstreamManager().nextDownstream(), fromUpstream, iteration);
             } else {
                 submitFail(iteration);
             }
@@ -316,7 +313,7 @@ public interface RootResolver<TOP extends Top> {
 
         @Override
         RequestState requestStateForIteration(RequestState requestStatePrior, int iteration) {
-            return new RequestState(iteration, requestStatePrior.produced());
+            return new RequestState(iteration, requestStatePrior.deduplicationSet());
         }
 
         @Override
@@ -332,7 +329,6 @@ public interface RootResolver<TOP extends Top> {
         com.vaticle.typedb.core.pattern.Conjunction conjunction() {
             return conjunction;
         }
-
     }
 
 }

--- a/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
@@ -18,6 +18,7 @@
 
 package com.vaticle.typedb.core.logic.resolvable;
 
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.iterator.Iterators;
 import com.vaticle.typedb.core.common.parameters.Arguments;
 import com.vaticle.typedb.core.common.parameters.Options.Database;
@@ -151,15 +152,15 @@ public class UnifyAttributeConcludableTest {
         Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.anon(0), instanceOf("first-name", "john"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(1, unified.get().concepts().size());
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        assertEquals(1, unified.next().concepts().size());
 
         concepts = map(
                 pair(Identifier.Variable.anon(0), instanceOf("first-name", "abe"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
 
     }
 

--- a/test/integration/logic/resolvable/UnifyHasConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyHasConcludableTest.java
@@ -19,6 +19,7 @@
 package com.vaticle.typedb.core.logic.resolvable;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.parameters.Arguments;
 import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.common.parameters.Options.Database;
@@ -174,9 +175,9 @@ public class UnifyHasConcludableTest {
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.anon(0), instanceOf("first-name", "john"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(2, unified.get().concepts().size());
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        assertEquals(2, unified.next().concepts().size());
 
         // filter out invalid type
         concepts = map(
@@ -184,7 +185,7 @@ public class UnifyHasConcludableTest {
                 pair(Identifier.Variable.anon(0), instanceOf("age"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
 
         // filter out invalid value
         concepts = map(
@@ -192,7 +193,7 @@ public class UnifyHasConcludableTest {
                 pair(Identifier.Variable.anon(0), instanceOf("first-name", "bob"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
     }
 
     @Test
@@ -224,9 +225,9 @@ public class UnifyHasConcludableTest {
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.name("a"), instanceOf("last-name", "john"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(2, unified.get().concepts().size());
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        assertEquals(2, unified.next().concepts().size());
 
         // filter out invalid type
         concepts = map(
@@ -234,7 +235,7 @@ public class UnifyHasConcludableTest {
                 pair(Identifier.Variable.name("a"), instanceOf("age"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
 
         // filter out invalid value
         concepts = map(
@@ -242,7 +243,7 @@ public class UnifyHasConcludableTest {
                 pair(Identifier.Variable.name("a"), instanceOf("first-name", "bob"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
     }
 
     @Ignore
@@ -275,9 +276,9 @@ public class UnifyHasConcludableTest {
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.anon(0), instanceOf("first-name", "john"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(2, unified.get().concepts().size());
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        assertEquals(2, unified.next().concepts().size());
 
         // test requirements
         assertEquals(0, unifier.requirements().roleTypes().size());
@@ -308,9 +309,9 @@ public class UnifyHasConcludableTest {
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.name("a"), instanceOf("last-name", "john"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(2, unified.get().concepts().size());
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        assertEquals(2, unified.next().concepts().size());
 
         // test requirements
         assertEquals(0, unifier.requirements().roleTypes().size());
@@ -351,9 +352,9 @@ public class UnifyHasConcludableTest {
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.anon(0), instanceOf("first-name", "john"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(2, unified.get().concepts().size());
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        assertEquals(2, unified.next().concepts().size());
 
         // filter out invalid type
         concepts = map(
@@ -361,7 +362,7 @@ public class UnifyHasConcludableTest {
                 pair(Identifier.Variable.anon(0), instanceOf("age"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
     }
 
     @Test
@@ -393,9 +394,9 @@ public class UnifyHasConcludableTest {
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.name("a"), instanceOf("first-name", "john"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(2, unified.get().concepts().size());
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        assertEquals(2, unified.next().concepts().size());
 
         // filter out invalid type
         concepts = map(
@@ -403,7 +404,7 @@ public class UnifyHasConcludableTest {
                 pair(Identifier.Variable.name("a"), instanceOf("age"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
     }
 
     @Test
@@ -451,9 +452,9 @@ public class UnifyHasConcludableTest {
                 pair(Identifier.Variable.name("x"), instanceOf("self-owning-attribute")),
                 pair(Identifier.Variable.anon(0), instanceOf("self-owning-attribute"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(1, unified.get().concepts().size());
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        assertEquals(1, unified.next().concepts().size());
 
         // test requirements of one-to-many using invalid answer
         concepts = map(
@@ -461,7 +462,7 @@ public class UnifyHasConcludableTest {
                 pair(Identifier.Variable.anon(0), instanceOf("age"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
     }
 
     @Test

--- a/test/integration/logic/resolvable/UnifyIsaConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyIsaConcludableTest.java
@@ -19,6 +19,7 @@
 package com.vaticle.typedb.core.logic.resolvable;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.parameters.Arguments;
 import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.common.parameters.Options;
@@ -270,9 +271,9 @@ public class UnifyIsaConcludableTest {
                 pair(Identifier.Variable.anon(0), instanceOf("first-name", "john")),
                 pair(Identifier.Variable.label("first-name"), conceptMgr.getThingType("first-name"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(1, unified.get().concepts().size());
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        assertEquals(1, unified.next().concepts().size());
 
         // filter out invalid type
         concepts = map(
@@ -280,7 +281,7 @@ public class UnifyIsaConcludableTest {
                 pair(Identifier.Variable.label("first-name"), conceptMgr.getThingType("age"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
     }
 
     @Test
@@ -311,9 +312,9 @@ public class UnifyIsaConcludableTest {
                 pair(Identifier.Variable.anon(0), instanceOf("employment")),
                 pair(Identifier.Variable.label("employment"), conceptMgr.getThingType("employment"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(1, unified.get().concepts().size());
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        assertEquals(1, unified.next().concepts().size());
 
         // filter out invalid type
         concepts = map(
@@ -321,7 +322,7 @@ public class UnifyIsaConcludableTest {
                 pair(Identifier.Variable.label("employment"), conceptMgr.getThingType("age"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
     }
 
     @Test
@@ -354,9 +355,9 @@ public class UnifyIsaConcludableTest {
                 pair(Identifier.Variable.anon(0), instanceOf("employment")),
                 pair(Identifier.Variable.name("rel-type"), conceptMgr.getThingType("employment"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(1, unified.get().concepts().size());
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        assertEquals(1, unified.next().concepts().size());
 
         // filter out invalid type
         concepts = map(
@@ -364,7 +365,7 @@ public class UnifyIsaConcludableTest {
                 pair(Identifier.Variable.name("rel-type"), conceptMgr.getThingType("age"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
     }
 
     @Test
@@ -429,30 +430,30 @@ public class UnifyIsaConcludableTest {
         Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("first-name", "johnny"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(1, unified.get().concepts().size());
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        assertEquals(1, unified.next().concepts().size());
 
         // filter out using >
         concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("first-name", "abe"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
 
         // filter out using <
         concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("first-name", "zack"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
 
         // filter out using contains
         concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("first-name", "carol"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
 
     }
 }

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -51,9 +51,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static com.vaticle.typedb.common.collection.Collections.list;
@@ -61,6 +61,7 @@ import static com.vaticle.typedb.common.collection.Collections.map;
 import static com.vaticle.typedb.common.collection.Collections.pair;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.logic.resolvable.Util.createRule;
 import static com.vaticle.typedb.core.logic.resolvable.Util.getStringMapping;
 import static com.vaticle.typedb.core.logic.resolvable.Util.resolvedConjunction;
@@ -197,11 +198,12 @@ public class UnifyRelationConcludableTest {
                 pair(Identifier.Variable.label("employment"), employment.getType()),
                 pair(Identifier.Variable.label("employment:employee"), employment.getType().getRelates("employee"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(2, unified.get().concepts().size());
-        assertEquals(employment, unified.get().get("r"));
-        assertEquals(person, unified.get().get("y"));
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        ConceptMap unifiedAnswer = unified.first().get();
+        assertEquals(2, unifiedAnswer.concepts().size());
+        assertEquals(employment, unifiedAnswer.get("r"));
+        assertEquals(person, unifiedAnswer.get("y"));
 
         // filter out invalid types
         Relation friendship = instanceOf("friendship").asRelation();
@@ -214,7 +216,7 @@ public class UnifyRelationConcludableTest {
                 pair(Identifier.Variable.label("employment:employee"), friendship.getType().getRelates("friend"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
     }
 
     @Test
@@ -254,12 +256,13 @@ public class UnifyRelationConcludableTest {
                 pair(Identifier.Variable.label("employment"), employment.getType()),
                 pair(Identifier.Variable.label("employment:employee"), employment.getType().getRelates("employee"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(3, unified.get().concepts().size());
-        assertEquals(employment.getType(), unified.get().get("rel"));
-        assertEquals(person, unified.get().get("y"));
-        assertEquals(employment, unified.get().get(Identifier.Variable.anon(0)));
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        ConceptMap unifiedAnswer = unified.first().get();
+        assertEquals(3, unifiedAnswer.concepts().size());
+        assertEquals(employment.getType(), unifiedAnswer.get("rel"));
+        assertEquals(person, unifiedAnswer.get("y"));
+        assertEquals(employment, unifiedAnswer.get(Identifier.Variable.anon(0)));
 
         // filter out invalid types
         Relation friendship = instanceOf("friendship").asRelation();
@@ -272,7 +275,7 @@ public class UnifyRelationConcludableTest {
                 pair(Identifier.Variable.label("employment:employee"), friendship.getType().getRelates("friend"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
     }
 
     @Test
@@ -312,12 +315,13 @@ public class UnifyRelationConcludableTest {
                 pair(Identifier.Variable.label("employment"), employment.getType()),
                 pair(Identifier.Variable.label("employment:employee"), employment.getType().getRelates("employee"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(3, unified.get().concepts().size());
-        assertEquals(employment.getType().getRelates("employee"), unified.get().get("role"));
-        assertEquals(person, unified.get().get("y"));
-        assertEquals(employment, unified.get().get(Identifier.Variable.anon(0)));
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        ConceptMap unifiedAnswer = unified.first().get();
+        assertEquals(3, unified.next().concepts().size());
+        assertEquals(employment.getType().getRelates("employee"), unifiedAnswer.get("role"));
+        assertEquals(person, unifiedAnswer.get("y"));
+        assertEquals(employment, unifiedAnswer.get(Identifier.Variable.anon(0)));
 
         // filter out invalid types
         Relation friendship = instanceOf("friendship").asRelation();
@@ -330,7 +334,7 @@ public class UnifyRelationConcludableTest {
                 pair(Identifier.Variable.label("employment:employee"), friendship.getType().getRelates("friend"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
     }
 
     @Test
@@ -504,7 +508,7 @@ public class UnifyRelationConcludableTest {
                                "($employee: $x, $employee: $y) isa $employment", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
-        Set<Map<String, Set<String>>> result = Iterators.iterate(unifiers).map(u -> getStringMapping(u.mapping())).toSet();
+        Set<Map<String, Set<String>>> result = iterate(unifiers).map(u -> getStringMapping(u.mapping())).toSet();
 
         Set<Map<String, Set<String>>> expected = set(
                 new HashMap<String, Set<String>>() {{
@@ -537,11 +541,12 @@ public class UnifyRelationConcludableTest {
                 pair(Identifier.Variable.name("employment"), employment.getType()),
                 pair(Identifier.Variable.name("employee"), employment.getType().getRelates("employee"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(2, unified.get().concepts().size());
-        assertEquals(person, unified.get().get("p"));
-        assertEquals(employment, unified.get().get(Identifier.Variable.anon(0)));
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        ConceptMap unifiedAnswer = unified.first().get();
+        assertEquals(2, unifiedAnswer.concepts().size());
+        assertEquals(person, unifiedAnswer.get("p"));
+        assertEquals(employment, unifiedAnswer.get(Identifier.Variable.anon(0)));
 
         // filter out answers with differing role players that must be the same
         employment = instanceOf("employment").asRelation();
@@ -557,7 +562,7 @@ public class UnifyRelationConcludableTest {
                 pair(Identifier.Variable.name("employee"), employment.getType().getRelates("employee"))
         );
         unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertFalse(unified.isPresent());
+        assertFalse(unified.hasNext());
     }
 
     @Test
@@ -571,7 +576,7 @@ public class UnifyRelationConcludableTest {
                                "(employee: $x, employer: $x, employee: $y) isa employment", logicMgr);
 
         List<Unifier> unifier = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
-        List<Map<String, Set<String>>> result = Iterators.iterate(unifier).map(u -> getStringMapping(u.mapping())).toList();
+        List<Map<String, Set<String>>> result = iterate(unifier).map(u -> getStringMapping(u.mapping())).toList();
 
         List<Map<String, Set<String>>> expected = list(
                 new HashMap<String, Set<String>>() {{
@@ -707,7 +712,7 @@ public class UnifyRelationConcludableTest {
                                "($employee: $x, $employee: $x) isa $employment", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
-        Set<Map<String, Set<String>>> result = Iterators.iterate(unifiers).map(u -> getStringMapping(u.mapping())).toSet();
+        Set<Map<String, Set<String>>> result = iterate(unifiers).map(u -> getStringMapping(u.mapping())).toSet();
 
         Set<Map<String, Set<String>>> expected = set(
                 new HashMap<String, Set<String>>() {{
@@ -739,12 +744,13 @@ public class UnifyRelationConcludableTest {
                 pair(Identifier.Variable.name("employment"), employment.getType()),
                 pair(Identifier.Variable.name("employee"), employment.getType().getRelates("employee"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
-        assertTrue(unified.isPresent());
-        assertEquals(3, unified.get().concepts().size());
-        assertEquals(person, unified.get().get("p"));
-        assertEquals(person, unified.get().get("q"));
-        assertEquals(employment, unified.get().get(Identifier.Variable.anon(0)));
+        FunctionalIterator<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
+        assertTrue(unified.hasNext());
+        ConceptMap unifiedAnswer = unified.first().get();
+        assertEquals(3, unifiedAnswer.concepts().size());
+        assertEquals(person, unifiedAnswer.get("p"));
+        assertEquals(person, unifiedAnswer.get("q"));
+        assertEquals(employment, unifiedAnswer.get(Identifier.Variable.anon(0)));
     }
 
     @Test
@@ -787,6 +793,119 @@ public class UnifyRelationConcludableTest {
         assertEquals(expected, result);
     }
 
+    @Test
+    public void unUnify_produces_cartesian_named_types() {
+        String conjunction = "{$r ($role: $x) isa $rel;}";
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
+        Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
+
+        Rule rule = createRule("people-are-self-friends", "{ $x isa person; }",
+                               " (friend: $x) isa friendship ", logicMgr);
+
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
+        assertEquals(1, unifiers.size());
+        Unifier unifier = unifiers.get(0);
+
+        // test filter allows a valid answer
+        Relation friendship = instanceOf("friendship").asRelation();
+        Thing person = instanceOf("person");
+        addRolePlayer(friendship, "friend", person);
+        Map<Identifier.Variable, Concept> concepts = map(
+                pair(Identifier.Variable.anon(0), friendship),
+                pair(Identifier.Variable.name("x"), person),
+                pair(Identifier.Variable.label("friendship"), friendship.getType()),
+                pair(Identifier.Variable.label("friendship:friend"), friendship.getType().getRelates("friend"))
+        );
+        List<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map())).toList();
+        assertEquals(6, unified.size());
+
+        Set<Map<String, String>> expected = set(
+                new HashMap<String, String>() {{
+                    put("$rel", "friendship");
+                    put("$role", "friendship:friend");
+                }},
+                new HashMap<String, String>() {{
+                    put("$rel", "friendship");
+                    put("$role", "relation:role");
+                }},
+                new HashMap<String, String>() {{
+                    put("$rel", "relation");
+                    put("$role", "friendship:friend");
+                }},
+                new HashMap<String, String>() {{
+                    put("$rel", "relation");
+                    put("$role", "relation:role");
+                }},
+                new HashMap<String, String>() {{
+                    put("$rel", "thing");
+                    put("$role", "friendship:friend");
+                }},
+                new HashMap<String, String>() {{
+                    put("$rel", "thing");
+                    put("$role", "relation:role");
+                }}
+        );
+
+        Set<Map<String, String>> actual = new HashSet<>();
+        iterate(unified).forEachRemaining(answer -> {
+            actual.add(new HashMap<String, String>() {{
+                put("$rel", answer.get("rel").asType().getLabel().name());
+                put("$role", answer.get("role").asType().getLabel().scopedName());
+            }});
+        });
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void unUnify_produces_cartesian_named_types_only_for_unbound_vars() {
+        String conjunction = "{$r ($role: $x) isa $rel;}";
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
+        Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
+
+        Rule rule = createRule("people-are-self-friends", "{ $x isa person; }",
+                               " (friend: $x) isa friendship ", logicMgr);
+
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
+        assertEquals(1, unifiers.size());
+        Unifier unifier = unifiers.get(0);
+
+        // test filter allows a valid answer
+        Relation friendship = instanceOf("friendship").asRelation();
+        Thing person = instanceOf("person");
+        addRolePlayer(friendship, "friend", person);
+        Map<Identifier.Variable, Concept> concepts = map(
+                pair(Identifier.Variable.anon(0), friendship),
+                pair(Identifier.Variable.name("x"), person),
+                pair(Identifier.Variable.label("friendship"), friendship.getType()),
+                pair(Identifier.Variable.label("friendship:friend"), friendship.getType().getRelates("friend"))
+        );
+        List<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map(
+                pair(Identifier.Variable.name("rel"), friendship.getType())
+        ))).toList();
+        assertEquals(2, unified.size());
+
+        Set<Map<String, String>> expected = set(
+                new HashMap<String, String>() {{
+                    put("$rel", "friendship");
+                    put("$role", "friendship:friend");
+                }},
+                new HashMap<String, String>() {{
+                    put("$rel", "friendship");
+                    put("$role", "relation:role");
+                }}
+        );
+
+        Set<Map<String, String>> actual = new HashSet<>();
+        iterate(unified).forEachRemaining(answer -> {
+            actual.add(new HashMap<String, String>() {{
+                put("$rel", answer.get("rel").asType().getLabel().name());
+                put("$role", answer.get("role").asType().getLabel().scopedName());
+            }});
+        });
+
+        assertEquals(expected, actual);
+    }
 
     // TODO: rule unification pruning tests based based on types
 }


### PR DESCRIPTION
## What is the goal of this PR?

We introduce caching in the reasoner avoid repeated work. Adding this caching has also allowed us to tighten the criteria upon which we trigger an outer reiteration of the reasoner for a given query. Such an iteration is necessary to search for inferred facts that can only be found based on the inferences made by prior iterations.

The cache ensures that work can be re-used for the same exact partial answer when revisited. We also implement cache subsumption: any partial answer can utilise the cached answers for any more general (subsuming) partial answer which has a complete cache.

## What are the changes implemented in this PR?

- Subsumptive caching for ConcludableResolver
- Subsumptive caching for RetrievableResolver
- Abstracts RequestState across the non-compound resolvers. The compound resolvers need to be brought in line with this approach in a follow-up PR.
- Adds Poller classes to implement polling the cache for new answers
- Account for the case of `$x isa $type` in rules (previously handled by always triggering at least one reiteration) by generating answers over the cartesian product of all possible types for the answer found. This takes place during un-unification.

Authored jointly with @flyingsilverfin 