### PR TITLE
Reduce traversal and resolver caches memory overhead

### DIFF
--- a/common/cache/CommonCache.java
+++ b/common/cache/CommonCache.java
@@ -28,11 +28,11 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 public class CommonCache<KEY, VALUE> {
 
     protected static final int CACHE_SIZE = 10_000; // TODO: parameterise this through typedb.properties
-    protected static final int CACHE_TIMEOUT_DAY = 1_440;
+    protected static final int CACHE_TIMEOUT_MINUTES = 1_440;
     private final Cache<KEY, VALUE> cache;
 
     public CommonCache() {
-        this(CACHE_SIZE, CACHE_TIMEOUT_DAY);
+        this(CACHE_SIZE, CACHE_TIMEOUT_MINUTES);
     }
 
     public CommonCache(int size, int timeoutMinutes) {

--- a/common/cache/CommonCache.java
+++ b/common/cache/CommonCache.java
@@ -18,6 +18,7 @@
 
 package com.vaticle.typedb.core.common.cache;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
 import java.util.function.Function;
@@ -26,12 +27,12 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class CommonCache<KEY, VALUE> {
 
-    private static final int CACHE_SIZE = 10_000; // TODO: parameterise this through typedb.properties
-    private static final int CACHE_TIMEOUT_MINUTES = 1_440;
-    private final com.github.benmanes.caffeine.cache.Cache<KEY, VALUE> cache;
+    protected static final int CACHE_SIZE = 10_000; // TODO: parameterise this through typedb.properties
+    protected static final int CACHE_TIMEOUT_DAY = 1_440;
+    private final Cache<KEY, VALUE> cache;
 
     public CommonCache() {
-        this(CACHE_SIZE, CACHE_TIMEOUT_MINUTES);
+        this(CACHE_SIZE, CACHE_TIMEOUT_DAY);
     }
 
     public CommonCache(int size, int timeoutMinutes) {

--- a/logic/LogicCache.java
+++ b/logic/LogicCache.java
@@ -20,15 +20,15 @@ package com.vaticle.typedb.core.logic;
 
 import com.vaticle.typedb.core.common.cache.CommonCache;
 import com.vaticle.typedb.core.common.parameters.Label;
-import com.vaticle.typedb.core.traversal.Traversal;
 import com.vaticle.typedb.core.traversal.common.Identifier;
+import com.vaticle.typedb.core.traversal.structure.Structure;
 
 import java.util.Map;
 import java.util.Set;
 
 public class LogicCache {
 
-    private CommonCache<Traversal, Map<Identifier.Variable.Retrievable, Set<Label>>> typeResolverCache;
+    private CommonCache<Structure, Map<Identifier.Variable.Retrievable, Set<Label>>> typeResolverCache;
     private CommonCache<String, Rule> ruleCache;
 
     public LogicCache() {
@@ -41,7 +41,7 @@ public class LogicCache {
         this.typeResolverCache = new CommonCache<>(size, timeOutMinutes);
     }
 
-    public CommonCache<Traversal, Map<Identifier.Variable.Retrievable, Set<Label>>> resolver() { return typeResolverCache; }
+    public CommonCache<Structure, Map<Identifier.Variable.Retrievable, Set<Label>>> resolver() { return typeResolverCache; }
 
     CommonCache<String, Rule> rule() { return ruleCache; }
 }

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -182,9 +182,9 @@ public class TypeResolver {
     }
 
     private Map<Identifier.Variable.Retrievable, Set<Label>> executeTypeResolvers(TraversalBuilder traversalBuilder) {
-        return logicCache.resolver().get(traversalBuilder.traversal(), traversal -> {
+        return logicCache.resolver().get(traversalBuilder.traversal().structure(), structure -> {
             Map<Identifier.Variable.Retrievable, Set<Label>> mapping = new HashMap<>();
-            traversalEng.iterator(traversal, true)
+            traversalEng.iterator(traversalBuilder.traversal(), true)
                     // TODO: This filter should not be needed if we enforce traversal only to return non-abstract
                     .filter(result -> !containsAbstractThing(result, traversalBuilder))
                     .forEachRemaining(

--- a/traversal/TraversalCache.java
+++ b/traversal/TraversalCache.java
@@ -25,7 +25,7 @@ import com.vaticle.typedb.core.traversal.structure.Structure;
 public class TraversalCache extends CommonCache<Structure, Planner> {
 
     public TraversalCache() {
-        super(500, CACHE_TIMEOUT_DAY);
+        super(500, CACHE_TIMEOUT_MINUTES);
     }
 
     public TraversalCache(int size, int timeOutMinutes) {

--- a/traversal/TraversalCache.java
+++ b/traversal/TraversalCache.java
@@ -25,7 +25,7 @@ import com.vaticle.typedb.core.traversal.structure.Structure;
 public class TraversalCache extends CommonCache<Structure, Planner> {
 
     public TraversalCache() {
-        super();
+        super(500, CACHE_TIMEOUT_DAY);
     }
 
     public TraversalCache(int size, int timeOutMinutes) {

--- a/traversal/TraversalEngine.java
+++ b/traversal/TraversalEngine.java
@@ -60,9 +60,10 @@ public class TraversalEngine {
         return iterator(traversal, false);
     }
 
-    public FunctionalIterator<VertexMap> iterator(Traversal traversal, boolean extraPlanningTime) {
-        traversal.initialise(cache);
-        return traversal.iterator(graphMgr, extraPlanningTime);
+    public FunctionalIterator<VertexMap> iterator(Traversal traversal, boolean singleUse) {
+        if (singleUse) traversal.initialise();
+        else traversal.initialise(cache);
+        return traversal.iterator(graphMgr, singleUse);
     }
 
     public FunctionalIterator<VertexMap> iterator(GraphProcedure procedure, Traversal.Parameters params) {

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -328,18 +328,18 @@ public class GraphPlanner implements Planner {
         solver.setHint(new MPVariable[]{}, new double[]{});
     }
 
-    void mayOptimise(GraphManager graph, boolean extraTime) {
+    void mayOptimise(GraphManager graph, boolean singleUse) {
         if (procedure == null) {
             try {
                 firstOptimisingLock.writeLock().lock();
-                if (procedure == null) optimise(graph, extraTime);
+                if (procedure == null) optimise(graph, singleUse);
                 assert procedure != null;
             } finally {
                 firstOptimisingLock.writeLock().unlock();
             }
         } else if (isOptimising.compareAndSet(false, true)) {
             try {
-                optimise(graph, extraTime);
+                optimise(graph, singleUse);
             } finally {
                 isOptimising.set(false);
             }
@@ -347,7 +347,7 @@ public class GraphPlanner implements Planner {
     }
 
     @SuppressWarnings("NonAtomicOperationOnVolatileField")
-    private void optimise(GraphManager graph, boolean extraTime) {
+    private void optimise(GraphManager graph, boolean singleUse) {
         updateObjective(graph);
         if (isUpToDate() && isOptimal()) {
             if (LOG.isDebugEnabled()) LOG.debug("GraphPlanner still optimal and up-to-date");
@@ -355,7 +355,7 @@ public class GraphPlanner implements Planner {
         }
 
         // TODO: we should have a more clever logic to allocate extra time
-        long allocatedDuration = extraTime ? HIGHER_TIME_LIMIT_MILLIS : DEFAULT_TIME_LIMIT_MILLIS;
+        long allocatedDuration = singleUse ? HIGHER_TIME_LIMIT_MILLIS : DEFAULT_TIME_LIMIT_MILLIS;
         Instant start, endSolver, end;
         totalDuration += allocatedDuration;
         solver.setTimeLimit(totalDuration);

--- a/traversal/planner/Planner.java
+++ b/traversal/planner/Planner.java
@@ -30,8 +30,8 @@ public interface Planner {
 
     Procedure procedure();
 
-    default void tryOptimise(GraphManager graphMgr, boolean extraTime) {
-        if (isGraph()) this.asGraph().mayOptimise(graphMgr, extraTime);
+    default void tryOptimise(GraphManager graphMgr, boolean singleUse) {
+        if (isGraph()) this.asGraph().mayOptimise(graphMgr, singleUse);
     }
 
     static Planner create(Structure structure) {


### PR DESCRIPTION
## What is the goal of this PR?

The type resolver and traversal caches with size 10k each can occupy a lot of native memory (non-heap) via the MP solver objects. The type resolver traversals are no longer cached and traversal cache is limited to 500 plans.

## What are the changes implemented in this PR?

* limit traversal cache to size 500
* type resolver cache stores `Structure` not `Traversal` objects, allowing the planner objects to be garbage collected