### PR TITLE
Deploy artifacts that include Console

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -135,9 +135,9 @@ build:
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-targz -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-zip -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //server:deploy-windows-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-targz -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-zip -- snapshot
     deploy-apt-snapshot:
       image: vaticle-ubuntu-20.04
       filter:
@@ -230,6 +230,6 @@ release:
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run --define version=$(cat VERSION) //server:deploy-linux-targz -- release
-        bazel run --define version=$(cat VERSION) //server:deploy-mac-zip -- release
-        bazel run --define version=$(cat VERSION) //server:deploy-windows-zip -- release
+        bazel run --define version=$(cat VERSION) //:deploy-linux-targz -- release
+        bazel run --define version=$(cat VERSION) //:deploy-mac-zip -- release
+        bazel run --define version=$(cat VERSION) //:deploy-windows-zip -- release

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -135,6 +135,9 @@ build:
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-targz -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-windows-zip -- snapshot
         bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-targz -- snapshot
         bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-zip -- snapshot
         bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-zip -- snapshot
@@ -230,6 +233,9 @@ release:
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run --define version=$(cat VERSION) //server:deploy-linux-targz -- release
+        bazel run --define version=$(cat VERSION) //server:deploy-mac-zip -- release
+        bazel run --define version=$(cat VERSION) //server:deploy-windows-zip -- release
         bazel run --define version=$(cat VERSION) //:deploy-linux-targz -- release
         bazel run --define version=$(cat VERSION) //:deploy-mac-zip -- release
         bazel run --define version=$(cat VERSION) //:deploy-windows-zip -- release

--- a/BUILD
+++ b/BUILD
@@ -17,6 +17,7 @@
 
 load("//:deployment.bzl", deployment_github = "deployment", deployment_docker = "deployment")
 load("@vaticle_bazel_distribution//apt:rules.bzl", "assemble_apt", "deploy_apt")
+load("@vaticle_bazel_distribution//artifact:rules.bzl", "deploy_artifact")
 load("@vaticle_bazel_distribution//brew:rules.bzl", "deploy_brew")
 load("@vaticle_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_zip", "checksum", "assemble_versioned")
 load("@vaticle_bazel_distribution//github:rules.bzl", "deploy_github")
@@ -92,6 +93,33 @@ assemble_zip(
     additional_files = assemble_files,
     permissions = permissions,
     output_filename = "typedb-all-windows",
+)
+
+deploy_artifact(
+    name = "deploy-linux-targz",
+    target = ":assemble-linux-targz",
+    artifact_group = "vaticle_typedb",
+    artifact_name = "typedb-all-linux-{version}.tar.gz",
+    release = deployment['artifact.release'],
+    snapshot = deployment['artifact.snapshot'],
+)
+
+deploy_artifact(
+    name = "deploy-mac-zip",
+    target = ":assemble-mac-zip",
+    artifact_group = "vaticle_typedb",
+    artifact_name = "typedb-all-mac-{version}.zip",
+    release = deployment['artifact.release'],
+    snapshot = deployment['artifact.snapshot'],
+)
+
+deploy_artifact(
+    name = "deploy-windows-zip",
+    target = ":assemble-windows-zip",
+    artifact_group = "vaticle_typedb",
+    artifact_name = "typedb-all-windows-{version}.zip",
+    release = deployment['artifact.release'],
+    snapshot = deployment['artifact.snapshot'],
 )
 
 assemble_versioned(


### PR DESCRIPTION
## What is the goal of this PR?

In order to test repositories that load TypeQL files into TypeDB, we require an artifact of TypeDB that includes the Console. This is because Console comes with built-in functionality for loading from TypeQL files, which cannot be easily replicated since it makes use of a TypeQL parser.

## What are the changes implemented in this PR?

Deploy artifacts for `typedb-all` for snapshots and releases.
