### PR TITLE
Request reiteration status with explicit resolver messages

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -109,9 +109,8 @@ build:
         bazel test //test/behaviour/resolution/tests/negation:test --test_output=streamed
         bazel test //test/behaviour/resolution/tests/recursion:test --test_output=streamed
         bazel test //test/behaviour/resolution/tests/schema_queries:test --test_output=streamed
-        # TODO The following two sets of tests are a bit too flaky to include in CI
-        # bazel test //test/behaviour/resolution/tests/variable_roles:test --test_output=streamed
-        # bazel test //test/behaviour/resolution/tests/concept_inequality:test --test_output=streamed
+        bazel test //test/behaviour/resolution/tests/variable_roles:test --test_output=streamed
+        bazel test //test/behaviour/resolution/tests/concept_inequality:test --test_output=streamed
     test-assembly-linux-targz:
       image: vaticle-ubuntu-20.04
       filter:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -109,8 +109,9 @@ build:
         bazel test //test/behaviour/resolution/tests/negation:test --test_output=streamed
         bazel test //test/behaviour/resolution/tests/recursion:test --test_output=streamed
         bazel test //test/behaviour/resolution/tests/schema_queries:test --test_output=streamed
-        bazel test //test/behaviour/resolution/tests/variable_roles:test --test_output=streamed
         bazel test //test/behaviour/resolution/tests/concept_inequality:test --test_output=streamed
+        # Flakey tests:
+        # bazel test //test/behaviour/resolution/tests/variable_roles:test --test_output=streamed
     test-assembly-linux-targz:
       image: vaticle-ubuntu-20.04
       filter:

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,7 +49,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "6d5f05f8f07621bc8803d47404e225c85ec11bc6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "f763ba70f081b73f7668d904de50b9cb9cfc8858", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/reasoner/ExplanationProducer.java
+++ b/reasoner/ExplanationProducer.java
@@ -65,7 +65,7 @@ public class ExplanationProducer implements Producer<Explanation> {
         this.processing = new AtomicInteger();
         this.computeSize = options.parallel() ? Executors.PARALLELISATION_FACTOR : 1;
         this.explainer = registry.explainer(conjunction, this::requestAnswered, this::requestFailed, this::exception);
-        Root.Explain downstream = new AnswerStateImpl.TopImpl.ExplainImpl.InitialImpl(bounds, explainer, false).toDownstream();
+        Root.Explain downstream = new AnswerStateImpl.TopImpl.ExplainImpl.InitialImpl(bounds, explainer).toDownstream();
         this.explainRequest = Request.create(explainer, downstream);
         if (options.traceInference()) ResolutionTracer.initialise(options.logsDir());
     }
