### PR TITLE
Unifiers include type requirements for all variables

### DIFF
--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -360,7 +360,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
                 } else {
                     unifierBuilder.addVariableType(relVar.isa().get().type(), unifiedRelVar.isa().get().type().id());
                 }
-            } else return Iterators.empty();
+            }
 
             List<RolePlayer> conjRolePlayers = list(relation().players());
             Set<RolePlayer> thenRolePlayers = relationConclusion.relation().players();

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -398,7 +398,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
                         Set<Label> allowedTypes = iterate(conjRoleType.resolvedTypes())
                                 .flatMap(roleLabel -> subtypeLabels(roleLabel, conceptMgr))
                                 .toSet();
-                        unifierBuilder.addLabelType(conjRoleType.id().asLabel(), allowedTypes, conjRoleType.id());
+                        unifierBuilder.addLabelType(conjRoleType.id().asLabel(), allowedTypes, thenRoleType.id());
                     } else {
                         unifierBuilder.addVariableType(conjRoleType, thenRoleType.id());
                     }
@@ -539,10 +539,11 @@ public abstract class Concludable extends Resolvable<Conjunction> {
             ThingVariable conclusionAttr = hasConclusion.has().attribute();
             if (unificationSatisfiable(attr, conclusionAttr)) {
                 unifierBuilder.addThing(attr, conclusionAttr.id());
-                if (attr.reference().isName() && attr.isa().isPresent() && attr.isa().get().type().label().isPresent()) {
-                    Set<Label> allowedTypes = subtypeLabels(attr.isa().get().type().label().get().properLabel(), conceptMgr).toSet();
+                if (attr.isa().isPresent() && attr.isa().get().type().label().isPresent()) {
+                    // $x has [type] $a/"John"
                     assert attr.isa().isPresent() && attr.isa().get().type().label().isPresent() &&
-                            allowedTypes.containsAll(unifierBuilder.requirements().isaExplicit().get(attr.id()));
+                            subtypeLabels(attr.isa().get().type().label().get().properLabel(), conceptMgr).toSet()
+                                    .containsAll(unifierBuilder.requirements().isaExplicit().get(attr.id()));
                 }
                 addConstantValueRequirements(unifierBuilder, values, attr.id(), conclusionAttr.id());
             } else return Iterators.empty();

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -335,41 +335,38 @@ public abstract class Concludable extends Resolvable<Conjunction> {
             return conceptMap.get(generating().get().id()).asThing().isInferred();
         }
 
+        @Override
+        public Optional<ThingVariable> generating() {
+            return Optional.of(relation.owner());
+        }
+
         public FunctionalIterator<Unifier> unify(Rule.Conclusion.Relation relationConclusion, ConceptManager conceptMgr) {
             if (relation().players().size() > relationConclusion.relation().players().size()) return Iterators.empty();
 
             Unifier.Builder unifierBuilder = Unifier.builder();
-            if (unificationSatisfiable(relation().owner(), relationConclusion.relation().owner())) {
-                unifierBuilder.add(relation().owner().id(), relationConclusion.relation().owner().id());
+            ThingVariable relVar = relation().owner();
+            ThingVariable unifiedRelVar = relationConclusion.relation().owner();
+            if (unificationSatisfiable(relVar, unifiedRelVar)) {
+                unifierBuilder.addThing(relVar, unifiedRelVar.id());
             } else return Iterators.empty();
 
-            if (relation().owner().isa().isPresent()) {
-                TypeVariable concludableRelationType = relation().owner().isa().get().type();
-                TypeVariable conclusionRelationType = relationConclusion.relation().owner().isa().get().type();
-                if (unificationSatisfiable(concludableRelationType, conclusionRelationType, conceptMgr)) {
-
-                    if (concludableRelationType.reference().isLabel()) {
-                        // require the unification target type variable satisfies a set of labels
-                        Set<Label> allowedTypes = iterate(concludableRelationType.resolvedTypes())
-                                .flatMap(label -> subtypeLabels(label, conceptMgr)).toSet();
-                        unifierBuilder.unifiedRequirements().isaExplicit(relationConclusion.relation().owner().id(), allowedTypes);
-                        unifierBuilder.requirements().isaExplicit(relation().owner().id(), allowedTypes);
-                    } else {
-                        unifierBuilder.add(concludableRelationType.id().asRetrievable(), conclusionRelationType.id());
-                    }
-                } else return Iterators.empty();
-            }
+            if (relVar.isa().isPresent()) {
+                if (relVar.isa().get().type().id().isLabel()) {
+                    // require the unification target type variable satisfies a set of labels
+                    Set<Label> allowedTypes = iterate(relVar.isa().get().type().resolvedTypes()).flatMap(label -> subtypeLabels(label, conceptMgr)).toSet();
+                    assert allowedTypes.containsAll(relVar.resolvedTypes())
+                            && unificationSatisfiable(relVar.isa().get().type(), unifiedRelVar.isa().get().type(), conceptMgr);
+                    unifierBuilder.addLabelType(relVar.isa().get().type().id().asLabel(), allowedTypes, unifiedRelVar.isa().get().type().id());
+                } else {
+                    unifierBuilder.addVariableType(relVar.isa().get().type(), unifiedRelVar.isa().get().type().id());
+                }
+            } else return Iterators.empty();
 
             List<RolePlayer> conjRolePlayers = list(relation().players());
             Set<RolePlayer> thenRolePlayers = relationConclusion.relation().players();
 
             return matchRolePlayers(conjRolePlayers, thenRolePlayers, new HashMap<>(), conceptMgr)
                     .map(mapping -> convertRPMappingToUnifier(mapping, unifierBuilder.clone(), conceptMgr));
-        }
-
-        @Override
-        public Optional<ThingVariable> generating() {
-            return Optional.of(relation.owner());
         }
 
         private FunctionalIterator<Map<RolePlayer, Set<RolePlayer>>> matchRolePlayers(
@@ -389,22 +386,21 @@ public abstract class Concludable extends Resolvable<Conjunction> {
                                                               thenRolePlayers, newMapping, conceptMgr));
         }
 
-        private Unifier convertRPMappingToUnifier(
-                Map<RolePlayer, Set<RolePlayer>> mapping, Unifier.Builder unifierBuilder, ConceptManager conceptMgr) {
+        private Unifier convertRPMappingToUnifier(Map<RolePlayer, Set<RolePlayer>> mapping,
+                                                  Unifier.Builder unifierBuilder, ConceptManager conceptMgr) {
             mapping.forEach((conjRP, thenRPs) -> thenRPs.forEach(thenRP -> {
-                unifierBuilder.add(conjRP.player().id(), thenRP.player().id());
+                unifierBuilder.addThing(conjRP.player(), thenRP.player().id());
                 if (conjRP.roleType().isPresent()) {
                     assert thenRP.roleType().isPresent();
                     TypeVariable conjRoleType = conjRP.roleType().get();
                     TypeVariable thenRoleType = thenRP.roleType().get();
-                    if (conjRoleType.reference().isLabel()) {
+                    if (conjRoleType.id().isLabel()) {
                         Set<Label> allowedTypes = iterate(conjRoleType.resolvedTypes())
                                 .flatMap(roleLabel -> subtypeLabels(roleLabel, conceptMgr))
                                 .toSet();
-                        unifierBuilder.unifiedRequirements().roleTypes(thenRoleType.id(), allowedTypes);
-                        unifierBuilder.requirements().roleTypes(conjRoleType.id(), allowedTypes);
+                        unifierBuilder.addLabelType(conjRoleType.id().asLabel(), allowedTypes, conjRoleType.id());
                     } else {
-                        unifierBuilder.add(conjRoleType.id().asRetrievable(), thenRoleType.id());
+                        unifierBuilder.addVariableType(conjRoleType, thenRoleType.id());
                     }
                 }
             }));
@@ -533,27 +529,20 @@ public abstract class Concludable extends Resolvable<Conjunction> {
 
         public FunctionalIterator<Unifier> unify(Rule.Conclusion.Has hasConclusion, ConceptManager conceptMgr) {
             Unifier.Builder unifierBuilder = Unifier.builder();
-            if (unificationSatisfiable(has().owner(), hasConclusion.has().owner())) {
-                unifierBuilder.add(has().owner().id(), hasConclusion.has().owner().id());
+            ThingVariable owner = has().owner();
+            ThingVariable unifiedOwner = hasConclusion.has().owner();
+            if (unificationSatisfiable(owner, unifiedOwner)) {
+                unifierBuilder.addThing(owner, unifiedOwner.id());
             } else return Iterators.empty();
 
             ThingVariable attr = has().attribute();
             ThingVariable conclusionAttr = hasConclusion.has().attribute();
             if (unificationSatisfiable(attr, conclusionAttr)) {
-                unifierBuilder.add(attr.id(), conclusionAttr.id());
-                if (attr.reference().isAnonymous()) {
-                    // form: $x has age 10 -> require ISA age and PREDICATE =10
-                    assert attr.isa().isPresent() && attr.isa().get().type().label().isPresent();
-                    Label attrLabel = attr.isa().get().type().label().get().properLabel();
-                    Set<Label> labels = subtypeLabels(attrLabel, conceptMgr).toSet();
-                    unifierBuilder.unifiedRequirements().isaExplicit(conclusionAttr.id(), labels);
-                    unifierBuilder.requirements().isaExplicit(attr.id(), labels);
-                } else if (attr.reference().isName() && attr.isa().isPresent() && attr.isa().get().type().label().isPresent()) {
-                    // form: $x has age $a (may also handle $x has $a; $a isa age)   -> require ISA age
-                    Label attrLabel = attr.isa().get().type().label().get().properLabel();
-                    Set<Label> labels = subtypeLabels(attrLabel, conceptMgr).toSet();
-                    unifierBuilder.unifiedRequirements().isaExplicit(conclusionAttr.id(), labels);
-                    unifierBuilder.requirements().isaExplicit(attr.id(), labels);
+                unifierBuilder.addThing(attr, conclusionAttr.id());
+                if (attr.reference().isName() && attr.isa().isPresent() && attr.isa().get().type().label().isPresent()) {
+                    Set<Label> allowedTypes = subtypeLabels(attr.isa().get().type().label().get().properLabel(), conceptMgr).toSet();
+                    assert attr.isa().isPresent() && attr.isa().get().type().label().isPresent() &&
+                            allowedTypes.containsAll(unifierBuilder.requirements().isaExplicit().get(attr.id()));
                 }
                 addConstantValueRequirements(unifierBuilder, values, attr.id(), conclusionAttr.id());
             } else return Iterators.empty();
@@ -652,21 +641,24 @@ public abstract class Concludable extends Resolvable<Conjunction> {
 
         FunctionalIterator<Unifier> unify(Rule.Conclusion.Isa isa, ConceptManager conceptMgr) {
             Unifier.Builder unifierBuilder = Unifier.builder();
-            if (unificationSatisfiable(isa().owner(), isa.isa().owner())) {
-                unifierBuilder.add(isa().owner().id(), isa.isa().owner().id());
+            ThingVariable owner = isa().owner();
+            ThingVariable unifiedOwner = isa.isa().owner();
+            if (unificationSatisfiable(owner, unifiedOwner)) {
+                unifierBuilder.addThing(owner, unifiedOwner.id());
             } else return Iterators.empty();
 
             TypeVariable type = isa().type();
-            if (unificationSatisfiable(type, isa.isa().type(), conceptMgr)) {
-                if (type.reference().isLabel()) {
+            TypeVariable unifiedType = isa.isa().type();
+            if (unificationSatisfiable(type, unifiedType, conceptMgr)) {
+                if (type.id().isLabel()) {
                     // form: $r isa friendship -> require type subs(friendship) for anonymous type variable
-                    Set<Label> subtypes = subtypeLabels(type.resolvedTypes(), conceptMgr).toSet();
-                    unifierBuilder.unifiedRequirements().isaExplicit(isa.isa().owner().id(), subtypes);
-                    unifierBuilder.requirements().isaExplicit(isa().owner().id(), subtypes);
+                    Set<Label> allowedTypes = subtypeLabels(type.resolvedTypes(), conceptMgr).toSet();
+                    assert allowedTypes.containsAll(unifierBuilder.requirements().isaExplicit().get(owner.id()));
+                    unifierBuilder.addLabelType(type.id().asLabel(), allowedTypes, unifiedType.id());
                 } else {
-                    unifierBuilder.add(type.id().asRetrievable(), isa.isa().type().id());
+                    unifierBuilder.addVariableType(type, unifiedType.id());
                 }
-                addConstantValueRequirements(unifierBuilder, values, isa().owner().id(), isa.isa().owner().id());
+                addConstantValueRequirements(unifierBuilder, values, owner.id(), unifiedOwner.id());
             } else return Iterators.empty();
 
             return single(unifierBuilder.build());
@@ -772,7 +764,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
             assert iterate(values).filter(ValueConstraint::isVariable).toSet().size() == 0;
             Unifier.Builder unifierBuilder = Unifier.builder();
             if (unificationSatisfiable(attribute, value.value().owner())) {
-                unifierBuilder.add(attribute.id(), value.value().owner().id());
+                unifierBuilder.addThing(attribute, value.value().owner().id());
             } else return Iterators.empty();
             addConstantValueRequirements(unifierBuilder, values, attribute.id(), value.value().owner().id());
             return single(unifierBuilder.build());

--- a/logic/resolvable/Unifier.java
+++ b/logic/resolvable/Unifier.java
@@ -327,8 +327,14 @@ public class Unifier {
             }
 
             public void isaExplicit(Retrievable id, Set<Label> labels) {
-                assert (!isaExplicit.containsKey(id) || isaExplicit.get(id).equals(labels));
-                isaExplicit.put(id, set(labels));
+                if (isaExplicit.containsKey(id)) {
+                    isaExplicit.compute(id, (i, existingLabels) -> {
+                        existingLabels.retainAll(labels);
+                        return existingLabels;
+                    });
+                } else {
+                    isaExplicit.put(id, new HashSet<>(labels));
+                }
             }
 
             public void predicates(Retrievable id, Function<Attribute, Boolean> predicateFn) {

--- a/logic/resolvable/Unifier.java
+++ b/logic/resolvable/Unifier.java
@@ -213,7 +213,6 @@ public class Unifier {
             unifiedRequirements.types(target, allowedTypes);
         }
 
-
         public Requirements.Constraint requirements() {
             return requirements;
         }
@@ -321,12 +320,12 @@ public class Unifier {
                 }
             }
 
-            public void types(Variable id, Set<Label> labels) {
+            private void types(Variable id, Set<Label> labels) {
                 assert !types.containsKey(id) || types.get(id).equals(labels);
                 types.put(id, set(labels));
             }
 
-            public void isaExplicit(Retrievable id, Set<Label> labels) {
+            private void isaExplicit(Retrievable id, Set<Label> labels) {
                 if (isaExplicit.containsKey(id)) {
                     isaExplicit.compute(id, (i, existingLabels) -> {
                         existingLabels.retainAll(labels);

--- a/reasoner/resolution/framework/RequestState.java
+++ b/reasoner/resolution/framework/RequestState.java
@@ -57,11 +57,13 @@ public abstract class RequestState {
     }
 
     public interface Exploration {
+
         void newAnswer(AnswerState.Partial<?> partial);
 
         DownstreamManager downstreamManager();
 
         boolean singleAnswerRequired();
+
     }
 
     public abstract static class CachingRequestState<ANSWER, SUBSUMES> extends RequestState {

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -365,7 +365,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
 
         @Override
         public void newAnswer(Partial<?> partial) {
-            answerCache.add(partial.conceptMap());
+            if (!answerCache.isComplete()) answerCache.add(partial.conceptMap());
         }
 
         @Override
@@ -420,7 +420,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
 
         @Override
         public void newAnswer(Partial<?> partial) {
-            answerCache.add(partial.asConcludable());
+            if (!answerCache.isComplete()) answerCache.add(partial.asConcludable());
         }
 
         @Override

--- a/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
@@ -139,7 +139,7 @@ public class UnifyAttributeConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(0, unifier.requirements().isaExplicit().size());
         assertEquals(1, unifier.requirements().predicates().size());
 
@@ -185,7 +185,7 @@ public class UnifyAttributeConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(0, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
 

--- a/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
@@ -140,7 +140,7 @@ public class UnifyAttributeConcludableTest {
 
         // test requirements
         assertEquals(0, unifier.requirements().types().size());
-        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(1, unifier.requirements().predicates().size());
 
         // test forward unification can reject an invalid partial answer
@@ -186,7 +186,7 @@ public class UnifyAttributeConcludableTest {
 
         // test requirements
         assertEquals(0, unifier.requirements().types().size());
-        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
 
         Rule rule2 = createRule("isa-rule-2", "{ " + var + " isa person; }", "(employee: " + var + ") isa employment", logicMgr);

--- a/test/integration/logic/resolvable/UnifyHasConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyHasConcludableTest.java
@@ -160,7 +160,7 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.anon(0)));
         assertEquals(1, unifier.requirements().predicates().size());
@@ -214,7 +214,7 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.anon(0)));
         assertEquals(1, unifier.requirements().predicates().size());
@@ -280,7 +280,7 @@ public class UnifyHasConcludableTest {
         assertEquals(2, unified.next().concepts().size());
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(0, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
     }
@@ -313,7 +313,7 @@ public class UnifyHasConcludableTest {
         assertEquals(2, unified.next().concepts().size());
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(0, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
     }
@@ -337,7 +337,7 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("b")));
         assertEquals(0, unifier.requirements().predicates().size());
@@ -383,7 +383,7 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("b")));
         assertEquals(0, unifier.requirements().predicates().size());
@@ -425,7 +425,7 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
     }
@@ -482,7 +482,7 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(set(Label.of("self-owning-attribute")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("b")));
         assertEquals(0, unifier.requirements().predicates().size());

--- a/test/integration/logic/resolvable/UnifyHasConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyHasConcludableTest.java
@@ -161,8 +161,8 @@ public class UnifyHasConcludableTest {
 
         // test requirements
         assertEquals(0, unifier.requirements().types().size());
-        assertEquals(1, unifier.requirements().isaExplicit().size());
-        assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.anon(0)));
+        assertEquals(2, unifier.requirements().isaExplicit().size());
+        assertEquals(set(Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.anon(0)));
         assertEquals(1, unifier.requirements().predicates().size());
 
         // test forward unification can reject an invalid partial answer
@@ -215,8 +215,8 @@ public class UnifyHasConcludableTest {
 
         // test requirements
         assertEquals(0, unifier.requirements().types().size());
-        assertEquals(1, unifier.requirements().isaExplicit().size());
-        assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.anon(0)));
+        assertEquals(2, unifier.requirements().isaExplicit().size());
+        assertEquals(set(Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.anon(0)));
         assertEquals(1, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
@@ -281,7 +281,7 @@ public class UnifyHasConcludableTest {
 
         // test requirements
         assertEquals(0, unifier.requirements().types().size());
-        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(2, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
     }
 
@@ -314,7 +314,7 @@ public class UnifyHasConcludableTest {
 
         // test requirements
         assertEquals(0, unifier.requirements().types().size());
-        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(2, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
     }
 
@@ -338,8 +338,8 @@ public class UnifyHasConcludableTest {
 
         // test requirements
         assertEquals(0, unifier.requirements().types().size());
-        assertEquals(1, unifier.requirements().isaExplicit().size());
-        assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("b")));
+        assertEquals(2, unifier.requirements().isaExplicit().size());
+        assertEquals(set(Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("b")));
         assertEquals(0, unifier.requirements().predicates().size());
 
         // test forward unification can reject an invalid partial answer
@@ -384,8 +384,8 @@ public class UnifyHasConcludableTest {
 
         // test requirements
         assertEquals(0, unifier.requirements().types().size());
-        assertEquals(1, unifier.requirements().isaExplicit().size());
-        assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("b")));
+        assertEquals(2, unifier.requirements().isaExplicit().size());
+        assertEquals(set(Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("b")));
         assertEquals(0, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
@@ -426,7 +426,7 @@ public class UnifyHasConcludableTest {
 
         // test requirements
         assertEquals(0, unifier.requirements().types().size());
-        assertEquals(1, unifier.requirements().isaExplicit().size());
+        assertEquals(2, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
     }
 

--- a/test/integration/logic/resolvable/UnifyIsaConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyIsaConcludableTest.java
@@ -158,7 +158,7 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(0, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
     }
@@ -183,7 +183,7 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(0, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
     }
@@ -209,7 +209,7 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(0, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
     }
@@ -259,7 +259,7 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")),
                      unifier.requirements().isaExplicit().values().iterator().next());
@@ -301,7 +301,7 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(set(Label.of("relation"), Label.of("employment")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("a")));
         assertEquals(0, unifier.requirements().predicates().size());
@@ -344,7 +344,7 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(set(Label.of("relation"), Label.of("employment")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("a")));
         assertEquals(0, unifier.requirements().predicates().size());
@@ -420,7 +420,7 @@ public class UnifyIsaConcludableTest {
         Unifier unifier = unifiers.get(0);
 
         // test requirements
-        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().types().size());
         assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(3, unifier.requirements().predicates().size());
 

--- a/test/integration/logic/resolvable/UnifyIsaConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyIsaConcludableTest.java
@@ -158,8 +158,8 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().types().size());
-        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(1, unifier.requirements().types().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
     }
 
@@ -183,8 +183,8 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().types().size());
-        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(1, unifier.requirements().types().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
     }
 
@@ -209,8 +209,8 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().types().size());
-        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(1, unifier.requirements().types().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
     }
 
@@ -259,9 +259,9 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().types().size());
+        assertEquals(1, unifier.requirements().types().size());
         assertEquals(1, unifier.requirements().isaExplicit().size());
-        assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")),
+        assertEquals(set(Label.of("first-name"), Label.of("last-name")),
                      unifier.requirements().isaExplicit().values().iterator().next());
         assertEquals(0, unifier.requirements().predicates().size());
 
@@ -301,9 +301,9 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().types().size());
+        assertEquals(1, unifier.requirements().types().size());
         assertEquals(1, unifier.requirements().isaExplicit().size());
-        assertEquals(set(Label.of("relation"), Label.of("employment")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("a")));
+        assertEquals(set(Label.of("employment")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("a")));
         assertEquals(0, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
@@ -344,9 +344,9 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.requirements().types().size());
+        assertEquals(1, unifier.requirements().types().size());
         assertEquals(1, unifier.requirements().isaExplicit().size());
-        assertEquals(set(Label.of("relation"), Label.of("employment")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("a")));
+        assertEquals(set(Label.of("employment")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("a")));
         assertEquals(0, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -93,31 +93,31 @@ public class UnifyRelationConcludableTest {
         typedb = RocksTypeDB.open(options);
         typedb.databases().create(database);
 
-        try(RocksSession schemaSession = typedb.session(database, Arguments.Session.Type.SCHEMA)) {
+        try (RocksSession schemaSession = typedb.session(database, Arguments.Session.Type.SCHEMA)) {
             try (RocksTransaction tx = schemaSession.transaction(Arguments.Transaction.Type.WRITE)) {
                 tx.query().define(TypeQL.parseQuery(
                         "define\n" +
-                                                        "person sub entity,\n" +
-                                                        "    owns first-name,\n" +
-                                                        "    owns last-name,\n" +
-                                                        "    owns age,\n" +
-                                                        "    plays employment:employee,\n" +
-                                                        "    plays employment:employer,\n" +
-                                "   plays employment:employee-recommender,\n" +
-                                "   plays friendship:friend;\n" +
+                                "person sub entity,\n" +
+                                "  owns first-name,\n" +
+                                "  owns last-name,\n" +
+                                "  owns age,\n" +
+                                "  plays employment:employee,\n" +
+                                "  plays employment:employer,\n" +
+                                "  plays employment:employee-recommender,\n" +
+                                "  plays friendship:friend;\n" +
                                 "\n" +
                                 "restricted-entity sub entity,\n" +
-                                "   plays part-time-employment:restriction;\n" +
+                                "  plays part-time-employment:restriction;\n" +
                                 "student sub person,\n" +
-                                                        "    plays part-time-employment:part-time-employee,\n" +
-                                                        "    plays part-time-employment:part-time-employer,\n" +
-                                "   plays part-time-employment:part-time-employee-recommender;\n" +
+                                "  plays part-time-employment:part-time-employee,\n" +
+                                "  plays part-time-employment:part-time-employer,\n" +
+                                "  plays part-time-employment:part-time-employee-recommender;\n" +
                                 "\n" +
                                 "student-driver sub student,\n" +
-                                "   plays part-time-driving:night-shift-driver,\n" +
-                                                        "plays part-time-driving:day-shift-driver;\n" +
+                                "  plays part-time-driving:night-shift-driver,\n" +
+                                "  plays part-time-driving:day-shift-driver;\n" +
                                 "organisation sub entity,\n" +
-                                                        "    plays employment:employer,\n" +
+                                "  plays employment:employer,\n" +
                                 "  plays employment:employee,\n" +
                                 "  plays employment:employee-recommender;\n" +
                                 "part-time-organisation sub organisation,\n" +
@@ -129,35 +129,34 @@ public class UnifyRelationConcludableTest {
                                 "  plays part-time-driving:night-shift-driver,\n" +
                                 "  plays part-time-driving:day-shift-driver;\n" +
                                 "\n" +
-                                                        "employment sub relation,\n" +
+                                "employment sub relation,\n" +
                                 "  relates employer,\n" +
-                                                        "    relates employee,\n" +
-                                                        "    relates contractor,\n" +
+                                "  relates employee,\n" +
+                                "  relates contractor,\n" +
                                 "  relates employee-recommender;\n" +
                                 "\n" +
-                                                        "part-time-employment sub employment,\n" +
+                                "part-time-employment sub employment,\n" +
                                 "  relates part-time-employer as employer,\n" +
                                 "  relates part-time-employee as employee,\n" +
-                                                        "    relates part-time-employee-recommender as employee-recommender,\n" +
-                                                        "    relates restriction;\n" +
-                                                        "\n " +
-                                                        "    part-time-driving sub part-time-employment,\n" +
+                                "  relates part-time-employee-recommender as employee-recommender,\n" +
+                                "  relates restriction;\n" +
+                                "\n " +
+                                "part-time-driving sub part-time-employment,\n" +
                                 "  relates night-shift-driver as part-time-employee,\n" +
                                 "  relates day-shift-driver as part-time-employee,\n" +
                                 "  relates taxi as part-time-employer;\n" +
-                                "\n" +
-                                                        "friendship sub relation,\n" +
-                                                        "    relates friend;\n" +
-                                                        "name sub attribute, value string, abstract;\n" +
-                                                        "first-name sub name;\n" +
-                                                        "last-name sub name;\n" +
-                                                        "age sub attribute, value long;"
-                                                        ).asDefine());
+                                "friendship sub relation,\n" +
+                                "    relates friend;\n" +
+                                "name sub attribute, value string, abstract;\n" +
+                                "first-name sub name;\n" +
+                                "last-name sub name;\n" +
+                                "age sub attribute, value long;"
+                ).asDefine());
                 tx.commit();
             }
         }
 
-        try(RocksSession dataSession = typedb.session(database, Arguments.Session.Type.DATA)){
+        try (RocksSession dataSession = typedb.session(database, Arguments.Session.Type.DATA)) {
             try (RocksTransaction tx = dataSession.transaction(Arguments.Transaction.Type.WRITE)) {
                 tx.query().insert(TypeQL.parseQuery(
                         "insert " +
@@ -168,7 +167,7 @@ public class UnifyRelationConcludableTest {
                                 "$x isa driving-hire;" +
                                 "$y isa driving-hire;" +
                                 "$z isa driving-hire;"
-                        ).asInsert()
+                                  ).asInsert()
                 );
                 tx.commit();
             }
@@ -207,19 +206,19 @@ public class UnifyRelationConcludableTest {
         throw TypeDBException.of(ILLEGAL_STATE);
     }
 
-    private Set<Label> typeHierarchy(String type){
+    private Set<Label> typeHierarchy(String type) {
         return conceptMgr.getThingType(type).getSubtypes()
                 .map(Type::getLabel).toSet();
     }
 
-    private RoleType role(String roleType, String typeScope){
+    private RoleType role(String roleType, String typeScope) {
         return conceptMgr.getRelationType(typeScope)
                 .getRelates()
                 .filter(r -> r.getLabel().name().equals(roleType))
                 .first().orElse(null);
     }
 
-    private Set<Label> roleHierarchy(String roleType, String typeScope){
+    private Set<Label> roleHierarchy(String roleType, String typeScope) {
         return role(roleType, typeScope)
                 .getSubtypes()
                 .map(Type::getLabel)
@@ -239,7 +238,7 @@ public class UnifyRelationConcludableTest {
                 "{ $r (employee: $y) isa employment; }",
                 rule(
                         " (employee: $x) isa employment",
-                "{ $x isa person; }")
+                        "{ $x isa person; }")
         );
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
@@ -255,8 +254,8 @@ public class UnifyRelationConcludableTest {
         assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(
                 roleHierarchy("employee", "employment"),
-                unifier.requirements().roleTypes().get(Variable.label("employment:employee")));
-        assertEquals(1, unifier.requirements().roleTypes().size());
+                unifier.requirements().types().get(Variable.label("employment:employee")));
+        assertEquals(1, unifier.requirements().types().size());
         assertEquals(0, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
@@ -292,12 +291,22 @@ public class UnifyRelationConcludableTest {
     }
 
     @Test
+    public void relation_and_incompatible_player_does_not_unify() {
+        Unifier unifier = uniqueUnifier(
+                "{ $r (employer: $y) isa employment; $y isa organisation; }",
+                rule(
+                        "(employer: $x) isa employment",
+                        "{ $x isa person; }")
+        );
+    }
+
+    @Test
     public void relation_type_and_player_unifies_rule_relation_exact() {
         Unifier unifier = uniqueUnifier(
                 "{ (employee: $y) isa $rel; }",
                 rule(
                         "(employee: $x) isa employment",
-                "{ $x isa person; }")
+                        "{ $x isa person; }")
         );
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
@@ -310,8 +319,8 @@ public class UnifyRelationConcludableTest {
         // test requirements
         assertEquals(
                 roleHierarchy("employee", "employment"),
-                unifier.requirements().roleTypes().get(Variable.label("relation:employee")));
-        assertEquals(1, unifier.requirements().roleTypes().size());
+                unifier.requirements().types().get(Variable.label("relation:employee")));
+        assertEquals(1, unifier.requirements().types().size());
         assertEquals(0, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
 
@@ -353,7 +362,7 @@ public class UnifyRelationConcludableTest {
                 "{ ($role: $y) isa employment; }",
                 rule(
                         " (employee: $x) isa employment ",
-                "{ $x isa person; }")
+                        "{ $x isa person; }")
         );
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
@@ -421,8 +430,8 @@ public class UnifyRelationConcludableTest {
         // test requirements
         assertEquals(
                 roleHierarchy("employee", "employment"),
-                unifier.requirements().roleTypes().get(Variable.label("relation:employee")));
-        assertEquals(1, unifier.requirements().roleTypes().size());
+                unifier.requirements().types().get(Variable.label("relation:employee")));
+        assertEquals(1, unifier.requirements().types().size());
         assertEquals(0, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
     }
@@ -433,7 +442,7 @@ public class UnifyRelationConcludableTest {
                 "{ (employee: $p, employee: $p) isa employment; }",
                 rule(
                         "($employee: $x, $employee: $y) isa $employment",
-                "{ $x isa person; $y isa person; $employment type employment;$employee type employment:employee; }")
+                        "{ $x isa person; $y isa person; $employment type employment;$employee type employment:employee; }")
         ).toList();
         Set<Map<String, Set<String>>> result = iterate(unifiers).map(u -> getStringMapping(u.mapping())).toSet();
         Set<Map<String, Set<String>>> expected = set(
@@ -453,7 +462,7 @@ public class UnifyRelationConcludableTest {
         assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(
                 roleHierarchy("employee", "employment"),
-                unifier.requirements().roleTypes().get(Variable.label("employment:employee")));
+                unifier.requirements().types().get(Variable.label("employment:employee")));
         assertEquals(0, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
@@ -794,10 +803,10 @@ public class UnifyRelationConcludableTest {
 
         Unifier unifier = unifiers.get(0);
         // test requirements
-        assertEquals(1, unifier.requirements().roleTypes().size());
-            assertEquals(
-                    roleHierarchy("employee", "employment"),
-                    unifier.requirements().roleTypes().get(Variable.label("employment:employee")));
+        assertEquals(1, unifier.requirements().types().size());
+        assertEquals(
+                roleHierarchy("employee", "employment"),
+                unifier.requirements().types().get(Variable.label("employment:employee")));
         assertEquals(
                 typeHierarchy("employment"),
                 unifier.requirements().isaExplicit().get(Variable.anon(0)));
@@ -866,7 +875,7 @@ public class UnifyRelationConcludableTest {
     }
 
     @Test
-    public void binaryRelationWithRoleHierarchy_ParentWithBaseRoles(){
+    public void binaryRelationWithRoleHierarchy_ParentWithBaseRoles() {
         String parentRelation = "{ (employer: $x, employee: $y); }";
         String conclusion = "(part-time-employer: $u, part-time-employee: $v) isa part-time-employment";
         String conclusion2 = "(taxi: $u, night-shift-driver: $v) isa part-time-driving";
@@ -876,7 +885,7 @@ public class UnifyRelationConcludableTest {
     }
 
     @Test
-    public void binaryRelationWithRoleHierarchy_ParentWithSubRoles(){
+    public void binaryRelationWithRoleHierarchy_ParentWithSubRoles() {
         String parentRelation = "{ (part-time-employer: $x, part-time-employee: $y); }";
         String conclusion = "(part-time-employer: $u, part-time-employee: $v) isa part-time-employment";
         String conclusion2 = "(taxi: $u, night-shift-driver: $v) isa part-time-driving";
@@ -890,7 +899,7 @@ public class UnifyRelationConcludableTest {
     }
 
     @Test
-    public void ternaryRelationWithRoleHierarchy_ParentWithBaseRoles(){
+    public void ternaryRelationWithRoleHierarchy_ParentWithBaseRoles() {
         String parentRelation = "{ (employer: $x, employee: $y, employee-recommender: $z); }";
         String conclusion = "(taxi: $u, night-shift-driver: $v, part-time-employee-recommender: $q) isa part-time-driving";
         String conclusion2 = "(part-time-employer: $u, part-time-employee: $v, part-time-employee-recommender: $q) isa part-time-employment";
@@ -902,7 +911,7 @@ public class UnifyRelationConcludableTest {
     }
 
     @Test
-    public void ternaryRelationWithRoleHierarchy_ParentWithSubRoles(){
+    public void ternaryRelationWithRoleHierarchy_ParentWithSubRoles() {
         String parentRelation = "{(part-time-employer: $x, part-time-employee: $y, part-time-employee-recommender: $z);}";
         String conclusion = "(employer: $u, employee: $v, employee-recommender: $q) isa employment";
         String conclusion2 = "(part-time-employer: $u, part-time-employee: $v, part-time-employee-recommender: $q) isa part-time-employment";
@@ -911,24 +920,24 @@ public class UnifyRelationConcludableTest {
 
         nonExistentUnifier(parentRelation, rule(conclusion, "{$u isa organisation; $v isa person; $q isa person;}"));
         verifyUnificationSucceeds(parentRelation, rule(conclusion2, "{$u isa part-time-organisation; $v isa student; $q isa student;}"));
-        verifyUnificationSucceeds(parentRelation, rule(conclusion3,"{$u isa driving-hire; $v isa student-driver; $q isa student;}"));
+        verifyUnificationSucceeds(parentRelation, rule(conclusion3, "{$u isa driving-hire; $v isa student-driver; $q isa student;}"));
         nonExistentUnifier(parentRelation, rule(conclusion4, "{$u isa part-time-organisation; $v isa student; $q isa student;}"));
     }
 
     @Test
-    public void ternaryRelationWithRoleHierarchy_ParentWithBaseRoles_childrenRepeatRolePlayers(){
+    public void ternaryRelationWithRoleHierarchy_ParentWithBaseRoles_childrenRepeatRolePlayers() {
         String parentRelation = "{ (employer: $x, employee: $y, employee-recommender: $z);}";
         String conclusion = "(employer: $u, employee: $u, employee-recommender: $q) isa employment";
         String conclusion2 = "(part-time-employer: $u, part-time-employee: $u, part-time-employee-recommender: $q) isa part-time-employment";
         String conclusion3 = "(part-time-employer: $u, part-time-employer: $u, part-time-employee-recommender: $q) isa part-time-employment";
 
         verifyUnificationSucceeds(parentRelation, rule(conclusion, "{$u isa student; $q isa student;}"));
-        verifyUnificationSucceeds(parentRelation, rule(conclusion2,  "{$u isa student; $q isa student;}"));
+        verifyUnificationSucceeds(parentRelation, rule(conclusion2, "{$u isa student; $q isa student;}"));
         nonExistentUnifier(parentRelation, rule(conclusion3, "{$u isa student; $q isa student;}"));
     }
 
     @Test
-    public void ternaryRelationWithRoleHierarchy_ParentWithBaseRoles_parentRepeatRolePlayers(){
+    public void ternaryRelationWithRoleHierarchy_ParentWithBaseRoles_parentRepeatRolePlayers() {
         String parentRelation = "{ (employer: $x, employee: $x, employee-recommender: $y);}";
         String conclusion = "(employer: $u, employee: $v, employee-recommender: $q) isa employment";
         String conclusion2 = "(part-time-employer: $u, part-time-employee: $v, part-time-employee-recommender: $q) isa part-time-employment";
@@ -945,7 +954,7 @@ public class UnifyRelationConcludableTest {
         String parent2 = "{ (part-time-employee: $y) isa employment; }";
         String conclusion = "(part-time-employer: $y, part-time-employee: $x) isa part-time-employment";
 
-        verifyUnificationSucceeds(parent, rule(conclusion,"{$x isa student; $y isa student;}"));
+        verifyUnificationSucceeds(parent, rule(conclusion, "{$x isa student; $y isa student;}"));
         verifyUnificationSucceeds(parent2, rule(conclusion, "{$x isa student; $y isa student;}"));
     }
 
@@ -984,11 +993,11 @@ public class UnifyRelationConcludableTest {
         verifyUnificationSucceedsFor(rule(conclusions.get(1), "{$p isa person;}"), parents, Lists.newArrayList(3, 4, 5, 6, 7, 9, 13));
         verifyUnificationSucceedsFor(rule(conclusions.get(1), "{$p isa student;}"), parents, Lists.newArrayList(3, 4, 5, 6, 7, 9, 13));
 
-        verifyUnificationSucceedsFor(rule(conclusions.get(2), "{$p isa part-time-organisation;$q isa student;}"), parents, Lists.newArrayList(0, 1 ,2, 3, 4, 5));
-        verifyUnificationSucceedsFor(rule(conclusions.get(2), "{$p isa student;$q isa student-driver;}"), parents, Lists.newArrayList( 3, 4, 5, 6, 7, 9, 13));
+        verifyUnificationSucceedsFor(rule(conclusions.get(2), "{$p isa part-time-organisation;$q isa student;}"), parents, Lists.newArrayList(0, 1, 2, 3, 4, 5));
+        verifyUnificationSucceedsFor(rule(conclusions.get(2), "{$p isa student;$q isa student-driver;}"), parents, Lists.newArrayList(3, 4, 5, 6, 7, 9, 13));
 
-        verifyUnificationSucceedsFor(rule(conclusions.get(3), "{$p isa driving-hire; $q isa student-driver;}"), parents, Lists.newArrayList(0, 1 ,2, 3, 4, 5));
-        verifyUnificationSucceedsFor(rule(conclusions.get(3), "{$p isa driving-hire; $q isa student-driver;}"), parents, Lists.newArrayList(0, 1 ,2, 3, 4, 5));
+        verifyUnificationSucceedsFor(rule(conclusions.get(3), "{$p isa driving-hire; $q isa student-driver;}"), parents, Lists.newArrayList(0, 1, 2, 3, 4, 5));
+        verifyUnificationSucceedsFor(rule(conclusions.get(3), "{$p isa driving-hire; $q isa student-driver;}"), parents, Lists.newArrayList(0, 1, 2, 3, 4, 5));
     }
 
     @Test
@@ -998,7 +1007,7 @@ public class UnifyRelationConcludableTest {
                 "{(part-time-employer: $x, part-time-employee: $x);}",
                 "{(taxi: $x, employee: $x); $x isa organisation;}",
                 "{(taxi: $x, employee: $x); $x isa driving-hire;}"
-                );
+        );
         List<String> conclusions = Lists.newArrayList(
                 "(employer: $p, employee: $q) isa employment",
                 "(employer: $p, employee: $p) isa employment",
@@ -1013,7 +1022,7 @@ public class UnifyRelationConcludableTest {
 
         verifyUnificationSucceedsFor(rule(conclusions.get(2), "{$p isa student;$q isa student-driver;}"), parents, Lists.newArrayList(0, 1));
 
-        verifyUnificationSucceedsFor(rule(conclusions.get(3), "{$p isa driving-hire; $q isa student-driver;}"), parents,  Lists.newArrayList(1));
+        verifyUnificationSucceedsFor(rule(conclusions.get(3), "{$p isa driving-hire; $q isa student-driver;}"), parents, Lists.newArrayList(1));
         verifyUnificationSucceedsFor(rule(conclusions.get(3), "{$p isa driving-hire; $q isa driving-hire;}"), parents, Lists.newArrayList(1, 2, 3));
     }
 
@@ -1131,11 +1140,11 @@ public class UnifyRelationConcludableTest {
         assertEquals(expected, actual);
     }
 
-    private Rule rule(String conclusion, String conditions){
+    private Rule rule(String conclusion, String conditions) {
         return createRule(UUID.randomUUID().toString(), conditions, conclusion, logicMgr);
     }
 
-    private FunctionalIterator<Unifier> unifiers(String parent, Rule rule){
+    private FunctionalIterator<Unifier> unifiers(String parent, Rule rule) {
         Conjunction parentConjunction = resolvedConjunction(parent, logicMgr);
         Concludable.Relation queryConcludable = Concludable.create(parentConjunction).stream()
                 .filter(Concludable::isRelation)
@@ -1144,28 +1153,28 @@ public class UnifyRelationConcludableTest {
         return queryConcludable.unify(rule.conclusion(), conceptMgr);
     }
 
-    private void nonExistentUnifier(String parent, Rule rule){
+    private void nonExistentUnifier(String parent, Rule rule) {
         assertFalse(unifiers(parent, rule).hasNext());
     }
 
-    private Unifier uniqueUnifier(String parent, Rule rule){
+    private Unifier uniqueUnifier(String parent, Rule rule) {
         List<Unifier> unifiers = unifiers(parent, rule).toList();
         assertEquals(1, unifiers.size());
         return unifiers.iterator().next();
     }
 
-    private void verifyUnificationSucceedsFor(Rule rule, List<String> parents, List<Integer> unifiableParents){
-        for (int parentIndex = 0; parentIndex < parents.size() ; parentIndex++) {
+    private void verifyUnificationSucceedsFor(Rule rule, List<String> parents, List<Integer> unifiableParents) {
+        for (int parentIndex = 0; parentIndex < parents.size(); parentIndex++) {
             String parent = parents.get(parentIndex);
             assertEquals(
                     String.format("Unexpected unification outcome at index [%s]:\nconjunction: %s\nconclusion: %s\nconditions: %s\n",
-                            parentIndex, parent, rule.conclusion(), rule.condition()),
+                                  parentIndex, parent, rule.conclusion(), rule.condition()),
                     unifiableParents.contains(parentIndex), unifiers(parent, rule).hasNext()
             );
         }
     }
 
-    private void verifyUnificationSucceeds(String parent, Rule rule){
+    private void verifyUnificationSucceeds(String parent, Rule rule) {
         Unifier unifier = uniqueUnifier(parent, rule);
         List<ConceptMap> childAnswers = rocksTransaction.query().match(TypeQL.match(rule.getThenPreNormalised())).toList();
         List<ConceptMap> parentAnswers = rocksTransaction.query().match(TypeQL.match(TypeQL.parsePattern(parent))).toList();
@@ -1193,14 +1202,14 @@ public class UnifyRelationConcludableTest {
         assertTrue(parentAnswers.containsAll(unifiedAnswers));
     }
 
-    Map<Variable, Concept> addRequiredLabeledTypes(ConceptMap ans, Unifier unifier){
+    Map<Variable, Concept> addRequiredLabeledTypes(ConceptMap ans, Unifier unifier) {
         Map<Variable, Concept> imap = new HashMap<>(ans.concepts());
-        unifier.unifiedRequirements().roleTypes()
+        unifier.unifiedRequirements().types()
                 .forEach((var, labels) -> labels.forEach(label -> imap.put(var, role(label.name(), label.scope().get()))));
         return imap;
     }
 
-    Map<Variable, Concept> addRequiredRetrievableConcepts(ConceptMap ans, Unifier unifier){
+    Map<Variable, Concept> addRequiredRetrievableConcepts(ConceptMap ans, Unifier unifier) {
         //insert random concepts for any var in unifier that is not in conceptmap
         Iterator<? extends Thing> instances = iterate(conceptMgr.getRootThingType().getInstances());
         return unifier.reverseUnifier().keySet().stream()

--- a/test/integration/reasoner/ReasonerTest.java
+++ b/test/integration/reasoner/ReasonerTest.java
@@ -76,7 +76,7 @@ public class ReasonerTest {
     }
 
     @Test
-    public void test_no_rules() {
+    public void test() {
         try (RocksSession session = typedb.session(database, Arguments.Session.Type.SCHEMA)) {
             try (RocksTransaction txn = singleThreadElgTransaction(session, Arguments.Transaction.Type.WRITE)) {
                 ConceptManager conceptMgr = txn.concepts();
@@ -101,6 +101,53 @@ public class ReasonerTest {
                     assertEquals("milk", a.get("x").asThing().getType().getLabel().scopedName());
                 });
                 assertEquals(2, ans.size());
+            }
+        }
+    }
+    @Test
+    public void test_no_rules() {
+        try (RocksSession session = typedb.session(database, Arguments.Session.Type.SCHEMA)) {
+            try (RocksTransaction txn = singleThreadElgTransaction(session, Arguments.Transaction.Type.WRITE)) {
+                ConceptManager conceptMgr = txn.concepts();
+                LogicManager logicMgr = txn.logic();
+
+                EntityType person = conceptMgr.putEntityType("person");
+                AttributeType name = conceptMgr.putAttributeType("name", AttributeType.ValueType.STRING);
+                person.setOwns(name);
+                RelationType friendship = conceptMgr.putRelationType("friendship");
+                friendship.setRelates("friend");
+                RelationType marriage = conceptMgr.putRelationType("marriage");
+                marriage.setRelates("husband");
+                marriage.setRelates("wife");
+                person.setPlays(friendship.getRelates("friend"));
+                person.setPlays(marriage.getRelates("husband"));
+                person.setPlays(marriage.getRelates("wife"));
+                logicMgr.putRule(
+                        "marriage-is-friendship",
+                        TypeQL.parsePattern("{ $x isa person; $y isa person; (husband: $x, wife: $y) isa marriage; }").asConjunction(),
+                        TypeQL.parseVariable("(friend: $x, friend: $y) isa friendship").asThing());
+                txn.commit();
+            }
+        }
+        try (RocksSession session = typedb.session(database, Arguments.Session.Type.DATA)) {
+            try (RocksTransaction txn = singleThreadElgTransaction(session, Arguments.Transaction.Type.WRITE)) {
+                txn.query().insert(TypeQL.parseQuery("insert $x isa person, has name 'Zack'; $y isa person, has name 'Yasmin'; (husband: $x, wife: $y) isa marriage;").asInsert());
+                txn.commit();
+            }
+            try (RocksTransaction txn = singleThreadElgTransaction(session, Arguments.Transaction.Type.READ)) {
+                List<ConceptMap> ans = txn.query().match(TypeQL.parseQuery("match $f (friend: $p1, friend: $p2) isa friendship; $p1 has name $na;").asMatch()).toList();
+
+                ans.iterator().forEachRemaining(a -> {
+                    assertEquals("friendship", a.get("f").asThing().getType().getLabel().scopedName());
+                    assertEquals("person", a.get("p1").asThing().getType().getLabel().scopedName());
+                    assertEquals("person", a.get("p2").asThing().getType().getLabel().scopedName());
+                    assertEquals("name", a.get("na").asAttribute().getType().getLabel().scopedName());
+                });
+
+                assertEquals(2, ans.size());
+
+                List<ConceptMap> answers = txn.query().match(TypeQL.parseQuery("match $f (friend: $p1, friend: $p2) isa friendship;").asMatch(), new Options.Query().infer(false)).toList();
+                assertEquals(2, answers.size());
             }
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

To ensure that answers are correctly filtered when only some of a rule's output are valid answers to the parent concludable, we must include type requirements on both thing and type variables in the unifier. This PR refactors and includes required types for all mapped variables in a unifier.

## What are the changes implemented in this PR?
* All mapped variables in a unifier have type requirements
* Refactor `Concludable.unify()` to use simpler unifier builder methods
* Make `Concludable.Unifier.Requirements.Constraint.isaExplicit/types` setters private as they are no longer accessed outside
* Update unification integration tests to reflect additional requirements being added