### PR TITLE
Address RocksDB iterator assertion error due to no keys

### DIFF
--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -223,6 +223,7 @@ public abstract class RocksStorage implements Storage {
                 deleteCloseSchemaWriteLock.readLock().lock();
                 if (!isOpen()) throw TypeDBException.of(RESOURCE_CLOSED);
                 iterator.seekForPrev(upperBound);
+                if (!iterator.isValid()) return null;
                 byte[] key = iterator.key();
                 ByteArray array;
                 if (key != null && (array = ByteArray.of(key)).hasPrefix(prefix)) return array;


### PR DESCRIPTION
## What is the goal of this PR?

When RocksDB -dev is enabled (ie with its own assertions), tests (notable `BasicTest`) fail when re-opening a RocksDB database. This is caused by syncing our key generator, which relies on a rocks iterator's `seekForPrev()` call. We get an invalid iterator back when there are 0 keys in RocksDB, which is only a RocksDB error when development JNI is in use. We solve this by adding an `isValid()` check after doing `seekForPrev()`


## What are the changes implemented in this PR?

* if the iterator is invalid when calling `seekForPrev()`, we return null
