### PR TITLE
Use a poller to store answer sources for the reasoner cache

### DIFF
--- a/common/poller/AbstractPoller.java
+++ b/common/poller/AbstractPoller.java
@@ -18,12 +18,10 @@
 
 package com.vaticle.typedb.core.common.poller;
 
-import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
-
 import java.util.Optional;
 import java.util.function.Function;
 
-public class AbstractPoller<T> implements Poller<T> {
+public abstract class AbstractPoller<T> implements Poller<T> {
 
     @Override
     public Optional<T> poll() {
@@ -31,8 +29,16 @@ public class AbstractPoller<T> implements Poller<T> {
     }
 
     @Override
-    public <U> Poller<U> flatMap(Function<T, FunctionalIterator<U>> flatMappingFn) {
+    public <U> Poller<U> flatMap(Function<T, Poller<U>> flatMappingFn) {
         return new FlatMappedPoller<>(this, flatMappingFn);
     }
+
+    @Override
+    public Poller<T> link(Poller<T> toLink) {
+        return new LinkedPoller<>(this, toLink);
+    }
+
+    @Override
+    public abstract void recycle();
 
 }

--- a/common/poller/AbstractPoller.java
+++ b/common/poller/AbstractPoller.java
@@ -21,6 +21,8 @@ package com.vaticle.typedb.core.common.poller;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static com.vaticle.typedb.common.collection.Collections.list;
+
 public abstract class AbstractPoller<T> implements Poller<T> {
 
     @Override
@@ -34,11 +36,8 @@ public abstract class AbstractPoller<T> implements Poller<T> {
     }
 
     @Override
-    public Poller<T> link(Poller<T> toLink) {
-        return new LinkedPoller<>(this, toLink);
+    public Poller<T> link(Poller<T> poller) {
+        return new LinkedPollers<>(list(this, poller));
     }
-
-    @Override
-    public abstract void recycle();
 
 }

--- a/common/poller/BasePoller.java
+++ b/common/poller/BasePoller.java
@@ -1,0 +1,26 @@
+package com.vaticle.typedb.core.common.poller;
+
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+
+import java.util.Optional;
+
+public class BasePoller<T> extends AbstractPoller<T> {
+
+    private final FunctionalIterator<T> source;
+
+    public BasePoller(FunctionalIterator<T> iterator) {
+        source = iterator;
+    }
+
+    @Override
+    public Optional<T> poll() {
+        if (source.hasNext()) return Optional.of(source.next());
+        source.recycle(); // TODO: Can we call hasNext() after recycle()?
+        return Optional.empty();
+    }
+
+    @Override
+    public void recycle() {
+        source.recycle();
+    }
+}

--- a/common/poller/BasePoller.java
+++ b/common/poller/BasePoller.java
@@ -32,9 +32,11 @@ public class BasePoller<T> extends AbstractPoller<T> {
 
     @Override
     public Optional<T> poll() {
-        if (source.hasNext()) return Optional.of(source.next());
-        source.recycle(); // TODO: Can we call hasNext() after recycle()?
-        return Optional.empty();
+        if (source.hasNext()) {
+            return Optional.of(source.next());
+        } else {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/common/poller/BasePoller.java
+++ b/common/poller/BasePoller.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package com.vaticle.typedb.core.common.poller;
 
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;

--- a/common/poller/FlatMappedPoller.java
+++ b/common/poller/FlatMappedPoller.java
@@ -41,14 +41,14 @@ public class FlatMappedPoller<T, U> extends AbstractPoller<U> {
             Optional<U> next = poller.poll();
             if (next.isPresent()) return next;
         }
-        Optional<T> fromSource = source.poll();
-        if (fromSource.isPresent()) {
+        Optional<T> fromSource;
+        while ((fromSource = source.poll()).isPresent()) {
             Poller<U> newPoller = flatMappingFn.apply(fromSource.get());
             flatMappedPollers.add(newPoller);
-            return newPoller.poll();
-        } else {
-            return Optional.empty();
+            Optional<U> next = newPoller.poll();
+            if (next.isPresent()) return next;
         }
+        return Optional.empty();
     }
 
     @Override

--- a/common/poller/FlatMappedPoller.java
+++ b/common/poller/FlatMappedPoller.java
@@ -27,24 +27,24 @@ public class FlatMappedPoller<T, U> extends AbstractPoller<U> {
 
     private final Poller<T> source;
     private final Function<T, Poller<U>> flatMappingFn;
-    private final List<Poller<U>> flatMappingPollers;
+    private final List<Poller<U>> flatMappedPollers;
 
-    public FlatMappedPoller(Poller<T> poller, Function<T, Poller<U>> flatMappingFn) {
+    FlatMappedPoller(Poller<T> poller, Function<T, Poller<U>> flatMappingFn) {
         this.source = poller;
         this.flatMappingFn = flatMappingFn;
-        this.flatMappingPollers = new ArrayList<>();
+        this.flatMappedPollers = new ArrayList<>();
     }
 
     @Override
     public Optional<U> poll() {
-        for (Poller<U> poller : flatMappingPollers) {
+        for (Poller<U> poller : flatMappedPollers) {
             Optional<U> next = poller.poll();
             if (next.isPresent()) return next;
         }
         Optional<T> fromSource = source.poll();
         if (fromSource.isPresent()) {
             Poller<U> newPoller = flatMappingFn.apply(fromSource.get());
-            flatMappingPollers.add(newPoller);
+            flatMappedPollers.add(newPoller);
             return newPoller.poll();
         } else {
             return Optional.empty();
@@ -53,7 +53,7 @@ public class FlatMappedPoller<T, U> extends AbstractPoller<U> {
 
     @Override
     public void recycle() {
-        flatMappingPollers.forEach(Poller::recycle);
+        flatMappedPollers.forEach(Poller::recycle);
         source.recycle();
     }
 

--- a/common/poller/LinkedPoller.java
+++ b/common/poller/LinkedPoller.java
@@ -1,0 +1,25 @@
+package com.vaticle.typedb.core.common.poller;
+
+import java.util.Optional;
+
+public class LinkedPoller<T> extends AbstractPoller<T> {
+
+    private final Poller<T> source;
+    private final Poller<T> toLink;
+
+    public LinkedPoller(Poller<T> source, Poller<T> toLink) {
+        this.source = source;
+        this.toLink = toLink;
+    }
+
+    @Override
+    public Optional<T> poll() {
+        return source.poll().map(Optional::of).orElseGet(toLink::poll);
+    }
+
+    @Override
+    public void recycle() {
+        toLink.recycle();
+        source.recycle();
+    }
+}

--- a/common/poller/LinkedPoller.java
+++ b/common/poller/LinkedPoller.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package com.vaticle.typedb.core.common.poller;
 
 import java.util.Optional;

--- a/common/poller/Poller.java
+++ b/common/poller/Poller.java
@@ -27,7 +27,7 @@ public interface Poller<T> {
 
     <U> Poller<U> flatMap(Function<T, Poller<U>> flatMappingFn);
 
-    Poller<T> link(Poller<T> toLink);
+    Poller<T> link(Poller<T> poller);
 
     void recycle();
 

--- a/common/poller/Poller.java
+++ b/common/poller/Poller.java
@@ -18,8 +18,6 @@
 
 package com.vaticle.typedb.core.common.poller;
 
-import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
-
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -27,6 +25,10 @@ public interface Poller<T> {
 
     Optional<T> poll();
 
-    <U> Poller<U> flatMap(Function<T, FunctionalIterator<U>> flatMappingFn);
+    <U> Poller<U> flatMap(Function<T, Poller<U>> flatMappingFn);
+
+    Poller<T> link(Poller<T> toLink);
+
+    void recycle();
 
 }

--- a/common/poller/Pollers.java
+++ b/common/poller/Pollers.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package com.vaticle.typedb.core.common.poller;
 
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;

--- a/common/poller/Pollers.java
+++ b/common/poller/Pollers.java
@@ -1,0 +1,15 @@
+package com.vaticle.typedb.core.common.poller;
+
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.Iterators;
+
+public class Pollers {
+
+    public static <T> Poller<T> empty() {
+        return poll(Iterators.empty());
+    }
+
+    public static <T> Poller<T> poll(FunctionalIterator<T> iterator) {
+        return new BasePoller<>(iterator);
+    }
+}

--- a/reasoner/resolution/framework/RequestState.java
+++ b/reasoner/resolution/framework/RequestState.java
@@ -31,6 +31,7 @@ import java.util.Set;
 
 import static com.vaticle.typedb.common.util.Objects.className;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
+import static com.vaticle.typedb.core.common.poller.Pollers.poll;
 
 public abstract class RequestState {
 
@@ -79,9 +80,9 @@ public abstract class RequestState {
             this.answerCache = answerCache;
             this.isSubscriber = isSubscriber;
             this.deduplicationSet = deduplicate ? new HashSet<>() : null;
-            this.cacheReader = answerCache.reader(isSubscriber)
-                    .flatMap(a -> toUpstream(a)
-                            .filter(partial -> !deduplicate || !deduplicationSet.contains(partial.conceptMap())));
+            this.cacheReader = answerCache.reader(isSubscriber).flatMap(
+                    a -> poll(toUpstream(a).filter(
+                            partial -> !deduplicate || !deduplicationSet.contains(partial.conceptMap()))));
         }
 
         @Override


### PR DESCRIPTION
## What is the goal of this PR?

Within the cache we had a source of new answers as an iterator. We want to poll this store of answers in case more have been added. For this we introduce pollers that can be linked together as new answer sources are found.

## What are the changes implemented in this PR?

- Add `BasePoller` which polls an iterator.
- Add `LinkedPoller` which polls over both linked Pollers.
- Refactor `FlatMapPoller` to take in a function that yields a poller, for consistency with `LinkedPoller`.
- `Pollers` class for static poller convenience methods.
