### PR TITLE
Fix TypeQL parser error messages being duplicated

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typeql_lang_java():
     git_repository(
         name = "vaticle_typeql_lang_java",
         remote = "https://github.com/vaticle/typeql-lang-java",
-        commit = "120ce84bbfcdcde3213b3894af258a9814870606", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
+        commit = "cf36798434f592fd64bc89daf0dc704d3cac4416", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typeql_lang_java():
     git_repository(
         name = "vaticle_typeql_lang_java",
         remote = "https://github.com/vaticle/typeql-lang-java",
-        commit = "c4ecdf860ff05ad8dc053b8746761eba4bb4e49b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
+        commit = "120ce84bbfcdcde3213b3894af258a9814870606", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql_lang_java
     )
 
 def vaticle_typedb_common():

--- a/server/common/ResponseBuilder.java
+++ b/server/common/ResponseBuilder.java
@@ -71,7 +71,7 @@ public class ResponseBuilder {
             return (StatusRuntimeException) e;
         } else {
             return Status.INTERNAL.withDescription(
-                    e.getMessage() + " Please check server logs for the stack trace."
+                    e.getMessage() + "\n\nPlease check server logs for the stack trace."
             ).asRuntimeException();
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

Previously, when parsing a query failed with an error, on converting the resulting error object to a string, the string would contain two copies of the error message - e.g:
```
[GQL03] TypeQL Error: There is a syntax error at line 1:
match $x sb thing;
         ^
no viable alternative at input 'match $x sb'
[GQL03] TypeQL Error: There is a syntax error at line 1:
match $x sb thing;
         ^
no viable alternative at input 'match $x sb'
```
This is now fixed and error messages are no longer duplicated.

Also, for ease of reading, two newlines now separate "Please check server logs for the stack trace" from the actual error when any error is thrown.

## What are the changes implemented in this PR?

- Update typeql-lang-java (fixes typeql parser error messages being duplicated)
- Two newlines now separate "Please check server logs for the stack trace" from the actual error when any error is thrown
