### PR TITLE
Upgrade to vaticle/typedb-protocol

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -42,7 +42,7 @@ def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/vaticle/typedb-protocol",
-        tag = "2.1.2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        commit = "008f0fc3bb11c221214a9b47899168680cf111be", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():


### PR DESCRIPTION
## What is the goal of this PR?

Bump TypeDB Protocol to the latest `master` to include feature needed in TypeDB Cluster.

## What are the changes implemented in this PR?

Bump `typedb-protocol` to latest commit on `master`