@@ -91,7 +91,6 @@ public class ExplanationProducer implements Producer<Explanation> {
     // note: root resolver calls this single-threaded, so is threads safe
     private void requestAnswered(Explain.Finished explainedAnswer) {
         if (options.traceInference()) ResolutionTracer.get().finish();
-        if (explainedAnswer.requiresReiteration()) requiresReiteration = true;
         Explanation explanation = explainedAnswer.explanation();
         explainablesManager.setAndRecordExplainables(explanation.conditionAnswer());
         queue.put(explanation);

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -59,6 +59,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     private ResolverRegistry resolverRegistry;
     private final ExplainablesManager explainablesManager;
     private final Request resolveRequest;
+    private final ReiterationQuery.Request reiterationRequest;
     private final int computeSize;
     private boolean done;
     private int iteration;
@@ -83,6 +84,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
         assert computeSize > 0;
         Root<?, ?> downstream = InitialImpl.create(filter(modifiers.filter()), new ConceptMap(), this.rootResolver, options.explain()).toDownstream();
         this.resolveRequest = Request.create(rootResolver, downstream);
+        this.reiterationRequest = ReiterationQuery.Request.create(rootResolver, this::receiveReiterationResponse);
         this.iterationsCheckedForReiteration = new HashSet<>();
         this.requiresReiteration = false;
         if (options.traceInference()) ResolutionTracer.initialise(options.logsDir());
@@ -103,6 +105,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
         assert computeSize > 0;
         Root<?, ?> downstream = InitialImpl.create(filter(modifiers.filter()), new ConceptMap(), this.rootResolver, options.explain()).toDownstream();
         this.resolveRequest = Request.create(rootResolver, downstream);
+        this.reiterationRequest = ReiterationQuery.Request.create(rootResolver, this::receiveReiterationResponse);
         this.iterationsCheckedForReiteration = new HashSet<>();
         this.requiresReiteration = false;
         if (options.traceInference()) ResolutionTracer.initialise(options.logsDir());
@@ -164,8 +167,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
         iterationsCheckedForReiteration.add(iteration);
         reiterationQueryRespondents = new HashSet<>(resolverRegistry.concludableResolvers());
         resolverRegistry.concludableResolvers()
-                .forEach(res -> res.execute(actor -> actor.receiveReiterationQuery(
-                        ReiterationQuery.Request.create(rootResolver, this::receiveReiterationResponse))));
+                .forEach(res -> res.execute(actor -> actor.receiveReiterationQuery(reiterationRequest)));
     }
 
     private synchronized void receiveReiterationResponse(ReiterationQuery.Response response) {

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -56,7 +56,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     private final AtomicInteger required;
     private final AtomicInteger processing;
     private final Options.Query options;
-    private ResolverRegistry resolverRegistry;
+    private final ResolverRegistry resolverRegistry;
     private final ExplainablesManager explainablesManager;
     private final Request resolveRequest;
     private final ReiterationQuery.Request reiterationRequest;

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -28,9 +28,11 @@ import com.vaticle.typedb.core.reasoner.resolution.ResolverRegistry;
 import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState.Partial.Compound.Root;
 import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState.Top.Match.Finished;
 import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerStateImpl.TopImpl.MatchImpl.InitialImpl;
+import com.vaticle.typedb.core.reasoner.resolution.framework.ReiterationQuery;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Request;
 import com.vaticle.typedb.core.reasoner.resolution.framework.ResolutionTracer;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Resolver;
+import com.vaticle.typedb.core.reasoner.resolution.resolver.ConcludableResolver;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
 import com.vaticle.typeql.lang.query.TypeQLMatch;
@@ -38,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.ThreadSafe;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -54,6 +57,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     private final AtomicInteger required;
     private final AtomicInteger processing;
     private final Options.Query options;
+    private ResolverRegistry resolverRegistry;
     private final ExplainablesManager explainablesManager;
     private final Request resolveRequest;
     private final int computeSize;
@@ -61,22 +65,26 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     private boolean done;
     private int iteration;
     private Queue<ConceptMap> queue;
+    private HashSet<Actor.Driver<? extends Resolver<?>>> reiterationQueryRespondents;
+    private final Set<Integer> iterationsCheckedForReiteration;
 
     // TODO: this class should not be a Producer, it implements a different async processing mechanism
     public ReasonerProducer(Conjunction conjunction, TypeQLMatch.Modifiers modifiers, Options.Query options,
                             ResolverRegistry resolverRegistry, ExplainablesManager explainablesManager) {
         this.options = options;
+        this.resolverRegistry = resolverRegistry;
         this.explainablesManager = explainablesManager;
         this.queue = null;
         this.iteration = 0;
         this.done = false;
         this.required = new AtomicInteger();
         this.processing = new AtomicInteger();
-        this.rootResolver = resolverRegistry.root(conjunction, this::requestAnswered, this::requestFailed, this::exception);
+        this.rootResolver = this.resolverRegistry.root(conjunction, this::requestAnswered, this::requestFailed, this::exception);
         this.computeSize = options.parallel() ? Executors.PARALLELISATION_FACTOR * 2 : 1;
         assert computeSize > 0;
         Root<?, ?> downstream = InitialImpl.create(filter(modifiers.filter()), new ConceptMap(), this.rootResolver, options.explain()).toDownstream();
         this.resolveRequest = Request.create(rootResolver, downstream);
+        this.iterationsCheckedForReiteration = new HashSet<>();
         if (options.traceInference()) ResolutionTracer.initialise(options.logsDir());
     }
 
@@ -94,6 +102,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
         assert computeSize > 0;
         Root<?, ?> downstream = InitialImpl.create(filter(modifiers.filter()), new ConceptMap(), this.rootResolver, options.explain()).toDownstream();
         this.resolveRequest = Request.create(rootResolver, downstream);
+        this.iterationsCheckedForReiteration = new HashSet<>();
         if (options.traceInference()) ResolutionTracer.initialise(options.logsDir());
     }
 
@@ -135,18 +144,32 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     private void requestFailed(int iteration) {
         LOG.trace("Failed to find answer to request in iteration: " + iteration);
         if (options.traceInference()) ResolutionTracer.get().finish();
-        if (!done && iteration == this.iteration && !mustReiterate()) {
-            // query is completely terminated
-            done = true;
-            queue.done();
-            required.set(0);
-            return;
-        }
+        if (!iterationsCheckedForReiteration.contains(iteration)) sendReiterationRequests();
+    }
 
-        if (!done) {
-            if (iteration == this.iteration) prepareNextIteration();
-            assert iteration < this.iteration;
-            retryInNewIteration();
+    private void sendReiterationRequests() {
+        iterationsCheckedForReiteration.add(iteration);
+        reiterationQueryRespondents = new HashSet<>(resolverRegistry.concludableResolvers());
+        resolverRegistry.concludableResolvers()
+                .forEach(res -> res.execute(actor -> actor.receiveReiterationQuery(
+                        ReiterationQuery.Request.create(rootResolver, this::receiveReiterationResponse))));
+    }
+
+    private void receiveReiterationResponse(ReiterationQuery.Response response) {
+        if (response.reiterate()) requiresReiteration = true;
+        assert reiterationQueryRespondents.contains(response.sender());
+        reiterationQueryRespondents.remove(response.sender());
+
+        if (reiterationQueryRespondents.isEmpty()) {
+            if (requiresReiteration) {
+                prepareNextIteration();
+                retryInNewIteration();
+            } else {
+                // query is completely terminated
+                done = true;
+                queue.done();
+                required.set(0);
+            }
         }
     }
 
@@ -161,20 +184,6 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     private void prepareNextIteration() {
         iteration++;
         requiresReiteration = false;
-    }
-
-    private boolean mustReiterate() {
-        /*
-        TODO: room for optimisation:
-        for example, reiteration should never be required if there
-        are no loops in the rule graph
-        NOTE: double check this logic holds in the actor execution model, eg. because of asynchrony, we may
-        always have to reiterate until no more answers are found.
-
-        counter example: $x isa $type; -> unifies with then { (friend: $y) isa friendship; }
-        Without reiteration we will miss $x = instance, $type = relation/thing
-         */
-        return requiresReiteration;
     }
 
     private void retryInNewIteration() {

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -145,7 +145,18 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     private void requestFailed(int iteration) {
         LOG.trace("Failed to find answer to request in iteration: " + iteration);
         if (options.traceInference()) ResolutionTracer.get().finish();
-        if (!iterationsCheckedForReiteration.contains(iteration)) sendReiterationRequests();
+        if (resolverRegistry.concludableResolvers().size() == 0) {
+            finish();
+        } else if (!iterationsCheckedForReiteration.contains(iteration)) {
+            sendReiterationRequests();
+        }
+    }
+
+    private void finish() {
+        // query is completely terminated
+        done = true;
+        queue.done();
+        required.set(0);
     }
 
     private void sendReiterationRequests() {
@@ -167,10 +178,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
                 prepareNextIteration();
                 retryInNewIteration();
             } else {
-                // query is completely terminated
-                done = true;
-                queue.done();
-                required.set(0);
+                finish();
             }
         }
     }

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -91,13 +91,14 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     public ReasonerProducer(Disjunction disjunction, TypeQLMatch.Modifiers modifiers, Options.Query options,
                             ResolverRegistry resolverRegistry, ExplainablesManager explainablesManager) {
         this.options = options;
+        this.resolverRegistry = resolverRegistry;
         this.explainablesManager = explainablesManager;
         this.queue = null;
         this.iteration = 0;
         this.done = false;
         this.required = new AtomicInteger();
         this.processing = new AtomicInteger();
-        this.rootResolver = resolverRegistry.root(disjunction, this::requestAnswered, this::requestFailed, this::exception);
+        this.rootResolver = this.resolverRegistry.root(disjunction, this::requestAnswered, this::requestFailed, this::exception);
         this.computeSize = options.parallel() ? Executors.PARALLELISATION_FACTOR * 2 : 1;
         assert computeSize > 0;
         Root<?, ?> downstream = InitialImpl.create(filter(modifiers.filter()), new ConceptMap(), this.rootResolver, options.explain()).toDownstream();

--- a/reasoner/resolution/ResolverRegistry.java
+++ b/reasoner/resolution/ResolverRegistry.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -89,6 +90,10 @@ public class ResolverRegistry {
         this.resolvers = new ConcurrentSet<>();
         this.terminated = new AtomicBoolean(false);
         this.resolutionTracing = resolutionTracing;
+    }
+
+    public Set<Actor.Driver<ConcludableResolver>> concludableResolvers() {
+        return new HashSet<>(concludableResolvers.values());
     }
 
     public void terminateResolvers(Throwable cause) {

--- a/reasoner/resolution/answer/AnswerState.java
+++ b/reasoner/resolution/answer/AnswerState.java
@@ -46,8 +46,6 @@ public interface AnswerState {
 
     ConceptMap conceptMap();
 
-    boolean requiresReiteration();
-
     Actor.Driver<? extends Resolver<?>> root();
 
     default boolean isTop() { return false; }
@@ -96,7 +94,7 @@ public interface AnswerState {
 
                 Partial.Compound.Root.Root.Match toDownstream();
 
-                Finished finish(ConceptMap conceptMap, boolean requiresReiteration);
+                Finished finish(ConceptMap conceptMap);
 
             }
 
@@ -128,7 +126,7 @@ public interface AnswerState {
 
                 Partial.Compound.Root.Explain toDownstream();
 
-                Finished finish(ConceptMap conceptMap, boolean requiresReiteration, Explanation explanation);
+                Finished finish(ConceptMap conceptMap, Explanation explanation);
 
             }
 
@@ -182,7 +180,7 @@ public interface AnswerState {
 
         interface Compound<SLF extends Compound<SLF, PRNT>, PRNT extends AnswerState> extends Partial<PRNT> {
 
-            SLF with(ConceptMap extension, boolean requiresReiteration);
+            SLF with(ConceptMap extension);
 
             Concludable<SLF> toDownstream(Mapping mapping, com.vaticle.typedb.core.logic.resolvable.Concludable concludable);
 
@@ -258,7 +256,7 @@ public interface AnswerState {
 
                 interface Explain extends Root<Explain, Top.Explain.Initial> {
 
-                    Explain with(ConceptMap extension, boolean requiresReiteration, Explanation explanation);
+                    Explain with(ConceptMap extension, Explanation explanation);
 
                     @Override
                     Concludable.Explain toDownstream(Mapping mapping, com.vaticle.typedb.core.logic.resolvable.Concludable concludable);
@@ -326,7 +324,7 @@ public interface AnswerState {
 
             Mapping mapping();
 
-            PRNT toUpstreamInferred(boolean requiresReiteration);
+            PRNT toUpstreamInferred();
 
             Optional<? extends Conclusion<?, ?>> toDownstream(Unifier unifier, Rule rule);
 
@@ -349,10 +347,9 @@ public interface AnswerState {
                 @Override
                 Optional<Conclusion.Match> toDownstream(Unifier unifier, Rule rule);
 
-                Match<P> with(ConceptMap extension, boolean requiresReiteration);
+                Match<P> with(ConceptMap extension);
 
-                P toUpstreamLookup(ConceptMap additionalConcepts, boolean isInferredConclusion,
-                                   boolean requiresReiteration);
+                P toUpstreamLookup(ConceptMap additionalConcepts, boolean isInferredConclusion);
 
                 @Override
                 default boolean isMatch() { return true; }
@@ -367,7 +364,7 @@ public interface AnswerState {
                 @Override
                 Optional<Conclusion.Explain> toDownstream(Unifier unifier, Rule rule);
 
-                Explain with(ConceptMap extension, boolean requiresReiteration, Rule rule, ConceptMap conclusionAnswer,
+                Explain with(ConceptMap extension, Rule rule, ConceptMap conclusionAnswer,
                              Unifier unifier, ConceptMap conditionAnswer);
 
                 @Override
@@ -414,7 +411,7 @@ public interface AnswerState {
                 @Override
                 FunctionalIterator<Concludable.Match<?>> aggregateToUpstream(Map<Identifier.Variable, Concept> concepts);
 
-                Match with(ConceptMap extension, boolean requiresReiteration);
+                Match with(ConceptMap extension);
 
                 @Override
                 Compound.Root.Condition.Match toDownstream(Set<Identifier.Variable.Retrievable> filter);
@@ -431,7 +428,7 @@ public interface AnswerState {
 
                 ConceptMap conditionAnswer();
 
-                Explain with(ConceptMap conditionAnswer, boolean requiresReiteration);
+                Explain with(ConceptMap conditionAnswer);
 
                 @Override
                 FunctionalIterator<Concludable.Explain> aggregateToUpstream(Map<Identifier.Variable, Concept> concepts);
@@ -451,7 +448,7 @@ public interface AnswerState {
 
         interface Retrievable<P extends Compound<P, ?>> extends Partial<P> {
 
-            P aggregateToUpstream(ConceptMap concepts, boolean requiresReiteration);
+            P aggregateToUpstream(ConceptMap concepts);
 
             @Override
             default boolean isRetrievable() { return true; }

--- a/reasoner/resolution/answer/AnswerStateImpl.java
+++ b/reasoner/resolution/answer/AnswerStateImpl.java
@@ -44,22 +44,15 @@ public abstract class AnswerStateImpl implements AnswerState {
 
     private final Actor.Driver<? extends Resolver<?>> root;
     private final ConceptMap conceptMap;
-    private final boolean requiresReiteration;
 
-    AnswerStateImpl(ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
+    AnswerStateImpl(ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root) {
         this.conceptMap = conceptMap;
         this.root = root;
-        this.requiresReiteration = requiresReiteration;
     }
 
     @Override
     public ConceptMap conceptMap() {
         return conceptMap;
-    }
-
-    @Override
-    public boolean requiresReiteration() {
-        return requiresReiteration;
     }
 
     @Override
@@ -81,8 +74,8 @@ public abstract class AnswerStateImpl implements AnswerState {
 
     public static abstract class TopImpl extends AnswerStateImpl implements Top {
 
-        TopImpl(ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-            super(conceptMap, root, requiresReiteration);
+        TopImpl(ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root) {
+            super(conceptMap, root);
         }
 
         public static abstract class MatchImpl extends TopImpl implements Match {
@@ -91,12 +84,12 @@ public abstract class AnswerStateImpl implements AnswerState {
             private final boolean explainable;
             private final int hash;
 
-            MatchImpl(Set<Identifier.Variable.Name> getFilter, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root,
-                      boolean requiresReiteration, boolean explainable) {
-                super(conceptMap, root, requiresReiteration);
+            MatchImpl(Set<Identifier.Variable.Name> getFilter, ConceptMap conceptMap,
+                      Actor.Driver<? extends Resolver<?>> root, boolean explainable) {
+                super(conceptMap, root);
                 this.getFilter = getFilter;
                 this.explainable = explainable;
-                this.hash = Objects.hash(root(), conceptMap(), requiresReiteration(), getFilter(), explainable());
+                this.hash = Objects.hash(root(), conceptMap(), getFilter(), explainable());
             }
 
             @Override
@@ -116,7 +109,6 @@ public abstract class AnswerStateImpl implements AnswerState {
                 AnswerStateImpl.TopImpl.MatchImpl that = (AnswerStateImpl.TopImpl.MatchImpl) o;
                 return Objects.equals(root(), that.root()) &&
                         Objects.equals(conceptMap(), that.conceptMap()) &&
-                        requiresReiteration() == that.requiresReiteration() &&
                         Objects.equals(getFilter(), that.getFilter()) &&
                         explainable() == that.explainable();
             }
@@ -128,12 +120,14 @@ public abstract class AnswerStateImpl implements AnswerState {
 
             public static class InitialImpl extends MatchImpl implements Initial {
 
-                private InitialImpl(Set<Identifier.Variable.Name> getFilter, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration, boolean explainable) {
-                    super(getFilter, conceptMap, root, requiresReiteration, explainable);
+                private InitialImpl(Set<Identifier.Variable.Name> getFilter, ConceptMap conceptMap,
+                                    Actor.Driver<? extends Resolver<?>> root, boolean explainable) {
+                    super(getFilter, conceptMap, root, explainable);
                 }
 
-                public static InitialImpl create(Set<Identifier.Variable.Name> getFilter, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean explainable) {
-                    return new InitialImpl(getFilter, conceptMap, root, false, explainable);
+                public static InitialImpl create(Set<Identifier.Variable.Name> getFilter, ConceptMap conceptMap,
+                                                 Actor.Driver<? extends Resolver<?>> root, boolean explainable) {
+                    return new InitialImpl(getFilter, conceptMap, root, explainable);
                 }
 
                 @Override
@@ -142,41 +136,43 @@ public abstract class AnswerStateImpl implements AnswerState {
                 }
 
                 @Override
-                public FinishedImpl finish(ConceptMap conceptMap, boolean requiresReiteration) {
+                public FinishedImpl finish(ConceptMap conceptMap) {
                     ConceptMap answer = conceptMap;
                     if (!explainable()) answer = conceptMap.filter(getFilter());
-                    return FinishedImpl.create(getFilter(), answer, root(), requiresReiteration, explainable());
+                    return FinishedImpl.create(getFilter(), answer, root(), explainable());
                 }
 
             }
 
             public static class FinishedImpl extends MatchImpl implements Finished {
 
-                private FinishedImpl(Set<Identifier.Variable.Name> getFilter, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration, boolean explainable) {
-                    super(getFilter, conceptMap, root, requiresReiteration, explainable);
+                private FinishedImpl(Set<Identifier.Variable.Name> getFilter, ConceptMap conceptMap,
+                                     Actor.Driver<? extends Resolver<?>> root, boolean explainable) {
+                    super(getFilter, conceptMap, root, explainable);
                 }
 
-                public static FinishedImpl create(Set<Identifier.Variable.Name> getFilter, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration, boolean explainable) {
+                public static FinishedImpl create(Set<Identifier.Variable.Name> getFilter, ConceptMap conceptMap,
+                                                  Actor.Driver<? extends Resolver<?>> root, boolean explainable) {
                     ConceptMap initialAns = conceptMap;
                     if (!explainable) initialAns = conceptMap.filter(getFilter);
-                    return new FinishedImpl(getFilter, initialAns, root, requiresReiteration, explainable);
+                    return new FinishedImpl(getFilter, initialAns, root, explainable);
                 }
             }
         }
 
         public static abstract class ExplainImpl extends TopImpl implements Explain {
 
-            ExplainImpl(ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-                super(conceptMap, root, requiresReiteration);
+            ExplainImpl(ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root) {
+                super(conceptMap, root);
             }
 
             public static class InitialImpl extends ExplainImpl implements Initial {
 
                 private final int hash;
 
-                public InitialImpl(ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-                    super(conceptMap, root, requiresReiteration);
-                    this.hash = Objects.hash(root(), conceptMap(), requiresReiteration());
+                public InitialImpl(ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root) {
+                    super(conceptMap, root);
+                    this.hash = Objects.hash(root(), conceptMap());
                 }
 
                 @Override
@@ -185,8 +181,8 @@ public abstract class AnswerStateImpl implements AnswerState {
                 }
 
                 @Override
-                public Finished finish(ConceptMap conceptMap, boolean requiresReiteration, Explanation explanation) {
-                    return new FinishedImpl(explanation, extendAnswer(conceptMap), root(), requiresReiteration);
+                public Finished finish(ConceptMap conceptMap, Explanation explanation) {
+                    return new FinishedImpl(explanation, extendAnswer(conceptMap), root());
                 }
 
                 @Override
@@ -195,8 +191,7 @@ public abstract class AnswerStateImpl implements AnswerState {
                     if (o == null || getClass() != o.getClass()) return false;
                     TopImpl.ExplainImpl.InitialImpl that = (TopImpl.ExplainImpl.InitialImpl) o;
                     return Objects.equals(root(), that.root()) &&
-                            Objects.equals(conceptMap(), that.conceptMap()) &&
-                            requiresReiteration() == that.requiresReiteration();
+                            Objects.equals(conceptMap(), that.conceptMap());
                 }
 
                 @Override
@@ -211,11 +206,11 @@ public abstract class AnswerStateImpl implements AnswerState {
                 private final Explanation explanation;
                 private final int hash;
 
-                FinishedImpl(Explanation explanation, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-                    super(conceptMap, root, requiresReiteration);
+                FinishedImpl(Explanation explanation, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root) {
+                    super(conceptMap, root);
                     assert explanation != null;
                     this.explanation = explanation;
-                    this.hash = Objects.hash(root(), conceptMap(), requiresReiteration(), explanation());
+                    this.hash = Objects.hash(root(), conceptMap(), explanation());
                 }
 
                 @Override
@@ -230,7 +225,6 @@ public abstract class AnswerStateImpl implements AnswerState {
                     TopImpl.ExplainImpl.FinishedImpl that = (TopImpl.ExplainImpl.FinishedImpl) o;
                     return Objects.equals(root(), that.root()) &&
                             Objects.equals(conceptMap(), that.conceptMap()) &&
-                            requiresReiteration() == that.requiresReiteration() &&
                             Objects.equals(explanation(), that.explanation());
                 }
 
@@ -247,8 +241,8 @@ public abstract class AnswerStateImpl implements AnswerState {
 
         private final PARENT parent;
 
-        PartialImpl(PARENT parent, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-            super(conceptMap, root, requiresReiteration);
+        PartialImpl(PARENT parent, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root) {
+            super(conceptMap, root);
             this.parent = parent;
         }
 
@@ -260,8 +254,8 @@ public abstract class AnswerStateImpl implements AnswerState {
         public static abstract class CompoundImpl<SLF extends Compound<SLF, PRNT>, PRNT extends AnswerState>
                 extends PartialImpl<PRNT> implements Compound<SLF, PRNT> {
 
-            CompoundImpl(PRNT prnt, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-                super(prnt, conceptMap, root, requiresReiteration);
+            CompoundImpl(PRNT prnt, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root) {
+                super(prnt, conceptMap, root);
             }
 
             @Override
@@ -278,16 +272,16 @@ public abstract class AnswerStateImpl implements AnswerState {
                 private final int hash;
 
                 NestableImpl(Set<Identifier.Variable.Retrievable> filter, Compound<?, ?> parent,
-                             ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration,
+                             ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root,
                              boolean explainable) {
-                    super(parent, conceptMap, root, requiresReiteration);
+                    super(parent, conceptMap, root);
                     this.filter = filter;
                     this.explainable = explainable;
-                    this.hash = Objects.hash(root(), parent(), conceptMap(), requiresReiteration(), filter());
+                    this.hash = Objects.hash(root(), parent(), conceptMap(), filter());
                 }
 
                 static NestableImpl childOf(Set<Identifier.Variable.Retrievable> filter, Compound<?, ?> parent, boolean explainable) {
-                    return new NestableImpl(filter, parent, parent.conceptMap().filter(filter), parent.root(), parent.requiresReiteration(), explainable);
+                    return new NestableImpl(filter, parent, parent.conceptMap().filter(filter), parent.root(), explainable);
                 }
 
                 @Override
@@ -296,8 +290,8 @@ public abstract class AnswerStateImpl implements AnswerState {
                 }
 
                 @Override
-                public Nestable with(ConceptMap extension, boolean requiresReiteration) {
-                    return new NestableImpl(filter(), parent(), extendAnswer(extension), root(), requiresReiteration, explainable);
+                public Nestable with(ConceptMap extension) {
+                    return new NestableImpl(filter(), parent(), extendAnswer(extension), root(), explainable);
                 }
 
                 @Override
@@ -314,7 +308,7 @@ public abstract class AnswerStateImpl implements AnswerState {
                 public Compound<?, ?> toUpstream() {
                     ConceptMap conceptMap = conceptMap();
                     if (!explainable) conceptMap = conceptMap.filter(filter);
-                    return parent().with(conceptMap, requiresReiteration() || parent().requiresReiteration());
+                    return parent().with(conceptMap);
                 }
 
                 @Override
@@ -330,7 +324,6 @@ public abstract class AnswerStateImpl implements AnswerState {
                     return Objects.equals(root(), that.root()) &&
                             Objects.equals(parent(), that.parent()) &&
                             Objects.equals(conceptMap(), that.conceptMap()) &&
-                            requiresReiteration() == that.requiresReiteration() &&
                             Objects.equals(filter(), that.filter());
                 }
 
@@ -342,8 +335,8 @@ public abstract class AnswerStateImpl implements AnswerState {
 
             public static abstract class RootImpl<S extends Root<S, P>, P extends AnswerState> extends CompoundImpl<S, P> implements Root<S, P> {
 
-                RootImpl(P parent, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-                    super(parent, conceptMap, root, requiresReiteration);
+                RootImpl(P parent, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root) {
+                    super(parent, conceptMap, root);
                 }
 
                 public static class MatchImpl extends RootImpl<Match, Top.Match.Initial> implements Match {
@@ -352,14 +345,14 @@ public abstract class AnswerStateImpl implements AnswerState {
                     private final int hash;
 
                     MatchImpl(Top.Match.Initial parent, ConceptMap conceptMap,
-                              Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration, boolean explainable) {
-                        super(parent, conceptMap, root, requiresReiteration);
+                              Actor.Driver<? extends Resolver<?>> root, boolean explainable) {
+                        super(parent, conceptMap, root);
                         this.explainable = explainable;
-                        this.hash = Objects.hash(root, parent, conceptMap, requiresReiteration(), explainable);
+                        this.hash = Objects.hash(root, parent, conceptMap, explainable);
                     }
 
                     static MatchImpl childOf(Top.Match.Initial parent) {
-                        return new MatchImpl(parent, parent.conceptMap(), parent.root(), parent.requiresReiteration(), parent.explainable());
+                        return new MatchImpl(parent, parent.conceptMap(), parent.root(), parent.explainable());
                     }
 
                     @Override
@@ -368,8 +361,8 @@ public abstract class AnswerStateImpl implements AnswerState {
                     }
 
                     @Override
-                    public Match with(ConceptMap extension, boolean requiresReiteration) {
-                        return new MatchImpl(parent(), extendAnswer(extension), root(), requiresReiteration, explainable());
+                    public Match with(ConceptMap extension) {
+                        return new MatchImpl(parent(), extendAnswer(extension), root(), explainable());
                     }
 
                     @Override
@@ -384,7 +377,7 @@ public abstract class AnswerStateImpl implements AnswerState {
 
                     @Override
                     public Top.Match.Finished toFinishedTop(Conjunction compoundConjunction) {
-                        return parent().finish(conceptMap(), requiresReiteration());
+                        return parent().finish(conceptMap());
                     }
 
                     @Override
@@ -400,7 +393,6 @@ public abstract class AnswerStateImpl implements AnswerState {
                         return Objects.equals(root(), that.root()) &&
                                 Objects.equals(parent(), that.parent()) &&
                                 Objects.equals(conceptMap(), that.conceptMap()) &&
-                                requiresReiteration() == that.requiresReiteration() &&
                                 explainable() == that.explainable();
                     }
 
@@ -416,25 +408,25 @@ public abstract class AnswerStateImpl implements AnswerState {
                     private final int hash;
 
                     private ExplainImpl(Explanation explanation, Top.Explain.Initial parent, ConceptMap conceptMap,
-                                        Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-                        super(parent, conceptMap, root, requiresReiteration);
+                                        Actor.Driver<? extends Resolver<?>> root) {
+                        super(parent, conceptMap, root);
                         this.explanation = explanation;
-                        this.hash = Objects.hash(root(), parent(), conceptMap(), requiresReiteration(), explanation);
+                        this.hash = Objects.hash(root(), parent(), conceptMap(), explanation);
                     }
 
                     static ExplainImpl childOf(Top.Explain.Initial parent) {
-                        return new ExplainImpl(null, parent, parent.conceptMap(), parent.root(), parent.requiresReiteration());
+                        return new ExplainImpl(null, parent, parent.conceptMap(), parent.root());
                     }
 
                     @Override
-                    public Explain with(ConceptMap extension, boolean requiresReiteration) {
+                    public Explain with(ConceptMap extension) {
                         throw TypeDBException.of(ILLEGAL_STATE);
                     }
 
                     @Override
-                    public Explain with(ConceptMap extension, boolean requiresReiteration, Explanation explanation) {
+                    public Explain with(ConceptMap extension, Explanation explanation) {
                         assert this.explanation == null;
-                        return new ExplainImpl(explanation, parent(), extendAnswer(extension), root(), requiresReiteration());
+                        return new ExplainImpl(explanation, parent(), extendAnswer(extension), root());
                     }
 
                     @Override
@@ -451,7 +443,7 @@ public abstract class AnswerStateImpl implements AnswerState {
                     @Override
                     public Top.Explain.Finished toFinishedTop() {
                         assert explanation != null;
-                        return parent().finish(conceptMap(), requiresReiteration(), explanation);
+                        return parent().finish(conceptMap(), explanation);
                     }
 
                     @Override
@@ -467,7 +459,6 @@ public abstract class AnswerStateImpl implements AnswerState {
                         return Objects.equals(root(), that.root()) &&
                                 Objects.equals(parent(), that.parent()) &&
                                 Objects.equals(conceptMap(), that.conceptMap()) &&
-                                requiresReiteration() == that.requiresReiteration() &&
                                 Objects.equals(explanation, that.explanation);
                     }
 
@@ -482,8 +473,8 @@ public abstract class AnswerStateImpl implements AnswerState {
             public static abstract class ConditionImpl<S extends Condition<S, P>, P extends Conclusion<P, ?>> extends CompoundImpl<S, P>
                     implements Condition<S, P> {
 
-                ConditionImpl(P parent, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-                    super(parent, conceptMap, root, requiresReiteration);
+                ConditionImpl(P parent, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root) {
+                    super(parent, conceptMap, root);
                 }
 
                 @Override
@@ -496,25 +487,25 @@ public abstract class AnswerStateImpl implements AnswerState {
                     private final Set<Identifier.Variable.Retrievable> filter;
                     private final int hash;
 
-                    private MatchImpl(Set<Identifier.Variable.Retrievable> filter, Conclusion.Match parent, ConceptMap conceptMap,
-                                      Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-                        super(parent, conceptMap, root, requiresReiteration);
+                    private MatchImpl(Set<Identifier.Variable.Retrievable> filter, Conclusion.Match parent,
+                                      ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root) {
+                        super(parent, conceptMap, root);
                         this.filter = filter;
-                        this.hash = Objects.hash(parent(), root(), conceptMap(), requiresReiteration(), filter);
+                        this.hash = Objects.hash(parent(), root(), conceptMap(), filter);
                     }
 
                     static MatchImpl childOf(Set<Identifier.Variable.Retrievable> filter, Conclusion.Match parent) {
-                        return new MatchImpl(filter, parent, parent.conceptMap().filter(filter), parent.root(), false);
+                        return new MatchImpl(filter, parent, parent.conceptMap().filter(filter), parent.root());
                     }
 
                     @Override
-                    public Match with(ConceptMap extension, boolean requiresReiteration) {
-                        return new MatchImpl(filter, parent(), extendAnswer(extension), root(), requiresReiteration);
+                    public Match with(ConceptMap extension) {
+                        return new MatchImpl(filter, parent(), extendAnswer(extension), root());
                     }
 
                     @Override
                     public Conclusion.Match toUpstream() {
-                        return parent().with(conceptMap().filter(filter), requiresReiteration() || parent().requiresReiteration());
+                        return parent().with(conceptMap().filter(filter));
                     }
 
                     @Override
@@ -535,7 +526,6 @@ public abstract class AnswerStateImpl implements AnswerState {
                         return Objects.equals(root(), that.root()) &&
                                 Objects.equals(conceptMap(), that.conceptMap()) &&
                                 Objects.equals(parent(), that.parent()) &&
-                                requiresReiteration() == that.requiresReiteration() &&
                                 Objects.equals(filter, that.filter);
                     }
 
@@ -551,26 +541,25 @@ public abstract class AnswerStateImpl implements AnswerState {
                     private final int hash;
 
                     private ExplainImpl(Set<Identifier.Variable.Retrievable> filter, Conclusion.Explain parent,
-                                        ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root,
-                                        boolean requiresReiteration) {
-                        super(parent, conceptMap, root, requiresReiteration);
+                                        ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root) {
+                        super(parent, conceptMap, root);
                         this.filter = filter;
-                        this.hash = Objects.hash(root(), parent(), conceptMap(), requiresReiteration(), filter);
+                        this.hash = Objects.hash(root(), parent(), conceptMap(), filter);
                     }
 
                     static ExplainImpl childOf(Set<Identifier.Variable.Retrievable> filter, Conclusion.Explain parent) {
-                        return new ExplainImpl(filter, parent, parent.conceptMap().filter(filter), parent.root(), false);
+                        return new ExplainImpl(filter, parent, parent.conceptMap().filter(filter), parent.root());
                     }
 
                     @Override
-                    public Explain with(ConceptMap extension, boolean requiresReiteration) {
-                        return new ExplainImpl(filter, parent(), extendAnswer(extension), root(), requiresReiteration);
+                    public Explain with(ConceptMap extension) {
+                        return new ExplainImpl(filter, parent(), extendAnswer(extension), root());
                     }
 
                     @Override
                     public Conclusion.Explain toUpstream() {
                         if (conceptMap().concepts().isEmpty()) throw TypeDBException.of(ILLEGAL_STATE);
-                        return parent().with(conceptMap(), requiresReiteration() || parent().requiresReiteration());
+                        return parent().with(conceptMap());
                     }
 
                     @Override
@@ -591,7 +580,6 @@ public abstract class AnswerStateImpl implements AnswerState {
                         return Objects.equals(root(), that.root()) &&
                                 Objects.equals(conceptMap(), that.conceptMap()) &&
                                 Objects.equals(parent(), that.parent()) &&
-                                requiresReiteration() == that.requiresReiteration() &&
                                 Objects.equals(filter, that.filter);
                     }
 
@@ -608,8 +596,8 @@ public abstract class AnswerStateImpl implements AnswerState {
 
             private final Mapping mapping;
 
-            ConcludableImpl(Mapping mapping, PRNT parent, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-                super(parent, conceptMap, root, requiresReiteration);
+            ConcludableImpl(Mapping mapping, PRNT parent, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root) {
+                super(parent, conceptMap, root);
                 this.mapping = mapping;
             }
 
@@ -625,17 +613,17 @@ public abstract class AnswerStateImpl implements AnswerState {
                 private final int hash;
 
                 private MatchImpl(Mapping mapping, com.vaticle.typedb.core.logic.resolvable.Concludable concludable, P parent, ConceptMap conceptMap,
-                                  Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration, boolean explainable) {
-                    super(mapping, parent, conceptMap, root, requiresReiteration);
+                                  Actor.Driver<? extends Resolver<?>> root, boolean explainable) {
+                    super(mapping, parent, conceptMap, root);
                     this.concludable = concludable;
                     this.explainable = explainable;
-                    this.hash = Objects.hash(root(), parent(), conceptMap(), requiresReiteration(), explainable(), mapping());
+                    this.hash = Objects.hash(root(), parent(), conceptMap(),explainable(), mapping());
                 }
 
                 static <P extends Compound<P, ?>> MatchImpl<P> childOf(Mapping mapping, com.vaticle.typedb.core.logic.resolvable.Concludable concludable,
                                                                        P parent, boolean explainable) {
                     return new MatchImpl<>(mapping, concludable, parent, mapping.transform(parent.conceptMap()),
-                                           parent.root(), parent.requiresReiteration(), explainable);
+                                           parent.root(), explainable);
                 }
 
                 @Override
@@ -644,28 +632,25 @@ public abstract class AnswerStateImpl implements AnswerState {
                 }
 
                 @Override
-                public Match<P> with(ConceptMap extension, boolean requiresReiteration) {
-                    return new MatchImpl<>(mapping(), concludable, parent(), extendAnswer(extension), root(), requiresReiteration, explainable());
+                public Match<P> with(ConceptMap extension) {
+                    return new MatchImpl<>(mapping(), concludable, parent(), extendAnswer(extension), root(), explainable());
                 }
 
                 @Override
-                public P toUpstreamInferred(boolean requiresReiteration) {
+                public P toUpstreamInferred() {
                     ConceptMap upstreamAnswer = mapping().unTransform(conceptMap());
                     if (explainable()) upstreamAnswer = withExplainable(upstreamAnswer);
-                    return parent().with(upstreamAnswer, requiresReiteration() ||
-                            parent().requiresReiteration() || requiresReiteration);
+                    return parent().with(upstreamAnswer);
                 }
 
                 @Override
-                public P toUpstreamLookup(ConceptMap additionalConcepts, boolean isInferredConclusion,
-                                          boolean requiresReiteration) {
-                    boolean reiterate = requiresReiteration() || parent().requiresReiteration() || requiresReiteration;
+                public P toUpstreamLookup(ConceptMap additionalConcepts, boolean isInferredConclusion) {
                     ConceptMap upstreamAnswer = mapping().unTransform(additionalConcepts);
                     if (isInferredConclusion) {
                         if (explainable()) upstreamAnswer = withExplainable(upstreamAnswer);
-                        return parent().with(upstreamAnswer, reiterate);
+                        return parent().with(upstreamAnswer);
                     } else {
-                        return parent().with(upstreamAnswer, reiterate);
+                        return parent().with(upstreamAnswer);
                     }
                 }
 
@@ -692,7 +677,6 @@ public abstract class AnswerStateImpl implements AnswerState {
                     return Objects.equals(root(), that.root()) &&
                             Objects.equals(conceptMap(), that.conceptMap()) &&
                             Objects.equals(parent(), that.parent()) &&
-                            requiresReiteration() == that.requiresReiteration() &&
                             explainable == that.explainable &&
                             Objects.equals(mapping(), that.mapping());
                 }
@@ -709,21 +693,21 @@ public abstract class AnswerStateImpl implements AnswerState {
                 private final int hash;
 
                 ExplainImpl(@Nullable Explanation explanation, Mapping mapping, Compound.Root.Explain parent, ConceptMap conceptMap,
-                            Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-                    super(mapping, parent, conceptMap, root, requiresReiteration);
+                            Actor.Driver<? extends Resolver<?>> root) {
+                    super(mapping, parent, conceptMap, root);
                     this.explanation = explanation;
-                    this.hash = Objects.hash(root(), parent(), conceptMap(), mapping(), requiresReiteration(), explanation);
+                    this.hash = Objects.hash(root(), parent(), conceptMap(), mapping(), explanation);
                 }
 
                 static ExplainImpl childOf(Mapping mapping, Compound.Root.Explain parent) {
-                    return new ExplainImpl(null, mapping, parent, mapping.transform(parent.conceptMap()), parent.root(), parent.requiresReiteration());
+                    return new ExplainImpl(null, mapping, parent, mapping.transform(parent.conceptMap()), parent.root());
                 }
 
                 @Override
-                public Explain with(ConceptMap extension, boolean requiresReiteration, Rule rule, ConceptMap conclusionAnser, Unifier unifier, ConceptMap conditionAnswer) {
+                public Explain with(ConceptMap extension, Rule rule, ConceptMap conclusionAnser, Unifier unifier, ConceptMap conditionAnswer) {
                     assert this.explanation == null;
                     Explanation explanation = new Explanation(rule, transitiveMapping(mapping(), unifier), conclusionAnser, conditionAnswer);
-                    return new ExplainImpl(explanation, mapping(), parent(), extendAnswer(extension), root(), requiresReiteration);
+                    return new ExplainImpl(explanation, mapping(), parent(), extendAnswer(extension), root());
                 }
 
                 private Map<Identifier.Variable.Retrievable, Set<Identifier.Variable.Retrievable>> transitiveMapping(Mapping mapping, Unifier unifier) {
@@ -740,9 +724,8 @@ public abstract class AnswerStateImpl implements AnswerState {
                 }
 
                 @Override
-                public Compound.Root.Explain toUpstreamInferred(boolean requiresReiteration) {
-                    boolean reiterate = requiresReiteration() || parent().requiresReiteration() || requiresReiteration;
-                    return parent().with(mapping().unTransform(this.conceptMap()), reiterate, explanation);
+                public Compound.Root.Explain toUpstreamInferred() {
+                    return parent().with(mapping().unTransform(this.conceptMap()), explanation);
                 }
 
                 @Override
@@ -759,7 +742,6 @@ public abstract class AnswerStateImpl implements AnswerState {
                             Objects.equals(parent(), that.parent()) &&
                             Objects.equals(conceptMap(), that.conceptMap()) &&
                             Objects.equals(mapping(), that.mapping()) &&
-                            requiresReiteration() == that.requiresReiteration() &&
                             Objects.equals(explanation, that.explanation);
                 }
 
@@ -778,8 +760,8 @@ public abstract class AnswerStateImpl implements AnswerState {
             private final Unifier.Requirements.Instance instanceRequirements;
 
             ConclusionImpl(Rule rule, Unifier unifier, Unifier.Requirements.Instance instanceRequirements,
-                           PRNT prnt, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-                super(prnt, conceptMap, root, requiresReiteration);
+                           PRNT prnt, ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root) {
+                super(prnt, conceptMap, root);
                 this.rule = rule;
                 this.unifier = unifier;
                 this.instanceRequirements = instanceRequirements;
@@ -805,29 +787,30 @@ public abstract class AnswerStateImpl implements AnswerState {
                 private final boolean explainable;
                 private final int hash;
 
-                private MatchImpl(Rule rule, Unifier unifier, Unifier.Requirements.Instance instanceRequirements, Concludable.Match<?> parent,
-                                  ConceptMap conceptMap, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration,
-                                  boolean explainable) {
-                    super(rule, unifier, instanceRequirements, parent, conceptMap, root, requiresReiteration);
+                private MatchImpl(Rule rule, Unifier unifier, Unifier.Requirements.Instance instanceRequirements,
+                                  Concludable.Match<?> parent, ConceptMap conceptMap,
+                                  Actor.Driver<? extends Resolver<?>> root, boolean explainable) {
+                    super(rule, unifier, instanceRequirements, parent, conceptMap, root);
                     this.explainable = explainable;
-                    this.hash = Objects.hash(root(), parent(), conceptMap(), rule(), unifier(), instanceRequirements(), requiresReiteration(), explainable());
+                    this.hash = Objects.hash(root(), parent(), conceptMap(), rule(), unifier(), instanceRequirements(),
+                                             explainable());
                 }
 
                 static Optional<Match> childOf(Unifier unifier, Rule rule, Concludable.Match<?> parent) {
                     Optional<Pair<ConceptMap, Unifier.Requirements.Instance>> unified = unifier.unify(parent.conceptMap());
                     return unified.map(unification -> new MatchImpl(
-                            rule, unifier, unification.second(), parent, unification.first(), parent.root(), false, parent.explainable()
+                            rule, unifier, unification.second(), parent, unification.first(), parent.root(), parent.explainable()
                     ));
                 }
 
                 @Override
-                public Match with(ConceptMap extension, boolean requiresReiteration) {
-                    return new MatchImpl(rule(), unifier(), instanceRequirements(), parent(), extendAnswer(extension), root(), requiresReiteration, explainable());
+                public Match with(ConceptMap extension) {
+                    return new MatchImpl(rule(), unifier(), instanceRequirements(), parent(), extendAnswer(extension), root(), explainable());
                 }
 
                 @Override
                 public Match extend(ConceptMap ans) {
-                    return new MatchImpl(rule(), unifier(), instanceRequirements(), parent(), extendAnswer(ans), root(), requiresReiteration(), explainable());
+                    return new MatchImpl(rule(), unifier(), instanceRequirements(), parent(), extendAnswer(ans), root(), explainable());
                 }
 
                 @Override
@@ -838,7 +821,7 @@ public abstract class AnswerStateImpl implements AnswerState {
                 @Override
                 public FunctionalIterator<Concludable.Match<?>> aggregateToUpstream(Map<Identifier.Variable, Concept> concepts) {
                     FunctionalIterator<ConceptMap> unUnified = unifier().unUnify(concepts, instanceRequirements());
-                    return unUnified.map(ans -> parent().with(ans, requiresReiteration()));
+                    return unUnified.map(ans -> parent().with(ans));
                 }
 
                 @Override
@@ -857,7 +840,6 @@ public abstract class AnswerStateImpl implements AnswerState {
                             Objects.equals(rule(), that.rule()) &&
                             Objects.equals(unifier(), that.unifier()) &&
                             Objects.equals(instanceRequirements(), that.instanceRequirements()) &&
-                            requiresReiteration() == that.requiresReiteration() &&
                             explainable() == that.explainable();
                 }
 
@@ -872,17 +854,19 @@ public abstract class AnswerStateImpl implements AnswerState {
                 private final ConceptMap conditionAnswer;
                 private final int hash;
 
-                private ExplainImpl(ConceptMap conditionAnswer, Rule rule, Unifier unifier, Unifier.Requirements.Instance instanceRequirements,
-                                    ConceptMap conceptMap, Concludable.Explain parent, Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-                    super(rule, unifier, instanceRequirements, parent, conceptMap, root, requiresReiteration);
+                private ExplainImpl(ConceptMap conditionAnswer, Rule rule, Unifier unifier,
+                                    Unifier.Requirements.Instance instanceRequirements, ConceptMap conceptMap,
+                                    Concludable.Explain parent, Actor.Driver<? extends Resolver<?>> root) {
+                    super(rule, unifier, instanceRequirements, parent, conceptMap, root);
                     this.conditionAnswer = conditionAnswer;
-                    this.hash = Objects.hash(root(), parent(), conceptMap(), rule(), unifier(), instanceRequirements(), requiresReiteration(), conditionAnswer());
+                    this.hash = Objects.hash(root(), parent(), conceptMap(), rule(), unifier(), instanceRequirements(),
+                                             conditionAnswer());
                 }
 
                 static Optional<Explain> childOf(Unifier unifier, Rule rule, Concludable.Explain parent) {
                     Optional<Pair<ConceptMap, Unifier.Requirements.Instance>> unified = unifier.unify(parent.conceptMap());
                     return unified.map(unification -> new ExplainImpl(
-                            null, rule, unifier, unification.second(), unification.first(), parent, parent.root(), false
+                            null, rule, unifier, unification.second(), unification.first(), parent, parent.root()
                     ));
                 }
 
@@ -893,21 +877,21 @@ public abstract class AnswerStateImpl implements AnswerState {
 
                 @Override
                 public Explain extend(ConceptMap ans) {
-                    return new ExplainImpl(conditionAnswer(), rule(), unifier(), instanceRequirements(), extendAnswer(ans), parent(), root(), requiresReiteration());
+                    return new ExplainImpl(conditionAnswer(), rule(), unifier(), instanceRequirements(), extendAnswer(ans), parent(), root());
                 }
 
                 @Override
-                public Explain with(ConceptMap conditionAnswer, boolean requiresReiteration) {
+                public Explain with(ConceptMap conditionAnswer) {
                     assert this.conditionAnswer() == null && conditionAnswer != null;
                     // note: we add more concepts to the conclusion answer than there are variables to preserve uniqueness of multiple explanations
-                    return new ExplainImpl(conditionAnswer, rule(), unifier(), instanceRequirements(), extendAnswer(conditionAnswer), parent(), root(), requiresReiteration);
+                    return new ExplainImpl(conditionAnswer, rule(), unifier(), instanceRequirements(), extendAnswer(conditionAnswer), parent(), root());
                 }
 
                 @Override
                 public FunctionalIterator<Concludable.Explain> aggregateToUpstream(Map<Identifier.Variable, Concept> concepts) {
                     FunctionalIterator<ConceptMap> unUnified = unifier().unUnify(concepts, instanceRequirements());
                     return unUnified.map(ans ->
-                         parent().with(ans, requiresReiteration(), rule(), toConceptMap(concepts), unifier(), conditionAnswer())
+                         parent().with(ans, rule(), toConceptMap(concepts), unifier(), conditionAnswer())
                     );
                 }
 
@@ -934,7 +918,6 @@ public abstract class AnswerStateImpl implements AnswerState {
                             Objects.equals(rule(), that.rule()) &&
                             Objects.equals(unifier(), that.unifier()) &&
                             Objects.equals(instanceRequirements(), that.instanceRequirements()) &&
-                            requiresReiteration() == that.requiresReiteration() &&
                             Objects.equals(conditionAnswer(), that.conditionAnswer());
                 }
 
@@ -1002,33 +985,32 @@ public abstract class AnswerStateImpl implements AnswerState {
             private final int hash;
 
             private RetrievableImpl(Set<Identifier.Variable.Retrievable> filter, P parent, ConceptMap conceptMap,
-                                    Actor.Driver<? extends Resolver<?>> root, boolean requiresReiteration) {
-                super(parent, conceptMap, root, requiresReiteration);
+                                    Actor.Driver<? extends Resolver<?>> root) {
+                super(parent, conceptMap, root);
                 this.filter = filter;
-                this.hash = Objects.hash(root(), parent(), conceptMap(), requiresReiteration(), filter);
+                this.hash = Objects.hash(root(), parent(), conceptMap(), filter);
             }
 
             static <P extends Compound<P, ?>> RetrievableImpl<P> childOf(Set<Identifier.Variable.Retrievable> filter, P parent) {
-                return new RetrievableImpl<>(filter, parent, parent.conceptMap().filter(filter), parent.root(), parent.requiresReiteration());
+                return new RetrievableImpl<>(filter, parent, parent.conceptMap().filter(filter), parent.root());
             }
 
             @Override
-            public P aggregateToUpstream(ConceptMap concepts, boolean requiresReiteration) {
+            public P aggregateToUpstream(ConceptMap concepts) {
                 assert concepts.concepts().keySet().containsAll(conceptMap().concepts().keySet()) &&
                         filter.containsAll(concepts.concepts().keySet());
                 if (concepts.concepts().isEmpty()) throw TypeDBException.of(ILLEGAL_STATE);
-                return parent().with(concepts, parent().requiresReiteration() || requiresReiteration);
+                return parent().with(concepts);
             }
 
             @Override
             public boolean equals(Object o) {
                 if (this == o) return true;
                 if (o == null || getClass() != o.getClass()) return false;
-                RetrievableImpl that = (RetrievableImpl) o;
+                RetrievableImpl<?> that = (RetrievableImpl<?>) o;
                 return Objects.equals(root(), that.root()) &&
                         Objects.equals(parent(), that.parent()) &&
                         Objects.equals(conceptMap(), that.conceptMap()) &&
-                        requiresReiteration() == that.requiresReiteration() &&
                         Objects.equals(filter, that.filter);
             }
 

--- a/reasoner/resolution/answer/AnswerStateTest.java
+++ b/reasoner/resolution/answer/AnswerStateTest.java
@@ -50,7 +50,7 @@ public class AnswerStateTest {
         Map<Identifier.Variable.Retrievable, Concept> concepts = new HashMap<>();
         concepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         concepts.put(Identifier.Variable.name("y"), new MockConcept(1));
-        Partial.Compound<?, ?> partial = mapped.toUpstreamLookup(new ConceptMap(concepts), false, false);
+        Partial.Compound<?, ?> partial = mapped.toUpstreamLookup(new ConceptMap(concepts), false);
         Map<Identifier.Variable.Retrievable, Concept> expected = new HashMap<>();
         expected.put(Identifier.Variable.name("a"), new MockConcept(0));
         expected.put(Identifier.Variable.name("b"), new MockConcept(1));
@@ -66,7 +66,7 @@ public class AnswerStateTest {
         concepts.put(Identifier.Variable.name("a"), new MockConcept(0));
         Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("a"), Identifier.Variable.name("b"));
         Concludable.Match<?> mapped = InitialImpl.create(filter, new ConceptMap(), null, false).toDownstream()
-                .with(new ConceptMap(concepts), false)
+                .with(new ConceptMap(concepts))
                 .toDownstream(Mapping.of(mapping), null);
 
         Map<Identifier.Variable.Retrievable, Concept> expectedMapped = new HashMap<>();
@@ -76,7 +76,7 @@ public class AnswerStateTest {
         Map<Identifier.Variable.Retrievable, Concept> downstreamConcepts = new HashMap<>();
         downstreamConcepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         downstreamConcepts.put(Identifier.Variable.name("y"), new MockConcept(1));
-        Partial.Compound<?, ?> partial = mapped.toUpstreamLookup(new ConceptMap(downstreamConcepts), false, false);
+        Partial.Compound<?, ?> partial = mapped.toUpstreamLookup(new ConceptMap(downstreamConcepts), false);
 
         Map<Identifier.Variable.Retrievable, Concept> expectedWithInitial = new HashMap<>();
         expectedWithInitial.put(Identifier.Variable.name("a"), new MockConcept(0));
@@ -94,7 +94,7 @@ public class AnswerStateTest {
         concepts.put(Identifier.Variable.name("c"), new MockConcept(2));
         Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("a"), Identifier.Variable.name("b"));
         Concludable.Match<?> mapped = InitialImpl.create(filter, new ConceptMap(), null, false).toDownstream()
-                .with(new ConceptMap(concepts), false)
+                .with(new ConceptMap(concepts))
                 .toDownstream(Mapping.of(mapping), null);
 
         Map<Identifier.Variable.Retrievable, Concept> expectedMapped = new HashMap<>();
@@ -104,7 +104,7 @@ public class AnswerStateTest {
         Map<Identifier.Variable.Retrievable, Concept> downstreamConcepts = new HashMap<>();
         downstreamConcepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         downstreamConcepts.put(Identifier.Variable.name("y"), new MockConcept(1));
-        Partial.Compound<?, ?> partial = mapped.toUpstreamLookup(new ConceptMap(downstreamConcepts), false, false);
+        Partial.Compound<?, ?> partial = mapped.toUpstreamLookup(new ConceptMap(downstreamConcepts), false);
 
         Map<Identifier.Variable.Retrievable, Concept> expectedWithInitial = new HashMap<>();
         expectedWithInitial.put(Identifier.Variable.name("a"), new MockConcept(0));

--- a/reasoner/resolution/framework/AnswerCache.java
+++ b/reasoner/resolution/framework/AnswerCache.java
@@ -47,7 +47,7 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
     protected final List<ANSWER> answers;
     private final Set<ANSWER> answersSet;
     private boolean reexploreOnNewAnswers;
-    private boolean requiresReiteration;
+    protected boolean requiresReiteration;
     protected FunctionalIterator<ANSWER> unexploredAnswers;
     protected boolean complete;
     protected final Map<SUBSUMES, ? extends AnswerCache<?, SUBSUMES>> cacheRegister;
@@ -85,10 +85,6 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
 
     public boolean isComplete() {
         return complete;
-    }
-
-    public void setRequiresReiteration() {
-        this.requiresReiteration = true;
     }
 
     public boolean requiresReiteration() {
@@ -234,7 +230,7 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
         private void completeFromSubsumer(AnswerCache<?, ANSWER> subsumingCache) {
             setCompletedAnswers(subsumingCache.answers());
             setComplete();
-            if (subsumingCache.requiresReiteration()) setRequiresReiteration();
+            if (subsumingCache.requiresReiteration()) this.requiresReiteration = true;
         }
 
         private void setCompletedAnswers(List<ANSWER> completeAnswers) {

--- a/reasoner/resolution/framework/ReiterationQuery.java
+++ b/reasoner/resolution/framework/ReiterationQuery.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.vaticle.typedb.core.reasoner.resolution.framework;
+
+import com.vaticle.typedb.core.concurrent.actor.Actor.Driver;
+import com.vaticle.typedb.core.reasoner.resolution.resolver.ConcludableResolver;
+
+import java.util.function.Consumer;
+
+public class ReiterationQuery {
+    public static class Request {
+        private final Driver<? extends Resolver<?>> rootResolver;
+        private final Consumer<Response> onResponse;
+
+        public Request(Driver<? extends Resolver<?>> rootResolver, Consumer<Response> onResponse) {
+            this.rootResolver = rootResolver;
+            this.onResponse = onResponse;
+        }
+
+        public static Request create(Driver<? extends Resolver<?>> rootResolver, Consumer<Response> onResponse) {
+            return new Request(rootResolver, onResponse);
+        }
+
+        public Driver<? extends Resolver<?>> sender() {
+            return rootResolver;
+        }
+
+        public Consumer<Response> onResponse() {
+            return onResponse;
+        }
+
+    }
+
+    public static class Response {
+
+        private final boolean reiterate;
+        private final Driver<ConcludableResolver> sender;
+
+        public Response(Driver<ConcludableResolver> sender, boolean reiterate) {
+            this.reiterate = reiterate;
+            this.sender = sender;
+        }
+
+        public static Response create(Driver<ConcludableResolver> driver, boolean reiterate) {
+            return new Response(driver, reiterate);
+        }
+
+        public Driver<ConcludableResolver> sender() {
+            return sender;
+        }
+
+        public boolean reiterate() {
+            return reiterate;
+        }
+    }
+}

--- a/reasoner/resolution/framework/ReiterationQuery.java
+++ b/reasoner/resolution/framework/ReiterationQuery.java
@@ -28,7 +28,7 @@ public class ReiterationQuery {
         private final Driver<? extends Resolver<?>> rootResolver;
         private final Consumer<Response> onResponse;
 
-        public Request(Driver<? extends Resolver<?>> rootResolver, Consumer<Response> onResponse) {
+        private Request(Driver<? extends Resolver<?>> rootResolver, Consumer<Response> onResponse) {
             this.rootResolver = rootResolver;
             this.onResponse = onResponse;
         }
@@ -52,7 +52,7 @@ public class ReiterationQuery {
         private final boolean reiterate;
         private final Driver<ConcludableResolver> sender;
 
-        public Response(Driver<ConcludableResolver> sender, boolean reiterate) {
+        private Response(Driver<ConcludableResolver> sender, boolean reiterate) {
             this.reiterate = reiterate;
             this.sender = sender;
         }

--- a/reasoner/resolution/framework/RequestState.java
+++ b/reasoner/resolution/framework/RequestState.java
@@ -57,7 +57,7 @@ public abstract class RequestState {
     }
 
     public interface Exploration {
-        void newAnswer(AnswerState.Partial<?> partial, boolean requiresReiteration);
+        void newAnswer(AnswerState.Partial<?> partial);
 
         DownstreamManager downstreamManager();
 

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -126,7 +126,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         } else {
             CachingRequestState<?, ConceptMap> requestState = this.requestStates.get(fromUpstream);
             assert requestState.isExploration();
-            requestState.asExploration().newAnswer(fromDownstream.answer(), fromDownstream.answer().requiresReiteration());
+            requestState.asExploration().newAnswer(fromDownstream.answer());
             assert iteration == requestState.iteration();
             assert cacheRegistersByRoot.get(root).containsKey(fromUpstream.partialAnswer().conceptMap());
             nextAnswer(fromUpstream, requestState, iteration);
@@ -332,7 +332,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         @Override
         protected FunctionalIterator<? extends Partial<?>> toUpstream(ConceptMap conceptMap) {
             return Iterators.single(fromUpstream.partialAnswer().asConcludable().asMatch().toUpstreamLookup(
-                    conceptMap, concludable.isInferredAnswer(conceptMap), answerCache.requiresReiteration()));
+                    conceptMap, concludable.isInferredAnswer(conceptMap)));
         }
 
     }
@@ -365,9 +365,8 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         }
 
         @Override
-        public void newAnswer(Partial<?> partial, boolean requiresReiteration) {
+        public void newAnswer(Partial<?> partial) {
             answerCache.add(partial.conceptMap());
-            if (requiresReiteration) answerCache.setRequiresReiteration();
         }
 
         @Override
@@ -378,7 +377,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         @Override
         protected FunctionalIterator<? extends Partial<?>> toUpstream(ConceptMap conceptMap) {
             return Iterators.single(fromUpstream.partialAnswer().asConcludable().asMatch().toUpstreamLookup(
-                    conceptMap, concludable.isInferredAnswer(conceptMap), answerCache.requiresReiteration()));
+                    conceptMap, concludable.isInferredAnswer(conceptMap)));
         }
     }
 
@@ -391,7 +390,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
 
         @Override
         protected FunctionalIterator<? extends Partial<?>> toUpstream(Partial.Concludable<?> partial) {
-            return Iterators.single(partial.asExplain().toUpstreamInferred(answerCache.requiresReiteration()));
+            return Iterators.single(partial.asExplain().toUpstreamInferred());
         }
     }
 
@@ -421,9 +420,8 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         }
 
         @Override
-        public void newAnswer(Partial<?> partial, boolean requiresReiteration) {
+        public void newAnswer(Partial<?> partial) {
             answerCache.add(partial.asConcludable());
-            if (requiresReiteration) answerCache.setRequiresReiteration();
         }
 
         @Override
@@ -433,7 +431,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
 
         @Override
         protected FunctionalIterator<? extends Partial<?>> toUpstream(Partial.Concludable<?> partial) {
-            return Iterators.single(partial.asExplain().toUpstreamInferred(answerCache.requiresReiteration()));
+            return Iterators.single(partial.asExplain().toUpstreamInferred());
         }
 
     }

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -172,8 +172,9 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
     }
 
     public void receiveReiterationQuery(ReiterationQuery.Request request) {
-        boolean reiterate = iterate(cacheRegistersByRoot.get(request.sender()).values())
-                .filter(AnswerCache::requiresReiteration).first().isPresent();
+        boolean reiterate = cacheRegistersByRoot.containsKey(request.sender()) &&
+                iterate(cacheRegistersByRoot.get(request.sender()).values())
+                    .filter(AnswerCache::requiresReiteration).first().isPresent();
         driver().execute(actor -> actor.respondToReiterationQuery(request, reiterate));
     }
 

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -174,7 +174,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
     public void receiveReiterationQuery(ReiterationQuery.Request request) {
         boolean reiterate = iterate(cacheRegistersByRoot.get(request.sender()).values())
                 .filter(AnswerCache::requiresReiteration).first().isPresent();
-        respondToReiterationQuery(request, reiterate);
+        driver().execute(actor -> actor.respondToReiterationQuery(request, reiterate));
     }
 
     private void respondToReiterationQuery(ReiterationQuery.Request request, boolean reiterate) {

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -32,6 +32,7 @@ import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState.Partial;
 import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache;
 import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache.ConcludableAnswerCache;
 import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache.SubsumptionAnswerCache.ConceptMapCache;
+import com.vaticle.typedb.core.reasoner.resolution.framework.ReiterationQuery;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Request;
 import com.vaticle.typedb.core.reasoner.resolution.framework.RequestState.CachingRequestState;
 import com.vaticle.typedb.core.reasoner.resolution.framework.RequestState.Exploration;
@@ -168,6 +169,16 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
             }
             nextAnswer(fromUpstream, requestState, iteration);
         }
+    }
+
+    public void receiveReiterationQuery(ReiterationQuery.Request request) {
+        boolean reiterate = iterate(cacheRegistersByRoot.get(request.sender()).values())
+                .filter(AnswerCache::requiresReiteration).first().isPresent();
+        respondToReiterationQuery(request, reiterate);
+    }
+
+    private void respondToReiterationQuery(ReiterationQuery.Request request, boolean reiterate) {
+        request.onResponse().accept(ReiterationQuery.Response.create(driver(), reiterate));
     }
 
     @Override

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -152,7 +152,7 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
         @Override
         protected FunctionalIterator<? extends Partial<?>> toUpstream(ConceptMap answer) {
             return Iterators.single(fromUpstream.partialAnswer().asRetrievable()
-                                            .aggregateToUpstream(answer, answerCache.requiresReiteration()));
+                                            .aggregateToUpstream(answer));
         }
     }
 }

--- a/reasoner/resolution/resolver/RootResolver.java
+++ b/reasoner/resolution/resolver/RootResolver.java
@@ -154,8 +154,8 @@ public interface RootResolver<TOP extends Top> {
 
         public Disjunction(Driver<Disjunction> driver, com.vaticle.typedb.core.pattern.Disjunction disjunction,
                            Consumer<Finished> onAnswer, Consumer<Integer> onFail, Consumer<Throwable> onException,
-                           ResolverRegistry registry,
-                           TraversalEngine traversalEngine, ConceptManager conceptMgr, boolean resolutionTracing) {
+                           ResolverRegistry registry, TraversalEngine traversalEngine, ConceptManager conceptMgr,
+                           boolean resolutionTracing) {
             super(driver, Disjunction.class.getSimpleName() + "(pattern:" + disjunction + ")", disjunction,
                   registry, traversalEngine, conceptMgr, resolutionTracing);
             this.onAnswer = onAnswer;

--- a/test/integration/reasoner/resolution/ReiterationTest.java
+++ b/test/integration/reasoner/resolution/ReiterationTest.java
@@ -130,7 +130,10 @@ public class ReiterationTest {
 
                 ResolutionTracer.get().start();
                 Actor.Driver<RootResolver.Conjunction> root = registry.root(conjunction, answer -> {
-                    //if (answer.requiresReiteration()) receivedInferredAnswer[0] = true;
+                    if (iterate(answer.conceptMap().concepts().entrySet())
+                            .map(e -> e.getValue().asThing().isInferred()).first().isPresent()) {
+                        receivedInferredAnswer[0] = true;
+                    }
                     responses.add(answer);
                 }, iterDone -> {
                     assert iteration[0] == iterDone;

--- a/test/integration/reasoner/resolution/ReiterationTest.java
+++ b/test/integration/reasoner/resolution/ReiterationTest.java
@@ -130,7 +130,7 @@ public class ReiterationTest {
 
                 ResolutionTracer.get().start();
                 Actor.Driver<RootResolver.Conjunction> root = registry.root(conjunction, answer -> {
-                    if (answer.requiresReiteration()) receivedInferredAnswer[0] = true;
+                    //if (answer.requiresReiteration()) receivedInferredAnswer[0] = true;
                     responses.add(answer);
                 }, iterDone -> {
                     assert iteration[0] == iterDone;


### PR DESCRIPTION
## What is the goal of this PR?

Within the message-passing framework of the reasoner, answers would carry a flag to indicate whether an additional outer iteration is necessary to find all answers. It was possible that the answers needed to carry this flag could be not present or swallowed, and so the answer produced would not reiterate. In recursive cases in particular this caused missed answers. We solve this by introducing request and response messages specifically to communicate whether reiteration is required.

## What are the changes implemented in this PR?

- Upon receiving a failed response, the ReasonerProducer asks all ConcludableResolvbles whether reiteration is required for the given RootResolver. It waits to receive a response from all of them before proceeding with reiteration or terminating.
- Adds ReiterationQuery Request and Response types
- Strips out `requiresReiteration` flags from `AnswerState`, since these are now redundant.