### PR TITLE
Disallow users from creating / accessing 'reserved' databases

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -123,8 +123,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Database(3, "Database with the name '%s' has been deleted.");
         public static final Database DATABASE_CLOSED =
                 new Database(4, "Attempted to open a new session from the database '%s' that has been closed.");
-        public static final Database DATABASE_NAME_INVALID =
-                new Database(5, "Invalid database name: '%s'. Name must not start with an underscore.");
+        public static final Database DATABASE_NAME_RESERVED =
+                new Database(5, "Database name must not start with an underscore.");
 
         private static final String codePrefix = "DBS";
         private static final String messagePrefix = "Invalid Database Operations";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -123,6 +123,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Database(3, "Database with the name '%s' has been deleted.");
         public static final Database DATABASE_CLOSED =
                 new Database(4, "Attempted to open a new session from the database '%s' that has been closed.");
+        public static final Database DATABASE_NAME_INVALID =
+                new Database(5, "Invalid database name: '%s'. Name must not start with an underscore.");
 
         private static final String codePrefix = "DBS";
         private static final String messagePrefix = "Invalid Database Operations";

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -25,5 +25,5 @@ def vaticle_typedb_console_artifact():
         artifact_name = "typedb-console-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        tag = "2.1.0",
+        commit = "9ad46c1d6fbeed3acabc8667032b2ba755ab60ed",
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,7 +35,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.1.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "f970a961838acfd5e421b56a09f16e9e83460509", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():

--- a/rocks/RocksDatabaseManager.java
+++ b/rocks/RocksDatabaseManager.java
@@ -23,14 +23,17 @@ import com.vaticle.typedb.core.common.exception.TypeDBException;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Database.DATABASE_EXISTS;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Database.DATABASE_NAME_INVALID;
 
 public class RocksDatabaseManager implements TypeDB.DatabaseManager {
+
+    protected static final String RESERVED_NAME_PREFIX = "_";
 
     protected final RocksTypeDB typedb;
     protected final ConcurrentMap<String, RocksDatabase> databases;
@@ -55,11 +58,13 @@ public class RocksDatabaseManager implements TypeDB.DatabaseManager {
 
     @Override
     public boolean contains(String name) {
+        if (isReservedName(name)) throw TypeDBException.of(DATABASE_NAME_INVALID, name);
         return databases.containsKey(name);
     }
 
     @Override
     public RocksDatabase create(String name) {
+        if (isReservedName(name)) throw TypeDBException.of(DATABASE_NAME_INVALID, name);
         if (databases.containsKey(name)) throw TypeDBException.of(DATABASE_EXISTS, name);
 
         RocksDatabase database = databaseFactory.databaseCreateAndOpen(typedb, name);
@@ -69,12 +74,13 @@ public class RocksDatabaseManager implements TypeDB.DatabaseManager {
 
     @Override
     public RocksDatabase get(String name) {
+        if (isReservedName(name)) throw TypeDBException.of(DATABASE_NAME_INVALID, name);
         return databases.get(name);
     }
 
     @Override
     public Set<RocksDatabase> all() {
-        return new HashSet<>(databases.values());
+        return unreservedDatabase();
     }
 
     void remove(RocksDatabase database) {
@@ -83,5 +89,17 @@ public class RocksDatabaseManager implements TypeDB.DatabaseManager {
 
     protected void close() {
         all().parallelStream().forEach(RocksDatabase::close);
+    }
+
+    protected boolean isReservedName(String name) {
+        return name.startsWith(RESERVED_NAME_PREFIX);
+    }
+
+    protected Set<RocksDatabase> unreservedDatabase() {
+        return databases.values().stream().filter(database -> {
+            boolean isReserved = isReservedName(database.name());
+            System.out.println("name: " + database.name() + ", isReserved: " + isReserved);
+            return !isReserved;
+        }).collect(Collectors.toSet());
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

We've introduced the concept of "reserved database" - databases intended for use by the server instead of users. A database is considered a reserved database if the name starts with `_`.

## What are the changes implemented in this PR?

- Updated `RocksDatabaseManager` to disallow access to reserved databases, done by checking the prefix of the database name.