### PR TITLE
Assert graph planner objective exists

### DIFF
--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -257,11 +257,11 @@ public class GraphPlanner implements Planner {
 
     private void updateObjective(GraphManager graph) {
         if (snapshot < graph.data().stats().snapshot()) {
-            snapshot = graph.data().stats().snapshot();
             totalCostNext = 0.1;
             setBranchingFactor(graph);
             setCostExponentUnit(graph);
             computeTotalCostNext(graph);
+            snapshot = graph.data().stats().snapshot();
             hasObjective = true;
 
             assert !Double.isNaN(totalCostNext) && !Double.isNaN(totalCostLastRecorded) && totalCostLastRecorded > 0;

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -85,6 +85,7 @@ public class GraphPlanner implements Planner {
     private volatile boolean isUpToDate;
     private volatile long totalDuration;
     private volatile long snapshot;
+    private volatile boolean hasObjective;
 
     volatile double totalCostLastRecorded;
     double totalCostNext;
@@ -109,6 +110,7 @@ public class GraphPlanner implements Planner {
         branchingFactor = 0.01;
         costExponentUnit = 0.1;
         snapshot = -1L;
+        hasObjective = false;
     }
 
     static GraphPlanner create(Structure structure) {
@@ -260,6 +262,7 @@ public class GraphPlanner implements Planner {
             setBranchingFactor(graph);
             setCostExponentUnit(graph);
             computeTotalCostNext(graph);
+            hasObjective = true;
 
             assert !Double.isNaN(totalCostNext) && !Double.isNaN(totalCostLastRecorded) && totalCostLastRecorded > 0;
             if (totalCostNext / totalCostLastRecorded >= OBJECTIVE_PLANNER_COST_MAX_CHANGE) setOutOfDate();
@@ -270,6 +273,7 @@ public class GraphPlanner implements Planner {
                 setInitialValues();
             }
         }
+        assert hasObjective;
         if (LOG.isTraceEnabled()) LOG.trace(solver.exportModelAsLpFormat());
     }
 
@@ -377,6 +381,7 @@ public class GraphPlanner implements Planner {
 
     private void throwPlanningError() {
         LOG.error(toString());
+        LOG.error("Optimisation status: {}", resultStatus);
         LOG.error(solver.exportModelAsLpFormat());
         throw TypeDBException.of(UNEXPECTED_PLANNING_ERROR);
     }

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -273,7 +273,7 @@ public class GraphPlanner implements Planner {
                 setInitialValues();
             }
         }
-        assert hasObjective;
+        assert hasObjective : String.format("Failed to set objective function. Planner snapshot: %d; statistics snapshot: %d", snapshot, graph.data().stats().snapshot());
         if (LOG.isTraceEnabled()) LOG.trace(solver.exportModelAsLpFormat());
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

Assert that a query plan must have an objective function after updating the objective exists -- this should help catch a bug in grabl.

## What are the changes implemented in this PR?

* add an assertion to ensure that query planning does not have an empty objective