### PR TITLE
Set/unset abstract checks if already abstract

### DIFF
--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -99,17 +99,21 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
 
     @Override
     public void setAbstract() {
-        validateIsNotDeleted();
-        if (getInstances().first().isPresent()) {
-            throw exception(TypeDBException.of(TYPE_HAS_INSTANCES_SET_ABSTRACT, getLabel()));
+        if (!isAbstract()) {
+            validateIsNotDeleted();
+            if (getInstances().first().isPresent()) {
+                throw exception(TypeDBException.of(TYPE_HAS_INSTANCES_SET_ABSTRACT, getLabel()));
+            }
+            vertex.isAbstract(true);
         }
-        vertex.isAbstract(true);
     }
 
     @Override
     public void unsetAbstract() {
-        validateIsNotDeleted();
-        vertex.isAbstract(false);
+        if (isAbstract()) {
+            validateIsNotDeleted();
+            vertex.isAbstract(false);
+        }
     }
 
     @Nullable


### PR DESCRIPTION
## What is the goal of this PR?

To make loading a schema that contains `abstract` idempotent, we first check whether a type is already abstract before trying to set it abstract, and the opposite for unsetting abstractness.

## What are the changes implemented in this PR?

* only set abstract if not abstract
* only unset abstract if abstract
