### PR TITLE
Make RocksDatabaseManager not usable if it's already closed

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -115,16 +115,18 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
     }
 
     public static class Database extends ErrorMessage {
+        public static final Database DATABASE_MANAGER_CLOSED =
+                new Database(1, "Attempted to use database manager when it has been closed.");
         public static final Database DATABASE_EXISTS =
-                new Database(1, "The database with the name '%s' already exists.");
+                new Database(2, "The database with the name '%s' already exists.");
         public static final Database DATABASE_NOT_FOUND =
-                new Database(2, "The database with the name '%s' does not exist.");
+                new Database(3, "The database with the name '%s' does not exist.");
         public static final Database DATABASE_DELETED =
-                new Database(3, "Database with the name '%s' has been deleted.");
+                new Database(4, "Database with the name '%s' has been deleted.");
         public static final Database DATABASE_CLOSED =
-                new Database(4, "Attempted to open a new session from the database '%s' that has been closed.");
+                new Database(5, "Attempted to open a new session from the database '%s' that has been closed.");
         public static final Database DATABASE_NAME_RESERVED =
-                new Database(5, "Database name must not start with an underscore.");
+                new Database(6, "Database name must not start with an underscore.");
 
         private static final String codePrefix = "DBS";
         private static final String messagePrefix = "Invalid Database Operations";

--- a/rocks/RocksDatabase.java
+++ b/rocks/RocksDatabase.java
@@ -303,7 +303,7 @@ public class RocksDatabase implements TypeDB.Database {
         }
     }
 
-    void close() {
+    protected void close() {
         if (isOpen.compareAndSet(true, false)) {
             closeResources();
         }

--- a/rocks/RocksDatabaseManager.java
+++ b/rocks/RocksDatabaseManager.java
@@ -97,7 +97,7 @@ public class RocksDatabaseManager implements TypeDB.DatabaseManager {
 
     protected void close() {
         if (isOpen.compareAndSet(true, false)) {
-            all().parallelStream().forEach(RocksDatabase::close);
+            databases.values().parallelStream().forEach(RocksDatabase::close);
         }
     }
 

--- a/rocks/RocksDatabaseManager.java
+++ b/rocks/RocksDatabaseManager.java
@@ -88,7 +88,7 @@ public class RocksDatabaseManager implements TypeDB.DatabaseManager {
     @Override
     public Set<RocksDatabase> all() {
         if (!isOpen.get()) throw TypeDBException.of(DATABASE_MANAGER_CLOSED);
-        return allUnreserved();
+        return databases.values().stream().filter(database -> !isReservedName(database.name())).collect(Collectors.toSet());
     }
 
     void remove(RocksDatabase database) {
@@ -97,12 +97,8 @@ public class RocksDatabaseManager implements TypeDB.DatabaseManager {
 
     protected void close() {
         if (isOpen.compareAndSet(true, false)) {
-            allUnreserved().parallelStream().forEach(RocksDatabase::close);
+            all().parallelStream().forEach(RocksDatabase::close);
         }
-    }
-
-    private Set<RocksDatabase> allUnreserved() {
-        return databases.values().stream().filter(database -> !isReservedName(database.name())).collect(Collectors.toSet());
     }
 
     protected boolean isReservedName(String name) {

--- a/rocks/RocksDatabaseManager.java
+++ b/rocks/RocksDatabaseManager.java
@@ -88,7 +88,7 @@ public class RocksDatabaseManager implements TypeDB.DatabaseManager {
     @Override
     public Set<RocksDatabase> all() {
         if (!isOpen.get()) throw TypeDBException.of(DATABASE_MANAGER_CLOSED);
-        return databases.values().stream().filter(database -> !isReservedName(database.name())).collect(Collectors.toSet());
+        return allUnreserved();
     }
 
     void remove(RocksDatabase database) {
@@ -97,8 +97,12 @@ public class RocksDatabaseManager implements TypeDB.DatabaseManager {
 
     protected void close() {
         if (isOpen.compareAndSet(true, false)) {
-            all().parallelStream().forEach(RocksDatabase::close);
+            allUnreserved().parallelStream().forEach(RocksDatabase::close);
         }
+    }
+
+    private Set<RocksDatabase> allUnreserved() {
+        return databases.values().stream().filter(database -> !isReservedName(database.name())).collect(Collectors.toSet());
     }
 
     protected boolean isReservedName(String name) {


### PR DESCRIPTION
## What is the goal of this PR?

We make the `RocksDatabaseManager` stricter - it should reject operations if it's already closed. Additionally, we make `RocksDatabase` more extensible by the subclasses by making the `delete` method `protected.

## What are the changes implemented in this PR?

- Add an `isOpen` flag to indicate the state of the database manager
- Add checks in the methods such that operations are rejected, when `isOpen` is set to `false`
- Make `RocksDatabase::delete` protected so that it can be extended by the subclasses.