### PR TITLE
Streamline statistics counting and fix ACID with no RocksDB writes

### DIFF
--- a/graph/ThingGraph.java
+++ b/graph/ThingGraph.java
@@ -275,9 +275,9 @@ public class ThingGraph {
         AttributeVertex<Boolean> vertex = attributesByIID.booleans.computeIfAbsent(
                 new VertexIID.Attribute.Boolean(type.iid(), value),
                 iid -> {
-                    AttributeVertex<Boolean> v = new AttributeVertexImpl.Boolean(this, iid, isInferred);
+                    AttributeVertexImpl.Boolean v = new AttributeVertexImpl.Boolean(this, iid, isInferred);
                     thingsByTypeIID.computeIfAbsent(type.iid(), t -> new ConcurrentSet<>()).add(v);
-                    isNewVertex[0] = true;
+                    isNewVertex[0] = !v.isPersisted();
                     return v;
                 }
         );
@@ -297,9 +297,9 @@ public class ThingGraph {
         AttributeVertex<Long> vertex = attributesByIID.longs.computeIfAbsent(
                 new VertexIID.Attribute.Long(type.iid(), value),
                 iid -> {
-                    AttributeVertex<Long> v = new AttributeVertexImpl.Long(this, iid, isInferred);
+                    AttributeVertexImpl.Long v = new AttributeVertexImpl.Long(this, iid, isInferred);
                     thingsByTypeIID.computeIfAbsent(type.iid(), t -> new ConcurrentSet<>()).add(v);
-                    isNewVertex[0] = true;
+                    isNewVertex[0] = !v.isPersisted();
                     return v;
                 }
         );
@@ -321,9 +321,9 @@ public class ThingGraph {
         AttributeVertex<Double> vertex = attributesByIID.doubles.computeIfAbsent(
                 new VertexIID.Attribute.Double(type.iid(), value),
                 iid -> {
-                    AttributeVertex<Double> v = new AttributeVertexImpl.Double(this, iid, isInferred);
+                    AttributeVertexImpl.Double v = new AttributeVertexImpl.Double(this, iid, isInferred);
                     thingsByTypeIID.computeIfAbsent(type.iid(), t -> new ConcurrentSet<>()).add(v);
-                    isNewVertex[0] = true;
+                    isNewVertex[0] = !v.isPersisted();
                     return v;
                 }
         );
@@ -354,9 +354,9 @@ public class ThingGraph {
         boolean[] isNewVertex = new boolean[]{false};
         AttributeVertex<String> vertex = attributesByIID.strings.computeIfAbsent(
                 attIID, iid -> {
-                    AttributeVertex<String> v = new AttributeVertexImpl.String(this, iid, isInferred);
+                    AttributeVertexImpl.String v = new AttributeVertexImpl.String(this, iid, isInferred);
                     thingsByTypeIID.computeIfAbsent(type.iid(), t -> new ConcurrentSet<>()).add(v);
-                    isNewVertex[0] = true;
+                    isNewVertex[0] = !v.isPersisted();
                     return v;
                 }
         );
@@ -377,9 +377,9 @@ public class ThingGraph {
         AttributeVertex<LocalDateTime> vertex = attributesByIID.dateTimes.computeIfAbsent(
                 new VertexIID.Attribute.DateTime(type.iid(), value),
                 iid -> {
-                    AttributeVertex<LocalDateTime> v = new AttributeVertexImpl.DateTime(this, iid, isInferred);
+                    AttributeVertexImpl.DateTime v = new AttributeVertexImpl.DateTime(this, iid, isInferred);
                     thingsByTypeIID.computeIfAbsent(type.iid(), t -> new ConcurrentSet<>()).add(v);
-                    isNewVertex[0] = true;
+                    isNewVertex[0] = !v.isPersisted();
                     return v;
                 }
         );

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -149,7 +149,7 @@ public class Encoding {
     /**
      * The values in this class will be used as 'prefixes' within an IID in the
      * of every object database, and must not overlap with each other.
-     * <p>
+     *
      * The size of a prefix is 1 unsigned byte; i.e. min-value = 0 and max-value = 255.
      */
     public enum Prefix {
@@ -252,7 +252,7 @@ public class Encoding {
     /**
      * The values in this class will be used as 'infixes' between two IIDs of
      * two objects in the database, and must not overlap with each other.
-     * <p>
+     *
      * The size of a prefix is 1 signed byte; i.e. min-value = -128 and max-value = 127.
      */
     public enum Infix {

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -199,6 +199,7 @@ public class Encoding {
         private final ByteArray bytes;
 
         Prefix(int key, PrefixType type) {
+            assert key < 200 : "Core prefix encoding should not use reserved range";
             this.key = unsignedByte(key);
             this.type = type;
             this.bytes = ByteArray.of(new byte[]{this.key});

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -131,19 +131,12 @@ public class Encoding {
     }
 
     public enum PrefixType {
-        SYSTEM(-1),
-        INDEX(0),
-        STATISTICS(1),
-        TYPE(2),
-        THING(3),
-        RULE(4);
-
-        private final int key;
-
-        PrefixType(int key) {
-            this.key = key;
-        }
-
+        SYSTEM,
+        INDEX,
+        STATISTICS,
+        TYPE,
+        THING,
+        RULE;
     }
 
     /**
@@ -199,7 +192,7 @@ public class Encoding {
         private final ByteArray bytes;
 
         Prefix(int key, PrefixType type) {
-            assert key < 200 : "Core prefix encoding should not use reserved range";
+            assert key < 200 : "The encoding range >= 200 is reserved for TypeDB Cluster.";
             this.key = unsignedByte(key);
             this.type = type;
             this.bytes = ByteArray.of(new byte[]{this.key});
@@ -973,25 +966,19 @@ public class Encoding {
         }
     }
 
-    public interface System {
+    public enum System {
 
-        ByteArray bytes();
+        TRANSACTION_DUMMY_WRITE(0);
 
-        enum Core implements System {
+        private final ByteArray bytes;
 
-            TRANSACTION_DUMMY_WRITE(0);
+        System(int key) {
+            byte b = unsignedByte(key);
+            this.bytes = ByteArray.join(Prefix.SYSTEM.bytes(), ByteArray.of(new byte[]{b}));
+        }
 
-            private final ByteArray bytes;
-
-            Core(int key) {
-                byte b = unsignedByte(key);
-                this.bytes = ByteArray.join(Prefix.SYSTEM.bytes(), ByteArray.of(new byte[]{b}));
-            }
-
-            public ByteArray bytes() {
-                return bytes;
-            }
-
+        public ByteArray bytes() {
+            return bytes;
         }
 
     }

--- a/graph/vertex/impl/AttributeVertexImpl.java
+++ b/graph/vertex/impl/AttributeVertexImpl.java
@@ -145,7 +145,7 @@ public abstract class AttributeVertexImpl<VALUE> extends ThingVertexImpl impleme
         }
     }
 
-    private boolean isPersisted() {
+    public boolean isPersisted() {
         if (isPersisted == null) isPersisted = graph.storage().get(iid.bytes()) != null;
         return isPersisted;
     }

--- a/rocks/RocksDatabase.java
+++ b/rocks/RocksDatabase.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Set;
@@ -506,11 +507,11 @@ public class RocksDatabase implements TypeDB.Database {
                     for (Map.Entry<Long, ConcurrentMap<RocksStorage.Data, Event>> entry : this.events.entrySet()) {
                         Long snapshot = entry.getKey();
                         ConcurrentMap<RocksStorage.Data, Event> events = entry.getValue();
-                        events.keySet().forEach(storage -> {
-                            if (storage.snapshotEnd().isPresent() && isDeletable(storage)) {
-                                events.remove(storage);
-                            }
-                        });
+                        RocksStorage.Data other;
+                        for (Iterator<RocksStorage.Data> iter = events.keySet().iterator(); iter.hasNext(); ) {
+                            other = iter.next();
+                            if (other.snapshotEnd().isPresent() && isDeletable(other)) iter.remove();
+                        }
                         if (events.isEmpty()) this.events.remove(snapshot);
                     }
                     cleanupRunning.set(false);

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -274,8 +274,9 @@ public abstract class RocksStorage implements Storage {
         }
 
         public void commit() throws RocksDBException {
-            // We disable RocksDB indexing of uncommitted writes, as we're only about to write and never again reading
+            // guarantee at least 1 write per tx
             storageTransaction.putUntracked(TRANSACTION_DUMMY_WRITE.bytes().getBytes(), EMPTY_ARRAY.getBytes());
+            // We disable RocksDB indexing of uncommitted writes, as we're only about to write and never again reading
             // TODO: We should benchmark this
             storageTransaction.disableIndexing();
             storageTransaction.commit();

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -54,6 +54,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILL
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.RESOURCE_CLOSED;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_DATA_READ_VIOLATION;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_SCHEMA_READ_VIOLATION;
+import static com.vaticle.typedb.core.graph.common.Encoding.System.Core.TRANSACTION_DUMMY_WRITE;
 
 public abstract class RocksStorage implements Storage {
 
@@ -274,6 +275,7 @@ public abstract class RocksStorage implements Storage {
 
         public void commit() throws RocksDBException {
             // We disable RocksDB indexing of uncommitted writes, as we're only about to write and never again reading
+            storageTransaction.putUntracked(TRANSACTION_DUMMY_WRITE.bytes().getBytes(), EMPTY_ARRAY.getBytes());
             // TODO: We should benchmark this
             storageTransaction.disableIndexing();
             storageTransaction.commit();

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -54,7 +54,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILL
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.RESOURCE_CLOSED;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_DATA_READ_VIOLATION;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_SCHEMA_READ_VIOLATION;
-import static com.vaticle.typedb.core.graph.common.Encoding.System.Core.TRANSACTION_DUMMY_WRITE;
+import static com.vaticle.typedb.core.graph.common.Encoding.System.TRANSACTION_DUMMY_WRITE;
 
 public abstract class RocksStorage implements Storage {
 


### PR DESCRIPTION
## What is the goal of this PR?

As of #6306, Attribute PUT operations do a `read` before doing a `write` to rocksDB. We can harness this to only add a attribute PUT count job if the attribute is actually new, dramatically reducing the number of background count operations the statistics thread has to perform. 

This leads to an ACID bug where doing true attribute PUT leads to no actual writes on RocksDB, and therefore no storage version range against which to check for concurrent commits. We fix this by always writing at least one key to RocksDB per write transaction.


## What are the changes implemented in this PR?

* use the `isPersisted()` flag on an attribute vertex to only add a count job when putting an attribute that is actually brand new
* Always write a dummy key when committing a storage transaction. This guarantees that the RocksDB sequence number will increment and lead to a non-zero range that we can use for doing key-conflict detection and guaranteeing ACID safety.

Example of the problematic ACID case when statistics is writing fewer keys and no longer hiding this bug:
1. `name "Alice"` already exists in the storage, which is at sequence number 10
2. open write tx, put `name "Alice"`, commit. After commit, we are still at storage sequence number 10
3. open a write tx, delete `name "Alice"`. commit. This leads to a a conflict, because we opened a transaction at version 10 and a storage committed after or equal to version 10. However, it is not expected to fail due to using serialised transactions!

This becomes a non-issue if the sequence number always increments by at least one, because the second transaction opens at version 11. Then we can use the logic of checking only against storages that are committed greater than a version 10 (rather than equal to as well)

* To implement the dummy write we create a new `Encoding` prefix `System` and namespace `System` for future system-level operations
* Reserve a range of prefixes for use externally (eg. cluster).