### PR TITLE
Ensure that the RPC prefetch size is at least 1

### DIFF
--- a/server/TransactionService.java
+++ b/server/TransactionService.java
@@ -312,7 +312,7 @@ public class TransactionService implements StreamObserver<TransactionProto.Trans
         }
 
         private void streamResParts() {
-            streamResPartsWhile(i -> i < prefetchSize && iterator.hasNext());
+            streamResPartsWhile(i -> i < Math.max(prefetchSize, 1) && iterator.hasNext());
             if (mayClose()) return;
 
             respondStreamState(CONTINUE);

--- a/server/TransactionService.java
+++ b/server/TransactionService.java
@@ -307,12 +307,12 @@ public class TransactionService implements StreamObserver<TransactionProto.Trans
                        Function<List<T>, TransactionProto.Transaction.ResPart> resPartFn) {
             this.iterator = iterator;
             this.requestID = requestID;
-            this.prefetchSize = prefetchSize;
+            this.prefetchSize = Math.max(1, prefetchSize);
             this.resPartFn = resPartFn;
         }
 
         private void streamResParts() {
-            streamResPartsWhile(i -> i < Math.max(prefetchSize, 1) && iterator.hasNext());
+            streamResPartsWhile(i -> i < prefetchSize && iterator.hasNext());
             if (mayClose()) return;
 
             respondStreamState(CONTINUE);


### PR DESCRIPTION
## What is the goal of this PR?

Ensure that the minimum prefetch size is at least 1, so that the user cannot end up in a situation that streams back 0 answers per `res_part` request.

## What are the changes implemented in this PR?
* add a minimum of 1 to the RPC messages that are sent back per request