### PR TITLE
RPC prefetch size must be least 1

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -185,6 +185,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Transaction(15, "The transaction type '%s' was not recognised.");
         public static final Transaction DATA_ACQUIRE_LOCK_TIMEOUT =
                 new Transaction(16, "Could not acquire lock for data transaction. A schema session may have been left open.");
+        public static final Transaction RPC_PREFETCH_SIZE_TOO_SMALL =
+                new Transaction(17, "RPC answer streaming prefetch size must be at least 1, is set to: %d.");
 
         private static final String codePrefix = "TXN";
         private static final String messagePrefix = "Invalid Transaction Operation";

--- a/server/TransactionService.java
+++ b/server/TransactionService.java
@@ -61,10 +61,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.EMPTY
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.ITERATION_WITH_UNKNOWN_ID;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.UNKNOWN_REQUEST_TYPE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Session.SESSION_NOT_FOUND;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.BAD_TRANSACTION_TYPE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_ALREADY_OPENED;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_CLOSED;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_NOT_OPENED;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.*;
 import static com.vaticle.typedb.core.server.common.RequestReader.applyDefaultOptions;
 import static com.vaticle.typedb.core.server.common.RequestReader.byteStringAsUUID;
 import static com.vaticle.typedb.core.server.common.ResponseBuilder.Transaction.serverMsg;
@@ -307,7 +304,8 @@ public class TransactionService implements StreamObserver<TransactionProto.Trans
                        Function<List<T>, TransactionProto.Transaction.ResPart> resPartFn) {
             this.iterator = iterator;
             this.requestID = requestID;
-            this.prefetchSize = Math.max(1, prefetchSize);
+            if (prefetchSize < 1) throw TypeDBException.of(RPC_PREFETCH_SIZE_TOO_SMALL, prefetchSize);
+            this.prefetchSize = prefetchSize;
             this.resPartFn = resPartFn;
         }
 

--- a/server/TransactionService.java
+++ b/server/TransactionService.java
@@ -56,9 +56,16 @@ import java.util.function.Predicate;
 
 import static com.vaticle.factory.tracing.client.FactoryTracingThreadStatic.continueTraceOnThread;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.*;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.DUPLICATE_REQUEST;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.EMPTY_TRANSACTION_REQUEST;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.ITERATION_WITH_UNKNOWN_ID;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.UNKNOWN_REQUEST_TYPE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Session.SESSION_NOT_FOUND;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.*;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.BAD_TRANSACTION_TYPE;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.RPC_PREFETCH_SIZE_TOO_SMALL;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_ALREADY_OPENED;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_CLOSED;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_NOT_OPENED;
 import static com.vaticle.typedb.core.server.common.RequestReader.applyDefaultOptions;
 import static com.vaticle.typedb.core.server.common.RequestReader.byteStringAsUUID;
 import static com.vaticle.typedb.core.server.common.ResponseBuilder.Transaction.serverMsg;

--- a/server/TransactionService.java
+++ b/server/TransactionService.java
@@ -56,10 +56,7 @@ import java.util.function.Predicate;
 
 import static com.vaticle.factory.tracing.client.FactoryTracingThreadStatic.continueTraceOnThread;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.DUPLICATE_REQUEST;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.EMPTY_TRANSACTION_REQUEST;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.ITERATION_WITH_UNKNOWN_ID;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.UNKNOWN_REQUEST_TYPE;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.*;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Session.SESSION_NOT_FOUND;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.*;
 import static com.vaticle.typedb.core.server.common.RequestReader.applyDefaultOptions;


### PR DESCRIPTION
## What is the goal of this PR?

To avoid potential stalls (when latency is 0/disabled in the future), RPC prefetch size must be least 1 according to the user configuration. This PR adds the required validation.

## What are the changes implemented in this PR?

* require RPC prefetch is at least 1
