### PR TITLE
Delete and Insert queries are validated once rather than per answer

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,7 +49,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "f763ba70f081b73f7668d904de50b9cb9cfc8858", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "9581b8bee1403fd975d71ae95b04445eb7d1dbb4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/query/Deleter.java
+++ b/query/Deleter.java
@@ -31,6 +31,8 @@ import com.vaticle.typedb.core.concept.type.RoleType;
 import com.vaticle.typedb.core.concept.type.ThingType;
 import com.vaticle.typedb.core.pattern.constraint.thing.HasConstraint;
 import com.vaticle.typedb.core.pattern.variable.ThingVariable;
+import com.vaticle.typedb.core.pattern.variable.TypeVariable;
+import com.vaticle.typedb.core.pattern.variable.Variable;
 import com.vaticle.typedb.core.pattern.variable.VariableRegistry;
 import com.vaticle.typedb.core.reasoner.Reasoner;
 import com.vaticle.typeql.lang.pattern.variable.Reference;
@@ -73,13 +75,35 @@ public class Deleter {
     public static Deleter create(Reasoner reasoner, TypeQLDelete query, Context.Query context) {
         try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "create")) {
             VariableRegistry registry = VariableRegistry.createFromThings(query.variables(), false);
-            iterate(registry.types()).filter(t -> !t.reference().isLabel()).forEachRemaining(t -> {
-                throw TypeDBException.of(ILLEGAL_TYPE_VARIABLE_IN_DELETE, t.reference());
-            });
+            registry.variables().forEach(Deleter::validate);
 
             assert query.match().namedVariablesUnbound().containsAll(query.namedVariablesUnbound());
             Matcher matcher = Matcher.create(reasoner, query.match().get(query.namedVariablesUnbound()));
             return new Deleter(matcher, registry.things(), context);
+        }
+    }
+
+    public static void validate(Variable var) {
+        try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "validate")) {
+            if (var.isType()) validate(var.asType());
+            else validate(var.asThing());
+        }
+    }
+
+    public static void validate(TypeVariable var) {
+        if (!var.reference().isLabel()) throw TypeDBException.of(ILLEGAL_TYPE_VARIABLE_IN_DELETE, var.reference());
+    }
+
+    public static void validate(ThingVariable var) {
+        if (!var.reference().isName()) {
+            ErrorMessage.ThingWrite msg = var.relation().isPresent()
+                    ? ILLEGAL_ANONYMOUS_RELATION_IN_DELETE
+                    : ILLEGAL_ANONYMOUS_VARIABLE_IN_DELETE;
+            throw TypeDBException.of(msg, var);
+        } else if (var.iid().isPresent()) {
+            throw TypeDBException.of(THING_IID_NOT_INSERTABLE, var.reference(), var.iid().get());
+        } else if (!var.is().isEmpty()) {
+            throw TypeDBException.of(ILLEGAL_IS_CONSTRAINT, var, var.is().iterator().next());
         }
     }
 
@@ -121,20 +145,6 @@ public class Deleter {
             }
         }
 
-        private void validate(ThingVariable var) {
-            try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "validate")) {
-                if (!var.reference().isName()) {
-                    ErrorMessage.ThingWrite msg = var.relation().isPresent()
-                            ? ILLEGAL_ANONYMOUS_RELATION_IN_DELETE
-                            : ILLEGAL_ANONYMOUS_VARIABLE_IN_DELETE;
-                    throw TypeDBException.of(msg, var);
-                } else if (var.iid().isPresent()) {
-                    throw TypeDBException.of(THING_IID_NOT_INSERTABLE, var.reference(), var.iid().get());
-                } else if (!var.is().isEmpty()) {
-                    throw TypeDBException.of(ILLEGAL_IS_CONSTRAINT, var, var.is().iterator().next());
-                }
-            }
-        }
 
         private void deleteHas(ThingVariable var, Thing thing) {
             try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "delete_has")) {

--- a/query/Deleter.java
+++ b/query/Deleter.java
@@ -90,11 +90,11 @@ public class Deleter {
         }
     }
 
-    public static void validate(TypeVariable var) {
+    private static void validate(TypeVariable var) {
         if (!var.reference().isLabel()) throw TypeDBException.of(ILLEGAL_TYPE_VARIABLE_IN_DELETE, var.reference());
     }
 
-    public static void validate(ThingVariable var) {
+    private static void validate(ThingVariable var) {
         if (!var.reference().isName()) {
             ErrorMessage.ThingWrite msg = var.relation().isPresent()
                     ? ILLEGAL_ANONYMOUS_RELATION_IN_DELETE

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -111,7 +111,7 @@ public class Inserter {
         }
     }
 
-    private static void validate(Variable var) {
+    public static void validate(Variable var) {
         try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "validate")) {
             if (var.isType()) validate(var.asType());
             else validate(var.asThing());

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -111,7 +111,7 @@ public class Inserter {
         }
     }
 
-    public static void validate(Variable var) {
+    private static void validate(Variable var) {
         try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "validate")) {
             if (var.isType()) validate(var.asType());
             else validate(var.asThing());

--- a/query/Updater.java
+++ b/query/Updater.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 
 import static com.vaticle.factory.tracing.client.FactoryTracingThreadStatic.traceOnThread;
 import static com.vaticle.typedb.common.collection.Collections.list;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_ANONYMOUS_VARIABLE_IN_DELETE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_TYPE_VARIABLE_IN_DELETE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_TYPE_VARIABLE_IN_INSERT;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
@@ -71,6 +72,9 @@ public class Updater {
             VariableRegistry deleteRegistry = VariableRegistry.createFromThings(query.deleteVariables(), false);
             iterate(deleteRegistry.types()).filter(t -> !t.reference().isLabel()).forEachRemaining(t -> {
                 throw TypeDBException.of(ILLEGAL_TYPE_VARIABLE_IN_DELETE, t.reference());
+            });
+            iterate(deleteRegistry.things()).filter(t -> t.reference().isAnonymous()).forEachRemaining(t -> {
+                throw TypeDBException.of(ILLEGAL_ANONYMOUS_VARIABLE_IN_DELETE, t.reference());
             });
 
             VariableRegistry insertRegistry = VariableRegistry.createFromThings(query.insertVariables());


### PR DESCRIPTION
## What is the goal of this PR?

We refactor `Deleter`, `Inserter` and `Updater` in order to validate the queries once, before execution, rather than per-answer.


## What are the changes implemented in this PR?

* extract Validation for `Insert` and `Delete` operations into a static validation that runs before each query is executed
