### PR TITLE
Enable reasoner to handle reflexive relations

### DIFF
--- a/logic/resolvable/Unifier.java
+++ b/logic/resolvable/Unifier.java
@@ -227,7 +227,7 @@ public class Unifier {
 
         public Builder clone() {
             Map<Retrievable, Set<Variable>> unifierCopy = new HashMap<>();
-            unifier.forEach(((identifier, unifieds) -> unifierCopy.put(identifier, set(unifieds))));
+            unifier.forEach(((identifier, unifieds) -> unifierCopy.put(identifier, new HashSet<>(unifieds))));
             Requirements.Constraint requirementsCopy = requirements.duplicate();
             Requirements.Constraint unifiedRequirementsCopy = unifiedRequirements.duplicate();
             return new Builder(unifierCopy, requirementsCopy, unifiedRequirementsCopy);
@@ -352,7 +352,7 @@ public class Unifier {
                 Map<Retrievable, Set<Label>> isaExplicitCopy = new HashMap<>();
                 Map<Retrievable, Function<Attribute, Boolean>> predicatesCopy = new HashMap<>();
                 types.forEach(((identifier, labels) -> typesCopy.put(identifier, set(labels))));
-                isaExplicit.forEach(((identifier, labels) -> isaExplicitCopy.put(identifier, set(labels))));
+                isaExplicit.forEach(((identifier, labels) -> isaExplicitCopy.put(identifier, new HashSet<>(labels))));
                 predicates.forEach((predicatesCopy::put));
                 return new Constraint(typesCopy, isaExplicitCopy, predicatesCopy);
             }


### PR DESCRIPTION
## What is the goal of this PR?

We enable reasoner to handle reflexive relations where previously it would throw an internal error.

## What are the changes implemented in this PR?

- When matching for reflexive relations the reasoner would throw errors due to attempted modifications to immutable sets during unification. These sets should have been mutable. Therefore, use `HashSets` in place of our convenience `set()` immutable set static constructor.
