### PR TITLE
Reduce OOM by reusing rocks iterators in write transactions

### DIFF
--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -122,19 +122,8 @@ public abstract class RocksStorage implements Storage {
 
     org.rocksdb.RocksIterator getInternalRocksIterator() {
         org.rocksdb.RocksIterator iterator = recycled.poll();
-        if (iterator != null && isReadOnly) {
-            return iterator;
-        } else if (iterator != null) {
-            try {
-                iterator.refresh();
-            } catch (RocksDBException e) {
-                e.printStackTrace();
-                throw TypeDBException.of(e);
-            }
-            return iterator;
-        } else {
-            return storageTransaction.getIterator(readOptions);
-        }
+        if (iterator != null) return iterator;
+        else return storageTransaction.getIterator(readOptions);
     }
 
     void recycle(org.rocksdb.RocksIterator rocksIterator) {


### PR DESCRIPTION
## What is the goal of this PR?

To fix issues like #6323, we identify that the cause is that rocks iterators are not re-used in write transactions, and also not immediately cleaned up. We now allow write transactions to re-use rocks iterators as it they do in fact see uncommitted deletes to the rocks transaction.

## What are the changes implemented in this PR?
* allow all transactions to use recycled iterators