### PR TITLE
Fix TypeDB formula name for Homebrew

### DIFF
--- a/config/brew/typedb.rb
+++ b/config/brew/typedb.rb
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-class TypeDB < Formula
+class Typedb < Formula
   desc "TypeDB: a strongly-typed database"
   homepage "https://vaticle.com"
   url "https://github.com/vaticle/typedb/releases/download/{version}/typedb-all-mac-{version}.zip"


### PR DESCRIPTION
## What is the goal of this PR?

Allow TypeDB to be installed via Homebrew through renaming the formula to adhere to Homebrew expectation.

## What are the changes implemented in this PR?

Fix #6335

Rename formula class to what Homebrew expects it to be (`Typedb`) and therefore make package installable again.
