### PR TITLE
Refactor Reasoner Concludable Actor

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -99,8 +99,8 @@ build:
     test-behaviour-reasoner:
       image: vaticle-ubuntu-20.04
       command: |
-        export DEFAULT_JVM_DEBUG_PORT="*:5005"
-        bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed --java_debug --spawn_strategy=standalone
+        # export DEFAULT_JVM_DEBUG_PORT="*:5005"
+        # bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed --java_debug --spawn_strategy=standalone
         bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/relation_inference:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/rule_interaction:test --test_output=streamed

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -99,7 +99,7 @@ build:
     test-behaviour-reasoner:
       image: vaticle-ubuntu-20.04
       command: |
-        bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed
+        bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed --java_debug
         bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/relation_inference:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/rule_interaction:test --test_output=streamed

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -99,7 +99,7 @@ build:
     test-behaviour-reasoner:
       image: vaticle-ubuntu-20.04
       command: |
-        bazel --host_jvm_args="-Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005" test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed
+        bazel --host_jvm_args=-Xdebug --host_jvm_args=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005" test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/relation_inference:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/rule_interaction:test --test_output=streamed

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -99,7 +99,7 @@ build:
     test-behaviour-reasoner:
       image: vaticle-ubuntu-20.04
       command: |
-        bazel --host_jvm_args=-Xdebug --host_jvm_args=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005" test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed
+        bazel --host_jvm_args="-Xdebug" --host_jvm_args="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005" test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed --cache_test_results=false --java_debug
         bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/relation_inference:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/rule_interaction:test --test_output=streamed

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -100,7 +100,7 @@ build:
       image: vaticle-ubuntu-20.04
       command: |
         export DEFAULT_JVM_DEBUG_PORT="*:5005"
-        bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed --java_debug
+        bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed --java_debug --spawn_strategy=standalone
         bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/relation_inference:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/rule_interaction:test --test_output=streamed

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -99,7 +99,7 @@ build:
     test-behaviour-reasoner:
       image: vaticle-ubuntu-20.04
       command: |
-        bazel test --test_arg=--jvm_flags='-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005' //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed --spawn_strategy=standalone
+        bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/relation_inference:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/rule_interaction:test --test_output=streamed

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -99,8 +99,7 @@ build:
     test-behaviour-reasoner:
       image: vaticle-ubuntu-20.04
       command: |
-        # export DEFAULT_JVM_DEBUG_PORT="*:5005"
-        # bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed --java_debug --spawn_strategy=standalone
+        bazel test --test_arg=--jvm_flags='-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005' //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed --spawn_strategy=standalone
         bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/relation_inference:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/rule_interaction:test --test_output=streamed

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -99,7 +99,8 @@ build:
     test-behaviour-reasoner:
       image: vaticle-ubuntu-20.04
       command: |
-        bazel --host_jvm_args="-Xdebug" --host_jvm_args="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005" test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed --cache_test_results=false --java_debug
+        export DEFAULT_JVM_DEBUG_PORT="*:5005"
+        bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed --java_debug
         bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/relation_inference:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/rule_interaction:test --test_output=streamed

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -99,7 +99,7 @@ build:
     test-behaviour-reasoner:
       image: vaticle-ubuntu-20.04
       command: |
-        bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed --java_debug
+        bazel --host_jvm_args="-Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005" test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/relation_inference:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/rule_interaction:test --test_output=streamed

--- a/common/poller/AbstractPoller.java
+++ b/common/poller/AbstractPoller.java
@@ -20,6 +20,7 @@ package com.vaticle.typedb.core.common.poller;
 
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static com.vaticle.typedb.common.collection.Collections.list;
 
@@ -38,6 +39,11 @@ public abstract class AbstractPoller<T> implements Poller<T> {
     @Override
     public Poller<T> link(Poller<T> poller) {
         return new LinkedPollers<>(list(this, poller));
+    }
+
+    @Override
+    public Poller<T> filter(Predicate<T> predicate) {
+        return new FilteredPoller<>(this, predicate);
     }
 
 }

--- a/common/poller/FilteredPoller.java
+++ b/common/poller/FilteredPoller.java
@@ -19,19 +19,29 @@
 package com.vaticle.typedb.core.common.poller;
 
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
-public interface Poller<T> {
+public class FilteredPoller<T> extends AbstractPoller<T> {
 
-    Optional<T> poll();
+    private final Poller<T> poller;
+    private final Predicate<T> predicate;
 
-    <U> Poller<U> flatMap(Function<T, Poller<U>> flatMappingFn);
+    public FilteredPoller(Poller<T> poller, Predicate<T> predicate) {
+        this.poller = poller;
+        this.predicate = predicate;
+    }
 
-    Poller<T> link(Poller<T> poller);
+    @Override
+    public Optional<T> poll() {
+        Optional<T> fromSource;
+        while ((fromSource = poller.poll()).isPresent()) {
+            if (predicate.test(fromSource.get())) return fromSource;
+        }
+        return Optional.empty();
+    }
 
-    Poller<T> filter(Predicate<T> predicate);
-
-    void recycle();
-
+    @Override
+    public void recycle() {
+        poller.recycle();
+    }
 }

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -140,7 +140,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     private void requestFailed(int iteration) {
         LOG.trace("Failed to find answer to request in iteration: " + iteration);
         if (options.traceInference()) ResolutionTracer.get().finish();
-        if (resolverRegistry.boundConcludableResolvers().size() == 0) {
+        if (resolverRegistry.reiterationQueryRespondents(rootResolver, iteration).size() == 0) {
             finish();
         } else if (!sentReiterationRequests && iteration == this.iteration) {
             sendReiterationRequests();
@@ -148,17 +148,27 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     }
 
     private void finish() {
-        // query is completely terminated
-        done = true;
-        queue.done();
-        required.set(0);
+        if (!done) {
+            // query is completely terminated
+            done = true;
+            queue.done();
+            required.set(0);
+        }
+    }
+
+    private void exception(Throwable e) {
+        if (!done) {
+            done = true;
+            required.set(0);
+            queue.done(e);
+        }
     }
 
     private void sendReiterationRequests() {
         assert reiterationQueryRespondents == null || reiterationQueryRespondents.isEmpty();
         sentReiterationRequests = true;
-        reiterationQueryRespondents = new HashSet<>(resolverRegistry.boundConcludableResolvers());
-        resolverRegistry.boundConcludableResolvers()
+        reiterationQueryRespondents = new HashSet<>(resolverRegistry.reiterationQueryRespondents(rootResolver, iteration));
+        resolverRegistry.reiterationQueryRespondents(rootResolver, iteration)
                 .forEach(res -> res.execute(actor -> actor.receiveReiterationQuery(reiterationRequest)));
     }
 
@@ -174,14 +184,6 @@ public class ReasonerProducer implements Producer<ConceptMap> {
             } else {
                 finish();
             }
-        }
-    }
-
-    private void exception(Throwable e) {
-        if (!done) {
-            done = true;
-            required.set(0);
-            queue.done(e);
         }
     }
 

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -33,14 +33,11 @@ import com.vaticle.typedb.core.reasoner.resolution.framework.Request;
 import com.vaticle.typedb.core.reasoner.resolution.framework.ResolutionTracer;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Resolver;
 import com.vaticle.typedb.core.traversal.common.Identifier;
-import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
-import com.vaticle.typeql.lang.query.TypeQLMatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -125,8 +122,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     }
 
     @Override
-    public void recycle() {
-    }
+    public void recycle() {}
 
     // note: root resolver calls this single-threaded, so is thread safe
     private void requestAnswered(Finished answer) {
@@ -144,7 +140,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     private void requestFailed(int iteration) {
         LOG.trace("Failed to find answer to request in iteration: " + iteration);
         if (options.traceInference()) ResolutionTracer.get().finish();
-        if (resolverRegistry.concludableResolvers().size() == 0) {
+        if (resolverRegistry.boundConcludableResolvers().size() == 0) {
             finish();
         } else if (!sentReiterationRequests && iteration == this.iteration) {
             sendReiterationRequests();
@@ -161,8 +157,8 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     private void sendReiterationRequests() {
         assert reiterationQueryRespondents == null || reiterationQueryRespondents.isEmpty();
         sentReiterationRequests = true;
-        reiterationQueryRespondents = new HashSet<>(resolverRegistry.concludableResolvers());
-        resolverRegistry.concludableResolvers()
+        reiterationQueryRespondents = new HashSet<>(resolverRegistry.boundConcludableResolvers());
+        resolverRegistry.boundConcludableResolvers()
                 .forEach(res -> res.execute(actor -> actor.receiveReiterationQuery(reiterationRequest)));
     }
 

--- a/reasoner/resolution/ResolverRegistry.java
+++ b/reasoner/resolution/ResolverRegistry.java
@@ -194,7 +194,7 @@ public class ResolverRegistry {
     public Actor.Driver<BoundRetrievableResolver> registerBoundRetrievable(Retrievable retrievable, ConceptMap bounds) {
         LOG.debug("Register BoundRetrievableResolver, pattern: {} bounds: {}", retrievable.pattern(), bounds);
         Actor.Driver<BoundRetrievableResolver> resolver = Actor.driver(driver -> new BoundRetrievableResolver(
-                retrievable, bounds, driver, this, traversalEngine, conceptMgr, resolutionTracing
+                driver, retrievable, bounds, this, traversalEngine, conceptMgr, resolutionTracing
         ), executorService);
         resolvers.add(resolver);
         if (terminated.get()) throw TypeDBException.of(RESOLUTION_TERMINATED); // guard races without synchronized

--- a/reasoner/resolution/ResolverRegistry.java
+++ b/reasoner/resolution/ResolverRegistry.java
@@ -21,6 +21,7 @@ package com.vaticle.typedb.core.reasoner.resolution;
 import com.vaticle.typedb.common.collection.ConcurrentSet;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.concept.ConceptManager;
+import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.concurrent.actor.Actor;
 import com.vaticle.typedb.core.concurrent.actor.ActorExecutorGroup;
 import com.vaticle.typedb.core.logic.LogicManager;
@@ -28,12 +29,14 @@ import com.vaticle.typedb.core.logic.Rule;
 import com.vaticle.typedb.core.logic.resolvable.Concludable;
 import com.vaticle.typedb.core.logic.resolvable.Negated;
 import com.vaticle.typedb.core.logic.resolvable.Resolvable;
+import com.vaticle.typedb.core.logic.resolvable.Retrievable;
 import com.vaticle.typedb.core.pattern.Conjunction;
 import com.vaticle.typedb.core.pattern.Disjunction;
 import com.vaticle.typedb.core.pattern.equivalence.AlphaEquivalence;
 import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState.Top.Explain;
 import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState.Top.Match;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Resolver;
+import com.vaticle.typedb.core.reasoner.resolution.resolver.BoundRetrievableResolver;
 import com.vaticle.typedb.core.reasoner.resolution.resolver.ConcludableResolver;
 import com.vaticle.typedb.core.reasoner.resolution.resolver.ConclusionResolver;
 import com.vaticle.typedb.core.reasoner.resolution.resolver.ConditionResolver;
@@ -186,6 +189,16 @@ public class ResolverRegistry {
         resolvers.add(resolver);
         if (terminated.get()) throw TypeDBException.of(RESOLUTION_TERMINATED); // guard races without synchronized
         return ResolverView.retrievable(resolver, retrievable.retrieves());
+    }
+
+    public Actor.Driver<BoundRetrievableResolver> registerBoundRetrievable(Retrievable retrievable, ConceptMap bounds) {
+        LOG.debug("Register BoundRetrievableResolver, pattern: {} bounds: {}", retrievable.pattern(), bounds);
+        Actor.Driver<BoundRetrievableResolver> resolver = Actor.driver(driver -> new BoundRetrievableResolver(
+                retrievable, bounds, driver, this, traversalEngine, conceptMgr, resolutionTracing
+        ), executorService);
+        resolvers.add(resolver);
+        if (terminated.get()) throw TypeDBException.of(RESOLUTION_TERMINATED); // guard races without synchronized
+        return resolver;
     }
 
     // note: must be thread safe. We could move to a ConcurrentHashMap if we create an alpha-equivalence wrapper

--- a/reasoner/resolution/answer/AnswerState.java
+++ b/reasoner/resolution/answer/AnswerState.java
@@ -450,6 +450,8 @@ public interface AnswerState {
 
             P aggregateToUpstream(ConceptMap concepts);
 
+            Retrievable<P> with(ConceptMap extension);
+
             @Override
             default boolean isRetrievable() { return true; }
 

--- a/reasoner/resolution/answer/AnswerStateImpl.java
+++ b/reasoner/resolution/answer/AnswerStateImpl.java
@@ -1004,6 +1004,11 @@ public abstract class AnswerStateImpl implements AnswerState {
             }
 
             @Override
+            public Retrievable<P> with(ConceptMap extension) {
+                return new RetrievableImpl<>(filter, parent(), extendAnswer(extension), root());
+            }
+
+            @Override
             public boolean equals(Object o) {
                 if (this == o) return true;
                 if (o == null || getClass() != o.getClass()) return false;

--- a/reasoner/resolution/framework/AnswerCache.java
+++ b/reasoner/resolution/framework/AnswerCache.java
@@ -199,6 +199,10 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
             return true;
         }
 
+        public ConcludableAnswerCache asConcludableAnswerCache() {
+            return this;
+        }
+
         @Override
         protected List<ConceptMap> answers() {
             return iterate(answers).map(AnswerState::conceptMap).distinct().toList();

--- a/reasoner/resolution/framework/AnswerCache.java
+++ b/reasoner/resolution/framework/AnswerCache.java
@@ -131,7 +131,7 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
         if (index < answers.size()) {
             return Optional.of(answers.get(index));
         } else if (index == answers.size()) {
-            if (isComplete() || sourceExhausted()) return Optional.empty();
+            if (isComplete()) return Optional.empty();
             Optional<ANSWER> nextAnswer = searchForAnswer(index, isSubscriber);
             if (nextAnswer.isEmpty() && isSubscriber) reiterateOnAnswerAdded = true;
             return nextAnswer;

--- a/reasoner/resolution/framework/AnswerCache.java
+++ b/reasoner/resolution/framework/AnswerCache.java
@@ -76,6 +76,7 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
     }
 
     public void clearSource() {
+        answerSource.recycle();
         answerSource = empty();
     }
 

--- a/reasoner/resolution/framework/AnswerCache.java
+++ b/reasoner/resolution/framework/AnswerCache.java
@@ -70,12 +70,12 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
         if (addIfAbsent(answer) && reiterateOnAnswerAdded) requiresReiteration = true;
     }
 
-    public void addSource(FunctionalIterator<ANSWER> newAnswers) {
+    public void addToSource(FunctionalIterator<ANSWER> newAnswers) {
         assert !isComplete();
         answerSource = answerSource.link(poll(newAnswers));
     }
 
-    public void clearSources() {
+    public void clearSource() {
         answerSource = empty();
     }
 
@@ -127,10 +127,10 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
     }
 
     protected Optional<ANSWER> searchForAnswer(int index, boolean mayReadOverEagerly) {
-        return searchUnexploredForAnswer();
+        return searchSourceForAnswer();
     }
 
-    protected Optional<ANSWER> searchUnexploredForAnswer() {
+    protected Optional<ANSWER> searchSourceForAnswer() {
         Optional<ANSWER> answer;
         while ((answer = answerSource.poll()).isPresent()) {
             if (addIfAbsent(answer.get())) {
@@ -229,7 +229,7 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
             if (completeIfSubsumerComplete()) {
                 return get(index, mayReadOverEagerly);
             } else {
-                return searchUnexploredForAnswer();
+                return searchSourceForAnswer();
             }
         }
 

--- a/reasoner/resolution/framework/AnswerCache.java
+++ b/reasoner/resolution/framework/AnswerCache.java
@@ -22,7 +22,6 @@ import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.poller.AbstractPoller;
 import com.vaticle.typedb.core.common.poller.Poller;
-import com.vaticle.typedb.core.common.poller.Pollers;
 import com.vaticle.typedb.core.concept.Concept;
 import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState;
@@ -41,6 +40,7 @@ import java.util.Set;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
+import static com.vaticle.typedb.core.common.poller.Pollers.empty;
 import static com.vaticle.typedb.core.common.poller.Pollers.poll;
 
 public abstract class AnswerCache<ANSWER, SUBSUMES> {
@@ -57,7 +57,7 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
     protected AnswerCache(Map<SUBSUMES, ? extends AnswerCache<?, SUBSUMES>> cacheRegister, ConceptMap state) {
         this.cacheRegister = cacheRegister;
         this.state = state;
-        this.answerSource = Pollers.empty();
+        this.answerSource = empty();
         this.answers = new ArrayList<>(); // TODO: Replace answer list and deduplication set with a bloom filter
         this.answersSet = new HashSet<>();
         this.reiterateOnAnswerAdded = false;
@@ -73,6 +73,10 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
     public void addSource(FunctionalIterator<ANSWER> newAnswers) {
         assert !isComplete();
         answerSource = answerSource.link(poll(newAnswers));
+    }
+
+    public void clearSources() {
+        answerSource = empty();
     }
 
     public Poller<ANSWER> reader(boolean isSubscriber) {

--- a/reasoner/resolution/framework/AnswerCache.java
+++ b/reasoner/resolution/framework/AnswerCache.java
@@ -46,7 +46,7 @@ import static com.vaticle.typedb.core.common.poller.Pollers.poll;
 public abstract class AnswerCache<ANSWER, SUBSUMES> {
 
     protected final List<ANSWER> answers;
-    private final Set<ANSWER> answersSet;
+    protected final Set<ANSWER> answersSet;
     protected boolean reiterateOnAnswerAdded;
     protected boolean requiresReiteration;
     protected Poller<ANSWER> answerSource;
@@ -292,7 +292,7 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
             }
 
             @Override
-            protected boolean subsumes(ConceptMap conceptMap, ConceptMap contained) {
+            public boolean subsumes(ConceptMap conceptMap, ConceptMap contained) {
                 return conceptMap.concepts().entrySet().containsAll(contained.concepts().entrySet());
             }
         }

--- a/reasoner/resolution/framework/AnswerCache.java
+++ b/reasoner/resolution/framework/AnswerCache.java
@@ -102,7 +102,7 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
         if (answerSource != null) answerSource.recycle();
     }
 
-    public boolean isSourceExhausted() {
+    public boolean sourceExhausted() {
         return sourceExhausted;
     }
 
@@ -131,7 +131,7 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
         if (index < answers.size()) {
             return Optional.of(answers.get(index));
         } else if (index == answers.size()) {
-            if (isComplete()) return Optional.empty();
+            if (isComplete() || sourceExhausted()) return Optional.empty();
             Optional<ANSWER> nextAnswer = searchForAnswer(index, isSubscriber);
             if (nextAnswer.isEmpty() && isSubscriber) reiterateOnAnswerAdded = true;
             return nextAnswer;

--- a/reasoner/resolution/framework/AnswerCache.java
+++ b/reasoner/resolution/framework/AnswerCache.java
@@ -46,7 +46,7 @@ import static com.vaticle.typedb.core.common.poller.Pollers.poll;
 public abstract class AnswerCache<ANSWER, SUBSUMES> {
 
     protected final List<ANSWER> answers;
-    protected final Set<ANSWER> answersSet;
+    private final Set<ANSWER> answersSet;
     protected boolean reiterateOnAnswerAdded;
     protected boolean requiresReiteration;
     protected Poller<ANSWER> answerSource;
@@ -292,7 +292,7 @@ public abstract class AnswerCache<ANSWER, SUBSUMES> {
             }
 
             @Override
-            public boolean subsumes(ConceptMap conceptMap, ConceptMap contained) {
+            protected boolean subsumes(ConceptMap conceptMap, ConceptMap contained) {
                 return conceptMap.concepts().entrySet().containsAll(contained.concepts().entrySet());
             }
         }

--- a/reasoner/resolution/framework/ReiterationQuery.java
+++ b/reasoner/resolution/framework/ReiterationQuery.java
@@ -19,7 +19,7 @@
 package com.vaticle.typedb.core.reasoner.resolution.framework;
 
 import com.vaticle.typedb.core.concurrent.actor.Actor.Driver;
-import com.vaticle.typedb.core.reasoner.resolution.resolver.ConcludableResolver;
+import com.vaticle.typedb.core.reasoner.resolution.resolver.BoundConcludableResolver;
 
 import java.util.function.Consumer;
 
@@ -50,18 +50,18 @@ public class ReiterationQuery {
     public static class Response {
 
         private final boolean reiterate;
-        private final Driver<ConcludableResolver> sender;
+        private final Driver<BoundConcludableResolver> sender;
 
-        private Response(Driver<ConcludableResolver> sender, boolean reiterate) {
+        private Response(Driver<BoundConcludableResolver> sender, boolean reiterate) {
             this.reiterate = reiterate;
             this.sender = sender;
         }
 
-        public static Response create(Driver<ConcludableResolver> driver, boolean reiterate) {
+        public static Response create(Driver<BoundConcludableResolver> driver, boolean reiterate) {
             return new Response(driver, reiterate);
         }
 
-        public Driver<ConcludableResolver> sender() {
+        public Driver<BoundConcludableResolver> sender() {
             return sender;
         }
 

--- a/reasoner/resolution/framework/Request.java
+++ b/reasoner/resolution/framework/Request.java
@@ -18,50 +18,44 @@
 
 package com.vaticle.typedb.core.reasoner.resolution.framework;
 
+import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.concurrent.actor.Actor;
 import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState.Partial;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
-import java.util.Optional;
+
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 
 // TODO: add compute mode: single vs all (for negation vs regular)
 public class Request {
 
-    private final Actor.Driver<? extends Resolver<?>> sender;
-    private final Actor.Driver<? extends Resolver<?>> receiver;
-    private final Partial<?> partialAnswer;
-    private final int planIndex;
-    private final Actor.Driver<? extends Resolver<?>> subsumer; // TODO: This should be a separate subclass of request
+    protected final Actor.Driver<? extends Resolver<?>> sender;
+    protected final Actor.Driver<? extends Resolver<?>> receiver;
+    protected final Partial<?> partialAnswer;
+    protected final int planIndex;
 
     private final int hash;
 
     private Request(@Nullable Actor.Driver<? extends Resolver<?>> sender, Actor.Driver<? extends Resolver<?>> receiver,
-                    @Nullable Actor.Driver<? extends Resolver<?>> subsumer, Partial<?> partialAnswer, int planIndex) {
+                    Partial<?> partialAnswer, int planIndex) {
         this.sender = sender;
         this.receiver = receiver;
         this.partialAnswer = partialAnswer;
         this.planIndex = planIndex;
-        this.subsumer = subsumer;
-        this.hash = Objects.hash(this.sender, this.receiver, this.subsumer, this.partialAnswer);
+        this.hash = Objects.hash(this.sender, this.receiver, this.partialAnswer);
     }
 
     public static Request create(Actor.Driver<? extends Resolver<?>> sender, Actor.Driver<? extends Resolver<?>> receiver, Partial<?> partialAnswer, int planIndex) {
-        return new Request(sender, receiver, null, partialAnswer, planIndex);
+        return new Request(sender, receiver, partialAnswer, planIndex);
     }
 
     public static Request create(Actor.Driver<? extends Resolver<?>> sender, Actor.Driver<? extends Resolver<?>> receiver, Partial<?> partialAnswer) {
-        return new Request(sender, receiver, null, partialAnswer, -1);
-    }
-
-    public static Request create(Actor.Driver<? extends Resolver<?>> sender,
-                                 Actor.Driver<? extends Resolver<?>> receiver,
-                                 Actor.Driver<? extends Resolver<?>> subsumer, Partial<?> partialAnswer) {
-        return new Request(sender, receiver, subsumer, partialAnswer, -1);
+        return new Request(sender, receiver, partialAnswer, -1);
     }
 
     public static Request create(Actor.Driver<? extends Resolver<?>> receiver, Partial<?> partialAnswer) {
-        return new Request(null, receiver, null, partialAnswer, -1);
+        return new Request(null, receiver, partialAnswer, -1);
     }
 
     public Actor.Driver<? extends Resolver<?>> receiver() {
@@ -70,10 +64,6 @@ public class Request {
 
     public Actor.Driver<? extends Resolver<?>> sender() {
         return sender;
-    }
-
-    public Optional<Actor.Driver<? extends Resolver<?>>> subsumer() {
-        return Optional.ofNullable(subsumer);
     }
 
     public Partial<?> partialAnswer() {
@@ -91,7 +81,6 @@ public class Request {
         Request request = (Request) o;
         return Objects.equals(sender, request.sender) &&
                 Objects.equals(receiver, request.receiver) &&
-                Objects.equals(subsumer, request.subsumer) &&
                 Objects.equals(partialAnswer, request.partialAnswer());
     }
 
@@ -105,9 +94,125 @@ public class Request {
         return "Request{" +
                 "sender=" + sender +
                 ", receiver=" + receiver +
-                ", subsumer=" + subsumer +
                 ", partial=" + partialAnswer +
                 '}';
+    }
+
+    public boolean isToSubsumed() {
+        return false;
+    }
+
+    public ToSubsumed asToSubsumed() {
+        throw TypeDBException.of(ILLEGAL_STATE);
+    }
+
+    public boolean isToSubsumer() {
+        return false;
+    }
+
+    public ToSubsumer asToSubsumer() {
+        throw TypeDBException.of(ILLEGAL_STATE);
+    }
+
+    public static class ToSubsumed extends Request {
+
+        private final Actor.Driver<? extends Resolver<?>> subsumer;
+        private final int hash;
+
+        private ToSubsumed(@Nullable Actor.Driver<? extends Resolver<?>> sender,
+                           Actor.Driver<? extends Resolver<?>> receiver,
+                           @Nullable Actor.Driver<? extends Resolver<?>> subsumer, Partial<?> partialAnswer,
+                           int planIndex) {
+            super(sender, receiver, partialAnswer, planIndex);
+            this.subsumer = subsumer;
+            this.hash = Objects.hash(super.hashCode(), subsumer);
+        }
+
+        public static Request create(Actor.Driver<? extends Resolver<?>> sender,
+                                     Actor.Driver<? extends Resolver<?>> receiver,
+                                     Actor.Driver<? extends Resolver<?>> subsumer, Partial<?> partialAnswer) {
+            return new ToSubsumed(sender, receiver, subsumer, partialAnswer, -1);
+        }
+
+        public Request toRequest() {
+            return Request.create(sender, receiver, partialAnswer, planIndex);
+        }
+
+        public Actor.Driver<? extends Resolver<?>> subsumer() {
+            return subsumer;
+        }
+
+        @Override
+        public boolean isToSubsumed() {
+            return true;
+        }
+
+        @Override
+        public ToSubsumed asToSubsumed() {
+            return this;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            ToSubsumed that = (ToSubsumed) o;
+            return subsumer.equals(that.subsumer);
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+
+    }
+
+    public static class ToSubsumer extends Request {
+
+        private final ToSubsumed toSubsumed;
+        private final int hash;
+
+        private ToSubsumer(@Nullable Actor.Driver<? extends Resolver<?>> sender,
+                           Actor.Driver<? extends Resolver<?>> receiver,
+                           ToSubsumed toSubsumed, Partial<?> partialAnswer, int planIndex) {
+            super(sender, receiver, partialAnswer, planIndex);
+            this.toSubsumed = toSubsumed;
+            this.hash = Objects.hash(super.hashCode(), toSubsumed);
+        }
+
+        public static ToSubsumer create(@Nullable Actor.Driver<? extends Resolver<?>> sender, Actor.Driver<?
+                extends Resolver<?>> receiver, ToSubsumed toSubsumed, Partial<?> partialAnswer) {
+            return new ToSubsumer(sender, receiver, toSubsumed, partialAnswer, -1);
+        }
+
+        public ToSubsumed toSubsumed() {
+            return toSubsumed;
+        }
+
+        @Override
+        public boolean isToSubsumer() {
+            return true;
+        }
+
+        @Override
+        public ToSubsumer asToSubsumer() {
+            return this;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            ToSubsumer that = (ToSubsumer) o;
+            return toSubsumed.equals(that.toSubsumed);
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
     }
 
 }

--- a/reasoner/resolution/framework/Request.java
+++ b/reasoner/resolution/framework/Request.java
@@ -23,6 +23,7 @@ import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState.Partial;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
+import java.util.Optional;
 
 // TODO: add compute mode: single vs all (for negation vs regular)
 public class Request {
@@ -31,28 +32,36 @@ public class Request {
     private final Actor.Driver<? extends Resolver<?>> receiver;
     private final Partial<?> partialAnswer;
     private final int planIndex;
+    private final Actor.Driver<? extends Resolver<?>> subsumer; // TODO: This should be a separate subclass of request
 
     private final int hash;
 
     private Request(@Nullable Actor.Driver<? extends Resolver<?>> sender, Actor.Driver<? extends Resolver<?>> receiver,
-                    Partial<?> partialAnswer, int planIndex) {
+                    @Nullable Actor.Driver<? extends Resolver<?>> subsumer, Partial<?> partialAnswer, int planIndex) {
         this.sender = sender;
         this.receiver = receiver;
         this.partialAnswer = partialAnswer;
         this.planIndex = planIndex;
-        this.hash = Objects.hash(this.sender, this.receiver, this.partialAnswer);
+        this.subsumer = subsumer;
+        this.hash = Objects.hash(this.sender, this.receiver, this.subsumer, this.partialAnswer);
     }
 
     public static Request create(Actor.Driver<? extends Resolver<?>> sender, Actor.Driver<? extends Resolver<?>> receiver, Partial<?> partialAnswer, int planIndex) {
-        return new Request(sender, receiver, partialAnswer, planIndex);
+        return new Request(sender, receiver, null, partialAnswer, planIndex);
     }
 
     public static Request create(Actor.Driver<? extends Resolver<?>> sender, Actor.Driver<? extends Resolver<?>> receiver, Partial<?> partialAnswer) {
-        return new Request(sender, receiver, partialAnswer, -1);
+        return new Request(sender, receiver, null, partialAnswer, -1);
+    }
+
+    public static Request create(Actor.Driver<? extends Resolver<?>> sender,
+                                 Actor.Driver<? extends Resolver<?>> receiver,
+                                 Actor.Driver<? extends Resolver<?>> subsumer, Partial<?> partialAnswer) {
+        return new Request(sender, receiver, subsumer, partialAnswer, -1);
     }
 
     public static Request create(Actor.Driver<? extends Resolver<?>> receiver, Partial<?> partialAnswer) {
-        return new Request(null, receiver, partialAnswer, -1);
+        return new Request(null, receiver, null, partialAnswer, -1);
     }
 
     public Actor.Driver<? extends Resolver<?>> receiver() {
@@ -61,6 +70,10 @@ public class Request {
 
     public Actor.Driver<? extends Resolver<?>> sender() {
         return sender;
+    }
+
+    public Optional<Actor.Driver<? extends Resolver<?>>> subsumer() {
+        return Optional.ofNullable(subsumer);
     }
 
     public Partial<?> partialAnswer() {
@@ -78,6 +91,7 @@ public class Request {
         Request request = (Request) o;
         return Objects.equals(sender, request.sender) &&
                 Objects.equals(receiver, request.receiver) &&
+                Objects.equals(subsumer, request.subsumer) &&
                 Objects.equals(partialAnswer, request.partialAnswer());
     }
 
@@ -91,6 +105,7 @@ public class Request {
         return "Request{" +
                 "sender=" + sender +
                 ", receiver=" + receiver +
+                ", subsumer=" + subsumer +
                 ", partial=" + partialAnswer +
                 '}';
     }

--- a/reasoner/resolution/framework/Request.java
+++ b/reasoner/resolution/framework/Request.java
@@ -117,7 +117,6 @@ public class Request {
     public static class ToSubsumed extends Request {
 
         private final Actor.Driver<? extends Resolver<?>> subsumer;
-        private final int hash;
 
         private ToSubsumed(@Nullable Actor.Driver<? extends Resolver<?>> sender,
                            Actor.Driver<? extends Resolver<?>> receiver,
@@ -125,17 +124,12 @@ public class Request {
                            int planIndex) {
             super(sender, receiver, partialAnswer, planIndex);
             this.subsumer = subsumer;
-            this.hash = Objects.hash(super.hashCode(), subsumer);
         }
 
         public static Request create(Actor.Driver<? extends Resolver<?>> sender,
                                      Actor.Driver<? extends Resolver<?>> receiver,
                                      Actor.Driver<? extends Resolver<?>> subsumer, Partial<?> partialAnswer) {
             return new ToSubsumed(sender, receiver, subsumer, partialAnswer, -1);
-        }
-
-        public Request toRequest() {
-            return Request.create(sender, receiver, partialAnswer, planIndex);
         }
 
         public Actor.Driver<? extends Resolver<?>> subsumer() {
@@ -152,33 +146,17 @@ public class Request {
             return this;
         }
 
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            if (!super.equals(o)) return false;
-            ToSubsumed that = (ToSubsumed) o;
-            return subsumer.equals(that.subsumer);
-        }
-
-        @Override
-        public int hashCode() {
-            return hash;
-        }
-
     }
 
     public static class ToSubsumer extends Request {
 
         private final ToSubsumed toSubsumed;
-        private final int hash;
 
         private ToSubsumer(@Nullable Actor.Driver<? extends Resolver<?>> sender,
                            Actor.Driver<? extends Resolver<?>> receiver,
                            ToSubsumed toSubsumed, Partial<?> partialAnswer, int planIndex) {
             super(sender, receiver, partialAnswer, planIndex);
             this.toSubsumed = toSubsumed;
-            this.hash = Objects.hash(super.hashCode(), toSubsumed);
         }
 
         public static ToSubsumer create(@Nullable Actor.Driver<? extends Resolver<?>> sender, Actor.Driver<?
@@ -200,19 +178,6 @@ public class Request {
             return this;
         }
 
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            if (!super.equals(o)) return false;
-            ToSubsumer that = (ToSubsumer) o;
-            return toSubsumed.equals(that.toSubsumed);
-        }
-
-        @Override
-        public int hashCode() {
-            return hash;
-        }
     }
 
 }

--- a/reasoner/resolution/framework/RequestState.java
+++ b/reasoner/resolution/framework/RequestState.java
@@ -92,16 +92,6 @@ public abstract class RequestState {
             return ans;
         }
 
-        public Optional<? extends AnswerState.Partial<?>> nextAnswer(ConceptMap subsumptionFilter) {
-            Optional<? extends AnswerState.Partial<?>> ans = cacheReader.filter(a -> subsumes(a.conceptMap(), subsumptionFilter)).poll();
-            if (ans.isPresent() && deduplicationSet != null) deduplicationSet.add(ans.get().conceptMap());
-            return ans;
-        }
-
-        private static boolean subsumes(ConceptMap conceptMap, ConceptMap contained) {
-            return conceptMap.concepts().entrySet().containsAll(contained.concepts().entrySet());
-        }
-
         protected abstract FunctionalIterator<? extends AnswerState.Partial<?>> toUpstream(ANSWER answer);
 
         public AnswerCache<ANSWER, SUBSUMES> answerCache() {

--- a/reasoner/resolution/framework/RequestState.java
+++ b/reasoner/resolution/framework/RequestState.java
@@ -92,6 +92,16 @@ public abstract class RequestState {
             return ans;
         }
 
+        public Optional<? extends AnswerState.Partial<?>> nextAnswer(ConceptMap subsumptionFilter) {
+            Optional<? extends AnswerState.Partial<?>> ans = cacheReader.filter(a -> subsumes(a.conceptMap(), subsumptionFilter)).poll();
+            if (ans.isPresent() && deduplicationSet != null) deduplicationSet.add(ans.get().conceptMap());
+            return ans;
+        }
+
+        private static boolean subsumes(ConceptMap conceptMap, ConceptMap contained) {
+            return conceptMap.concepts().entrySet().containsAll(contained.concepts().entrySet());
+        }
+
         protected abstract FunctionalIterator<? extends AnswerState.Partial<?>> toUpstream(ANSWER answer);
 
         public AnswerCache<ANSWER, SUBSUMES> answerCache() {

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -211,10 +211,7 @@ public abstract class Resolver<RESOLVER extends Resolver<RESOLVER>> extends Acto
         }
 
         public void addDownstream(Request request) {
-             if (downstreams.contains(request)) {
-                 throw new RuntimeException(String.format("Duplicate downstream request: %s\nExisting downstreams: %s",
-                                                          request, downstreams));
-             }
+            assert !(downstreams.contains(request)) : "downstream answer producer already contains this request";
             downstreams.add(request);
             downstreamSelector = downstreams.iterator();
         }

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -203,9 +204,12 @@ public abstract class Resolver<RESOLVER extends Resolver<RESOLVER>> extends Acto
             return downstreamSelector.next();
         }
 
+        public void addDownstreams(List<Request> downstreams) {
+            downstreams.forEach(this::addDownstream);
+        }
+
         public void addDownstream(Request request) {
             assert !(downstreams.contains(request)) : "downstream answer producer already contains this request";
-
             downstreams.add(request);
             downstreamSelector = downstreams.iterator();
         }

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -211,7 +211,10 @@ public abstract class Resolver<RESOLVER extends Resolver<RESOLVER>> extends Acto
         }
 
         public void addDownstream(Request request) {
-            assert !(downstreams.contains(request)) : "downstream answer producer already contains this request";
+             if (downstreams.contains(request)) {
+                 throw new RuntimeException(String.format("Duplicate downstream request: %s\nExisting downstreams: %s",
+                                                          request, downstreams));
+             }
             downstreams.add(request);
             downstreamSelector = downstreams.iterator();
         }

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -107,6 +107,7 @@ public abstract class Resolver<RESOLVER extends Resolver<RESOLVER>> extends Acto
         return requestRouter.get(toDownstream);
     }
 
+    // TODO: Rename to sendRequest or request
     protected void requestFromDownstream(Request request, Request fromUpstream, int iteration) {
         LOG.trace("{} : Sending a new answer Request to downstream: {}", name(), request);
         if (resolutionTracing) ResolutionTracer.get().request(this.name(), request.receiver().name(), iteration,
@@ -117,6 +118,7 @@ public abstract class Resolver<RESOLVER extends Resolver<RESOLVER>> extends Acto
         receiver.execute(actor -> actor.receiveRequest(request, iteration));
     }
 
+    // TODO: Rename to sendResponse or respond
     protected void answerToUpstream(AnswerState answer, Request fromUpstream, int iteration) {
         assert answer.isPartial();
         Answer response = Answer.create(fromUpstream, answer.asPartial());

--- a/reasoner/resolution/resolver/BoundConcludableResolver.java
+++ b/reasoner/resolution/resolver/BoundConcludableResolver.java
@@ -1,0 +1,398 @@
+package com.vaticle.typedb.core.reasoner.resolution.resolver;
+
+import com.vaticle.typedb.core.common.exception.TypeDBException;
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.Iterators;
+import com.vaticle.typedb.core.concept.ConceptManager;
+import com.vaticle.typedb.core.concept.answer.ConceptMap;
+import com.vaticle.typedb.core.logic.Rule;
+import com.vaticle.typedb.core.logic.resolvable.Concludable;
+import com.vaticle.typedb.core.logic.resolvable.Unifier;
+import com.vaticle.typedb.core.pattern.Conjunction;
+import com.vaticle.typedb.core.reasoner.resolution.ResolverRegistry;
+import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState;
+import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache;
+import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache.SubsumptionAnswerCache.ConceptMapCache;
+import com.vaticle.typedb.core.reasoner.resolution.framework.ReiterationQuery;
+import com.vaticle.typedb.core.reasoner.resolution.framework.Request;
+import com.vaticle.typedb.core.reasoner.resolution.framework.RequestState;
+import com.vaticle.typedb.core.reasoner.resolution.framework.Resolver;
+import com.vaticle.typedb.core.reasoner.resolution.framework.Response;
+import com.vaticle.typedb.core.traversal.TraversalEngine;
+import com.vaticle.typedb.core.traversal.common.Identifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
+
+public class BoundConcludableResolver extends Resolver<BoundConcludableResolver>  {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BoundConcludableResolver.class);
+    private AnswerCache<?, ConceptMap> cache;
+    private final Concludable concludable;
+    private final Set<Identifier.Variable.Retrievable> unboundVars;
+    private final ConceptMap bounds;
+    private final Map<Driver<ConclusionResolver>, Rule> resolverRules;
+    private final LinkedHashMap<Driver<ConclusionResolver>, Set<Unifier>> applicableRules;
+    private final Map<Request, RequestState.CachingRequestState<?, ConceptMap>> requestStates;
+    private RequestState exploringRequestState;
+
+    public BoundConcludableResolver(Driver<BoundConcludableResolver> driver, Concludable concludable, ConceptMap bounds,
+                                    Map<Driver<ConclusionResolver>, Rule> resolverRules,
+                                    LinkedHashMap<Driver<ConclusionResolver>, Set<Unifier>> applicableRules,
+                                    ResolverRegistry registry, TraversalEngine traversalEngine,
+                                    ConceptManager conceptMgr, boolean resolutionTracing) {
+        super(driver, initName(concludable, bounds), registry, traversalEngine, conceptMgr, resolutionTracing);
+        this.concludable = concludable;
+        this.unboundVars = unboundVars(concludable.pattern());
+        this.bounds = bounds;
+        this.resolverRules = resolverRules;
+        this.applicableRules = applicableRules;
+        this.cache = new ConceptMapCache(new HashMap<>(), bounds, () -> traversalIterator(concludable.pattern(), bounds));
+        this.requestStates = new HashMap<>();
+        this.exploringRequestState = null;
+    }
+
+    private static String initName(Concludable concludable, ConceptMap bounds) {
+        return BoundConcludableResolver.class.getSimpleName() + "(pattern: " + concludable.pattern() + " bounds: " +
+                bounds.toString() + ")";
+    }
+
+    @Override
+    public void receiveRequest(Request fromUpstream, int iteration) {
+        LOG.trace("{}: received Request: {}", name(), fromUpstream);
+        if (isTerminated()) return;
+        if (fromUpstream.isToSubsumed()) {
+            assert fromUpstream.partialAnswer().conceptMap().equals(bounds);
+            receiveSubsumedRequest(fromUpstream.asToSubsumed(), iteration);
+        } else if (fromUpstream.isToSubsumer()) {
+            receiveSubsumerRequest(fromUpstream.asToSubsumer(), iteration);
+        } else {
+            assert fromUpstream.partialAnswer().conceptMap().equals(bounds);
+            receiveDirectRequest(fromUpstream, iteration);
+        }
+    }
+
+    private void receiveSubsumedRequest(Request.ToSubsumed fromUpstream, int iteration) {
+        throw TypeDBException.of(ILLEGAL_STATE);
+//        RequestState requestState = requestStates.computeIfAbsent(
+//                fromUpstream, request -> new BoundRetrievableResolver.BoundRequestState(request, cache, iteration));
+//        if (cache.sourceExhausted()) {
+//            sendAnswerOrFail(fromUpstream, iteration, requestState);
+//        } else {
+//            cache.clearSource();
+//            Optional<? extends AnswerState.Partial<?>> upstreamAnswer;
+//            upstreamAnswer = requestState.nextAnswer();
+//            if (upstreamAnswer.isPresent()) {
+//                answerToUpstream(upstreamAnswer.get(), fromUpstream, iteration);
+//            } else {
+//                requestFromSubsumer(fromUpstream, iteration);
+//            }
+//        }
+    }
+
+    private void receiveSubsumerRequest(Request.ToSubsumer fromUpstream, int iteration) {
+        throw TypeDBException.of(ILLEGAL_STATE);
+//        sendAnswerOrFail(fromUpstream, iteration, requestStates.computeIfAbsent(
+//                fromUpstream, request -> new BoundRetrievableResolver.SubsumerRequestState(request, cache, iteration)));
+    }
+
+    private void receiveDirectRequest(Request fromUpstream, int iteration) {
+//        sendAnswerOrFail(fromUpstream, iteration, requestStates.computeIfAbsent(
+//                fromUpstream, request -> new BoundRetrievableResolver.BoundRequestState(request, cache, iteration)));
+        sendAnswerOrSearchRulesOrFail(fromUpstream, iteration, requestStates.computeIfAbsent(
+                fromUpstream, request -> createRequestState(fromUpstream, iteration)));
+    }
+
+    @Override
+    protected void receiveAnswer(Response.Answer fromDownstream, int iteration) {
+        if (isTerminated()) return;
+        Request fromUpstream = fromUpstream(fromDownstream.sourceRequest());
+        RequestState.CachingRequestState<?, ConceptMap> requestState = this.requestStates.get(fromUpstream);
+        assert requestState.isExploration();
+        requestState.asExploration().newAnswer(fromDownstream.answer());
+        sendAnswerOrSearchRulesOrFail(fromUpstream, iteration, requestState);
+    }
+
+    @Override
+    protected void receiveFail(Response.Fail fromDownstream, int iteration) {
+        LOG.trace("{}: received Fail: {}", name(), fromDownstream);
+        if (isTerminated()) return;
+
+        Request toDownstream = fromDownstream.sourceRequest();
+        Request fromUpstream = fromUpstream(toDownstream);
+
+        RequestState.CachingRequestState<?, ConceptMap> requestState = this.requestStates.get(fromUpstream);
+        assert iteration == requestState.iteration();
+        if (requestState.isExploration()) {
+            requestState.asExploration().downstreamManager().removeDownstream(fromDownstream.sourceRequest());
+        }
+        sendAnswerOrSearchRulesOrFail(fromUpstream, iteration, requestState);
+    }
+
+    private void sendAnswerOrSearchRulesOrFail(Request fromUpstream, int iteration, RequestState.CachingRequestState<?, ConceptMap> requestState) {
+        Optional<AnswerState.Partial.Compound<?, ?>> upstreamAnswer = requestState.nextAnswer().map(AnswerState.Partial::asCompound);
+        if (upstreamAnswer.isPresent()) {
+            /*
+            When we only require 1 answer (eg. when the conjunction is already fully bound), we can short circuit
+            and prevent exploration of further rules.
+
+            One latency optimisation we could do here, is keep track of how many N repeated requests are received,
+            forward them downstream (to parallelise searching for the single answer), and when the first one finds an answer,
+            we respond for all N ahead of time. Then, when the rules actually return an answer to this concludable, we do nothing.
+             */
+            RequestState.CachingRequestState<?, ConceptMap> requestState1 = this.requestStates.get(fromUpstream);
+            if (requestState1.isExploration() && requestState1.asExploration().singleAnswerRequired()) {
+                requestState1.asExploration().downstreamManager().clearDownstreams();
+                requestState1.answerCache().setComplete();
+            }
+            answerToUpstream(upstreamAnswer.get(), fromUpstream, iteration);
+        } else {
+            RequestState.Exploration exploration;
+            if (requestState.isExploration() && !requestState.answerCache().isComplete()) {
+                if ((exploration = requestState.asExploration()).downstreamManager().hasDownstream()) {
+                    requestFromDownstream(exploration.downstreamManager().nextDownstream(), fromUpstream, iteration);
+                } else {
+                    requestState.answerCache().setComplete(); // TODO: The cache should not be set as complete during recursion
+                    failToUpstream(fromUpstream, iteration);
+                }
+            } else {
+                failToUpstream(fromUpstream, iteration);
+            }
+        }
+    }
+
+
+    private void requestFromSubsumer(Request.ToSubsumed fromUpstream, int iteration) {
+        Request toSubsumer = Request.ToSubsumer.create(driver(), fromUpstream.subsumer(),
+                                                       fromUpstream, fromUpstream.partialAnswer());
+        requestFromDownstream(toSubsumer, fromUpstream, iteration);
+    }
+
+    @Override
+    protected void initialiseDownstreamResolvers() {
+        throw TypeDBException.of(ILLEGAL_STATE);
+    }
+
+    public void receiveReiterationQuery(ReiterationQuery.Request request) {
+        driver().execute(actor -> actor.respondToReiterationQuery(request, cache.requiresReiteration()));
+    }
+
+    private void respondToReiterationQuery(ReiterationQuery.Request request, boolean reiterate) {
+        request.onResponse().accept(ReiterationQuery.Response.create(driver(), reiterate));
+    }
+
+    @Override
+    public void terminate(Throwable cause) {
+        super.terminate(cause);
+        requestStates.clear();
+    }
+
+    private static Set<Identifier.Variable.Retrievable> unboundVars(Conjunction conjunction) {
+        Set<Identifier.Variable.Retrievable> missingBounds = new HashSet<>();
+        iterate(conjunction.variables()).filter(var -> var.id().isRetrievable()).forEachRemaining(var -> {
+            if (var.isType() && !var.asType().label().isPresent()) missingBounds.add(var.asType().id().asRetrievable());
+            else if (var.isThing() && !var.asThing().iid().isPresent())
+                missingBounds.add(var.asThing().id().asRetrievable());
+        });
+        return missingBounds;
+    }
+
+    protected RequestState.CachingRequestState<?, ConceptMap> createRequestState(Request fromUpstream, int iteration) {
+        LOG.debug("{}: Creating new Responses for iteration{}, request: {}", name(), iteration, fromUpstream);
+        assert fromUpstream.partialAnswer().isConcludable();
+        RequestState.CachingRequestState<?, ConceptMap> requestState;
+        if (fromUpstream.partialAnswer().asConcludable().isExplain()) {
+            requestState = createExplainRequestState(fromUpstream, iteration);
+        } else if (fromUpstream.partialAnswer().asConcludable().isMatch()) {
+            requestState = createMatchRequestState(fromUpstream, iteration);
+        } else {
+            throw TypeDBException.of(ILLEGAL_STATE);
+        }
+        if (exploringRequestState == null) {
+            assert requestState.isExploration();
+            exploringRequestState = requestState;
+        }
+        return requestState;
+    }
+
+    protected RequestState.CachingRequestState<?, ConceptMap> createExplainRequestState(Request fromUpstream, int iteration) {
+        RequestState.CachingRequestState<?, ConceptMap> requestState;
+        if (exploringRequestState != null) {
+            if (cache.isConceptMapCache()) {
+                // We have a cache already which we must evict to use a cache suitable for explaining
+                cache = new AnswerCache.ConcludableAnswerCache(new HashMap<>(), bounds);
+                requestState = new Explain(fromUpstream, cache.asConcludableAnswerCache(), iteration);
+                requestState.asExploration().downstreamManager().addDownstreams(ruleDownstreams(fromUpstream));
+            } else if (cache.isConcludableAnswerCache()) {
+                requestState = new FollowingExplain(fromUpstream, cache.asConcludableAnswerCache(), iteration);
+            } else {
+                throw TypeDBException.of(ILLEGAL_STATE);
+            }
+        } else {
+            cache = new AnswerCache.ConcludableAnswerCache(new HashMap<>(), bounds);
+            requestState = new Explain(fromUpstream, cache.asConcludableAnswerCache(), iteration);
+            requestState.asExploration().downstreamManager().addDownstreams(ruleDownstreams(fromUpstream));
+        }
+        return requestState;
+    }
+
+    protected RequestState.CachingRequestState<?, ConceptMap> createMatchRequestState(Request fromUpstream, int iteration) {
+        RequestState.CachingRequestState<?, ConceptMap> requestState;
+        if (exploringRequestState != null) {
+            if (cache.isConceptMapCache()) {
+                requestState = new FollowingMatch(fromUpstream, cache.asConceptMapCache(), iteration);
+            } else if (cache.isConcludableAnswerCache()) {
+                requestState = new FollowingExplain(fromUpstream, cache.asConcludableAnswerCache(), iteration);
+            } else {
+                throw TypeDBException.of(ILLEGAL_STATE);
+            }
+        } else {
+            cache = new ConceptMapCache(new HashMap<>(), bounds, () -> traversalIterator(concludable.pattern(), bounds));
+            boolean singleAnswerRequired = bounds.concepts().keySet().containsAll(unboundVars);
+            requestState = new Match(fromUpstream, cache.asConceptMapCache(), iteration, singleAnswerRequired);
+            requestState.asExploration().downstreamManager().addDownstreams(ruleDownstreams(fromUpstream));
+        }
+        return requestState;
+    }
+
+    private List<Request> ruleDownstreams(Request fromUpstream) {
+        // loop termination: when receiving a new request, we check if we have seen it before from this root query
+        // if we have, we do not allow rules to be registered as possible downstreams
+        List<Request> downstreams = new ArrayList<>();
+        AnswerState.Partial.Concludable<?> partialAnswer = fromUpstream.partialAnswer().asConcludable();
+        for (Map.Entry<Driver<ConclusionResolver>, Set<Unifier>> entry : applicableRules.entrySet()) {
+            Driver<ConclusionResolver> conclusionResolver = entry.getKey();
+            for (Unifier unifier : entry.getValue()) {
+                Optional<? extends AnswerState.Partial.Conclusion<?, ?>> unified = partialAnswer.toDownstream(
+                        unifier, resolverRules.get(conclusionResolver));
+                unified.ifPresent(
+                        conclusion -> downstreams.add(Request.create(driver(), conclusionResolver, conclusion)));
+            }
+        }
+        return downstreams;
+    }
+
+    private class FollowingMatch extends RequestState.CachingRequestState<ConceptMap, ConceptMap> {
+
+        public FollowingMatch(Request fromUpstream, AnswerCache<ConceptMap, ConceptMap> answerCache, int iteration) {
+            super(fromUpstream, answerCache, iteration, true, true);
+        }
+
+        @Override
+        protected FunctionalIterator<? extends AnswerState.Partial<?>> toUpstream(ConceptMap conceptMap) {
+            return Iterators.single(fromUpstream.partialAnswer().asConcludable().asMatch().toUpstreamLookup(
+                    conceptMap, concludable.isInferredAnswer(conceptMap)));
+        }
+
+    }
+
+    private class Match extends RequestState.CachingRequestState<ConceptMap, ConceptMap> implements RequestState.Exploration {
+
+        private final DownstreamManager downstreamManager;
+        private final boolean singleAnswerRequired;
+
+        public Match(Request fromUpstream, AnswerCache<ConceptMap, ConceptMap> answerCache,
+                     int iteration, boolean singleAnswerRequired) {
+            super(fromUpstream, answerCache, iteration, true, false);
+            this.downstreamManager = new DownstreamManager();
+            this.singleAnswerRequired = singleAnswerRequired;
+        }
+
+        @Override
+        public boolean isExploration() {
+            return true;
+        }
+
+        @Override
+        public Exploration asExploration() {
+            return this;
+        }
+
+        @Override
+        public DownstreamManager downstreamManager() {
+            return downstreamManager;
+        }
+
+        @Override
+        public void newAnswer(AnswerState.Partial<?> partial) {
+            if (!answerCache.isComplete()) answerCache.add(partial.conceptMap());
+        }
+
+        @Override
+        public boolean singleAnswerRequired() {
+            return singleAnswerRequired;
+        }
+
+        @Override
+        protected FunctionalIterator<? extends AnswerState.Partial<?>> toUpstream(ConceptMap conceptMap) {
+            return Iterators.single(fromUpstream.partialAnswer().asConcludable().asMatch().toUpstreamLookup(
+                    conceptMap, concludable.isInferredAnswer(conceptMap)));
+        }
+    }
+
+    private static class FollowingExplain extends RequestState.CachingRequestState<AnswerState.Partial.Concludable<?>, ConceptMap> {
+
+        public FollowingExplain(Request fromUpstream, AnswerCache<AnswerState.Partial.Concludable<?>, ConceptMap> answerCache,
+                                int iteration) {
+            super(fromUpstream, answerCache, iteration, true, true);
+        }
+
+        @Override
+        protected FunctionalIterator<? extends AnswerState.Partial<?>> toUpstream(AnswerState.Partial.Concludable<?> partial) {
+            return Iterators.single(partial.asExplain().toUpstreamInferred());
+        }
+    }
+
+    private static class Explain extends RequestState.CachingRequestState<AnswerState.Partial.Concludable<?>, ConceptMap> implements RequestState.Exploration {
+
+        private final DownstreamManager downstreamManager;
+
+        public Explain(Request fromUpstream, AnswerCache<AnswerState.Partial.Concludable<?>, ConceptMap> answerCache,
+                       int iteration) {
+            super(fromUpstream, answerCache, iteration, false, false);
+            this.downstreamManager = new DownstreamManager();
+        }
+
+        @Override
+        public boolean isExploration() {
+            return true;
+        }
+
+        @Override
+        public Exploration asExploration() {
+            return this;
+        }
+
+        @Override
+        public DownstreamManager downstreamManager() {
+            return downstreamManager;
+        }
+
+        @Override
+        public void newAnswer(AnswerState.Partial<?> partial) {
+            if (!answerCache.isComplete()) answerCache.add(partial.asConcludable());
+        }
+
+        @Override
+        public boolean singleAnswerRequired() {
+            return false;
+        }
+
+        @Override
+        protected FunctionalIterator<? extends AnswerState.Partial<?>> toUpstream(AnswerState.Partial.Concludable<?> partial) {
+            return Iterators.single(partial.asExplain().toUpstreamInferred());
+        }
+
+    }
+}

--- a/reasoner/resolution/resolver/BoundConcludableResolver.java
+++ b/reasoner/resolution/resolver/BoundConcludableResolver.java
@@ -151,10 +151,9 @@ public class BoundConcludableResolver extends Resolver<BoundConcludableResolver>
             forward them downstream (to parallelise searching for the single answer), and when the first one finds an answer,
             we respond for all N ahead of time. Then, when the rules actually return an answer to this concludable, we do nothing.
              */
-            RequestState.CachingRequestState<?, ConceptMap> requestState1 = this.requestStates.get(fromUpstream);
-            if (requestState1.isExploration() && requestState1.asExploration().singleAnswerRequired()) {
-                requestState1.asExploration().downstreamManager().clearDownstreams();
-                requestState1.answerCache().setComplete();
+            if (requestState.isExploration() && requestState.asExploration().singleAnswerRequired()) {
+                requestState.asExploration().downstreamManager().clearDownstreams();
+                requestState.answerCache().setComplete();
             }
             answerToUpstream(upstreamAnswer.get(), fromUpstream, iteration);
         } else {

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -42,11 +42,13 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILL
 public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver> {
     private final ConceptMapCache cache;
     private final Map<Request, RequestState> requestStates;
+    private ConceptMap bounds;
 
     public BoundRetrievableResolver(Driver<BoundRetrievableResolver> driver, Retrievable retrievable, ConceptMap bounds,
                                     ResolverRegistry registry, TraversalEngine traversalEngine,
                                     ConceptManager conceptMgr, boolean resolutionTracing) {
         super(driver, initName(retrievable, bounds), registry, traversalEngine, conceptMgr, resolutionTracing);
+        this.bounds = bounds;
         this.cache = new ConceptMapCache(new HashMap<>(), bounds, () -> traversalIterator(retrievable.pattern(), bounds));
         this.requestStates = new HashMap<>();
     }
@@ -59,10 +61,12 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
     @Override
     public void receiveRequest(Request fromUpstream, int iteration) {
         if (fromUpstream.isToSubsumed()) {
+            assert fromUpstream.partialAnswer().conceptMap().equals(bounds);
             receiveSubsumedRequest(fromUpstream.asToSubsumed(), iteration);
         } else if (fromUpstream.isToSubsumer()) {
             receiveSubsumerRequest(fromUpstream.asToSubsumer(), iteration);
         } else {
+            assert fromUpstream.partialAnswer().conceptMap().equals(bounds);
             receiveDirectRequest(fromUpstream, iteration);
         }
     }

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -152,7 +152,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
         }
     }
 
-    private static class SubsumerRequestState extends RequestState.CachingRequestState<ConceptMap, ConceptMap> {
+    private class SubsumerRequestState extends RequestState.CachingRequestState<ConceptMap, ConceptMap> {
 
         public SubsumerRequestState(Request fromUpstream, AnswerCache<ConceptMap, ConceptMap> answerCache, int iteration) {  // TODO: Iteration shouldn't be needed
             super(fromUpstream, answerCache, iteration, false, false);
@@ -160,15 +160,15 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
 
         @Override
         protected FunctionalIterator<? extends AnswerState.Partial<?>> toUpstream(ConceptMap answer) {
-            if (subsumes(answer, fromUpstream.partialAnswer().conceptMap())) {
+            if (subsumesBounds(answer)) {
                 return Iterators.single(fromUpstream.partialAnswer().asRetrievable().with(answer));
             } else {
                 return Iterators.empty();
             }
         }
 
-        private static boolean subsumes(ConceptMap subsumer, ConceptMap subsumed) {
-            return subsumer.concepts().entrySet().containsAll(subsumed.concepts().entrySet());
+        private boolean subsumesBounds(ConceptMap subsumer) {
+            return subsumer.concepts().entrySet().containsAll(bounds.concepts().entrySet());
         }
     }
 }

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -78,8 +78,6 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
         RequestState requestState = requestStates.computeIfAbsent(
                 fromUpstream, request -> new BoundRetrievableRequestState(request, cache, iteration));
         if (cache.isComplete()) {
-            // We need to continue from where the RequestState left off before subsumption was activated, so we use
-            // toRequest() to convert to a vanilla request. TODO: Create a more elegant solution to track this state
             sendAnswerOrFail(fromUpstream, iteration, requestState);
         } else {
             // TODO: Once we don't add the traversal into the cache, we will be able to first check for any existing

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -70,7 +70,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
     private void receiveSubsumedRequest(Request.ToSubsumed fromUpstream, int iteration) {
         RequestState requestState = requestStates.computeIfAbsent(
                 fromUpstream, request -> new BoundRequestState(request, cache, iteration));
-        if (cache.isSourceExhausted()) {
+        if (cache.sourceExhausted()) {
             sendAnswerOrFail(fromUpstream, iteration, requestState);
         } else {
             cache.clearSource();
@@ -97,7 +97,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
     @Override
     protected void receiveAnswer(Response.Answer fromDownstream, int iteration) {
         Request.ToSubsumed fromUpstream = fromDownstream.sourceRequest().asToSubsumer().toSubsumed();
-        if (cache.isSourceExhausted()) sendAnswerOrFail(fromUpstream, iteration, requestStates.get(fromUpstream));
+        if (cache.sourceExhausted()) sendAnswerOrFail(fromUpstream, iteration, requestStates.get(fromUpstream));
         else {
             cache.add(fromDownstream.answer().conceptMap());
             Optional<? extends AnswerState.Partial<?>> upstreamAnswer = requestStates.get(fromUpstream).nextAnswer();

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -70,7 +70,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
     private void receiveSubsumedRequest(Request.ToSubsumed fromUpstream, int iteration) {
         RequestState requestState = requestStates.computeIfAbsent(
                 fromUpstream, request -> new BoundRequestState(request, cache, iteration));
-        if (cache.isComplete()) {
+        if (cache.isSourceExhausted()) {
             sendAnswerOrFail(fromUpstream, iteration, requestState);
         } else {
             cache.clearSource();
@@ -97,7 +97,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
     @Override
     protected void receiveAnswer(Response.Answer fromDownstream, int iteration) {
         Request.ToSubsumed fromUpstream = fromDownstream.sourceRequest().asToSubsumer().toSubsumed();
-        if (cache.isComplete()) sendAnswerOrFail(fromUpstream, iteration, requestStates.get(fromUpstream));
+        if (cache.isSourceExhausted()) sendAnswerOrFail(fromUpstream, iteration, requestStates.get(fromUpstream));
         else {
             cache.add(fromDownstream.answer().conceptMap());
             Optional<? extends AnswerState.Partial<?>> upstreamAnswer = requestStates.get(fromUpstream).nextAnswer();

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -111,6 +111,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
 
     @Override
     protected void receiveFail(Response.Fail fromDownstream, int iteration) {
+        cache.setComplete();
         Request fromUpstream = fromDownstream.sourceRequest().asToSubsumer().toSubsumed();
         sendAnswerOrFail(fromUpstream, iteration, requestStates.get(fromUpstream));
     }
@@ -120,7 +121,6 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
         if (upstreamAnswer.isPresent()) {
             answerToUpstream(upstreamAnswer.get(), fromUpstream, iteration);
         } else {
-            cache.setComplete();
             failToUpstream(fromUpstream, iteration);
         }
     }

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -106,7 +106,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
         Request.ToSubsumed fromUpstream = fromDownstream.sourceRequest().asToSubsumer().toSubsumed();
         if (cache.isComplete()) sendAnswerOrFail(fromUpstream, iteration, requestStates.get(fromUpstream));
         else {
-            cache.add(fromDownstream.answer().conceptMap().filter(retrievable.retrieves()));
+            cache.add(fromDownstream.answer().conceptMap());
             Optional<? extends AnswerState.Partial<?>> upstreamAnswer = requestStates.get(fromUpstream).nextAnswer();
             if (upstreamAnswer.isPresent()) {
                 answerToUpstream(upstreamAnswer.get(), fromUpstream, iteration);
@@ -172,7 +172,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
         @Override
         protected FunctionalIterator<? extends AnswerState.Partial<?>> toUpstream(ConceptMap answer) {
             if (subsumes(answer, fromUpstream.partialAnswer().conceptMap())) {
-                return Iterators.single(fromUpstream.partialAnswer().asRetrievable().aggregateToUpstream(answer));
+                return Iterators.single(fromUpstream.partialAnswer().asRetrievable().with(answer));
             } else {
                 return Iterators.empty();
             }

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.vaticle.typedb.core.reasoner.resolution.resolver;
+
+import com.vaticle.typedb.core.common.exception.TypeDBException;
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.Iterators;
+import com.vaticle.typedb.core.concept.ConceptManager;
+import com.vaticle.typedb.core.concept.answer.ConceptMap;
+import com.vaticle.typedb.core.logic.resolvable.Retrievable;
+import com.vaticle.typedb.core.reasoner.resolution.ResolverRegistry;
+import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState;
+import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache;
+import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache.SubsumptionAnswerCache.ConceptMapCache;
+import com.vaticle.typedb.core.reasoner.resolution.framework.Request;
+import com.vaticle.typedb.core.reasoner.resolution.framework.RequestState;
+import com.vaticle.typedb.core.reasoner.resolution.framework.Resolver;
+import com.vaticle.typedb.core.reasoner.resolution.framework.Response;
+import com.vaticle.typedb.core.traversal.TraversalEngine;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+
+public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver> {
+    private final Retrievable retrievable;
+    private final ConceptMap bounds;
+    private final ConceptMapCache cache;
+    private final Map<Request, RetrievableRequestState> requestStates;
+
+    public BoundRetrievableResolver(Retrievable retrievable, ConceptMap bounds, Driver<BoundRetrievableResolver> driver,
+                                    ResolverRegistry registry, TraversalEngine traversalEngine,
+                                    ConceptManager conceptMgr, boolean resolutionTracing) {
+        super(driver, initName(retrievable, bounds), registry, traversalEngine, conceptMgr, resolutionTracing);
+        this.retrievable = retrievable;
+        this.bounds = bounds;
+        this.cache = new ConceptMapCache(new HashMap<>(), this.bounds);
+        // TODO: Figure out how to fetch answers from completed subsumers
+        if (!this.cache.completeIfSubsumerComplete()) this.cache.addSource(traversalIterator(this.retrievable.pattern(), this.bounds));
+        this.requestStates = new HashMap<>();
+    }
+
+    private static String initName(Retrievable retrievable, ConceptMap bounds) {
+        return BoundRetrievableResolver.class.getSimpleName() + "(pattern: " + retrievable.pattern() + " " +
+                bounds.toString() + ")";
+    }
+
+    @Override
+    public void receiveRequest(Request fromUpstream, int iteration) {
+        this.requestStates.computeIfAbsent(fromUpstream, request -> new RetrievableRequestState(request, cache, iteration)); // TODO: Iteration shouldn't be needed
+        RetrievableRequestState requestState = this.requestStates.get(fromUpstream);
+
+        Optional<AnswerState.Partial.Compound<?, ?>> upstreamAnswer = requestState.nextAnswer().map(AnswerState.Partial::asCompound);
+        if (upstreamAnswer.isPresent()) {
+            answerToUpstream(upstreamAnswer.get(), fromUpstream, iteration);
+        } else {
+            cache.setComplete();
+            failToUpstream(fromUpstream, iteration);
+        }
+    }
+
+    @Override
+    protected void receiveAnswer(Response.Answer fromDownstream, int iteration) {
+        throw TypeDBException.of(ILLEGAL_STATE);
+    }
+
+    @Override
+    protected void receiveFail(Response.Fail fromDownstream, int iteration) {
+        throw TypeDBException.of(ILLEGAL_STATE);
+    }
+
+    @Override
+    protected void initialiseDownstreamResolvers() {
+        throw TypeDBException.of(ILLEGAL_STATE);
+    }
+
+    private static class RetrievableRequestState extends RequestState.CachingRequestState<ConceptMap, ConceptMap> {
+
+        public RetrievableRequestState(Request fromUpstream, AnswerCache<ConceptMap, ConceptMap> answerCache, int iteration) {
+            super(fromUpstream, answerCache, iteration, false, false);
+        }
+
+        @Override
+        protected FunctionalIterator<? extends AnswerState.Partial<?>> toUpstream(ConceptMap answer) {
+            return Iterators.single(fromUpstream.partialAnswer().asRetrievable()
+                                            .aggregateToUpstream(answer));
+        }
+    }
+}

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -47,7 +47,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
     private final Map<Request, RequestState> requestStates;
     private boolean traversalInitialised;
 
-    public BoundRetrievableResolver(Retrievable retrievable, ConceptMap bounds, Driver<BoundRetrievableResolver> driver,
+    public BoundRetrievableResolver(Driver<BoundRetrievableResolver> driver, Retrievable retrievable, ConceptMap bounds,
                                     ResolverRegistry registry, TraversalEngine traversalEngine,
                                     ConceptManager conceptMgr, boolean resolutionTracing) {
         super(driver, initName(retrievable, bounds), registry, traversalEngine, conceptMgr, resolutionTracing);
@@ -59,7 +59,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
     }
 
     private static String initName(Retrievable retrievable, ConceptMap bounds) {
-        return BoundRetrievableResolver.class.getSimpleName() + "(pattern: " + retrievable.pattern() + " " +
+        return BoundRetrievableResolver.class.getSimpleName() + "(pattern: " + retrievable.pattern() + " bounds: " +
                 bounds.toString() + ")";
     }
 

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -67,7 +67,8 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
         this.requestStates.computeIfAbsent(fromUpstream, request -> new BoundRetrievableRequestState(request, cache, iteration)); // TODO: Iteration shouldn't be needed
         BoundRetrievableRequestState requestState = this.requestStates.get(fromUpstream);
 
-        Optional<Compound<?, ?>> upstreamAnswer = requestState.nextAnswer(bounds).map(AnswerState.Partial::asCompound);
+        Optional<Compound<?, ?>> upstreamAnswer =
+                requestState.nextAnswer(fromUpstream.partialAnswer().conceptMap()).map(AnswerState.Partial::asCompound);
         if (upstreamAnswer.isPresent()) {
             answerToUpstream(upstreamAnswer.get(), fromUpstream, iteration);
         } else {

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -102,7 +102,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
         Request.ToSubsumed fromUpstream = fromDownstream.sourceRequest().asToSubsumer().toSubsumed();
         if (cache.isComplete()) sendAnswerOrFail(fromUpstream, iteration, requestStates.get(fromUpstream));
         else {
-            cache.clearSources();
+            cache.clearSource();
             cache.add(fromDownstream.answer().conceptMap().filter(retrievable.retrieves()));
             Optional<Compound<?, ?>> upstreamAnswer = requestStates.get(fromUpstream).nextAnswer().map(AnswerState.Partial::asCompound);
             if (upstreamAnswer.isPresent()) {
@@ -139,7 +139,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
         // TODO: Once we no longer rely on the cache to detect the conditions for reiteration, we can not add the
         //  traversal as a source and instead add answers from traversal one-by-one as needed, so that we can kill the
         //  traversal as soon as subsumption kicks in.
-        if (!traversalInitialised) cache.addSource(traversalIterator(retrievable.pattern(), bounds));
+        if (!traversalInitialised) cache.addToSource(traversalIterator(retrievable.pattern(), bounds));
         traversalInitialised = true;
     }
 

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -76,7 +76,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
 
     private void receiveSubsumedRequest(Request.ToSubsumed fromUpstream, int iteration) {
         RequestState requestState = requestStates.computeIfAbsent(
-                fromUpstream, request -> new BoundRetrievableRequestState(request, cache, iteration));
+                fromUpstream, request -> new BoundRequestState(request, cache, iteration));
         if (cache.isComplete()) {
             sendAnswerOrFail(fromUpstream, iteration, requestState);
         } else {
@@ -88,13 +88,13 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
 
     private void receiveSubsumerRequest(Request.ToSubsumer fromUpstream, int iteration) {
         sendAnswerOrFail(fromUpstream, iteration, requestStates.computeIfAbsent(
-                fromUpstream, request -> new SubsumptionBoundRetrievableRequestState(request, cache, iteration)));
+                fromUpstream, request -> new SubsumerRequestState(request, cache, iteration)));
     }
 
     private void receiveDirectRequest(Request fromUpstream, int iteration) {
         initTraversal();
         sendAnswerOrFail(fromUpstream, iteration, requestStates.computeIfAbsent(
-                fromUpstream, request -> new BoundRetrievableRequestState(request, cache, iteration)));
+                fromUpstream, request -> new BoundRequestState(request, cache, iteration)));
     }
 
     @Override
@@ -147,9 +147,9 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
         throw TypeDBException.of(ILLEGAL_STATE);
     }
 
-    private static class BoundRetrievableRequestState extends RequestState.CachingRequestState<ConceptMap, ConceptMap> {
+    private static class BoundRequestState extends RequestState.CachingRequestState<ConceptMap, ConceptMap> {
 
-        public BoundRetrievableRequestState(Request fromUpstream, AnswerCache<ConceptMap, ConceptMap> answerCache, int iteration) {  // TODO: Iteration shouldn't be needed
+        public BoundRequestState(Request fromUpstream, AnswerCache<ConceptMap, ConceptMap> answerCache, int iteration) {  // TODO: Iteration shouldn't be needed
             super(fromUpstream, answerCache, iteration, false, false);
         }
 
@@ -159,9 +159,9 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
         }
     }
 
-    private static class SubsumptionBoundRetrievableRequestState extends RequestState.CachingRequestState<ConceptMap, ConceptMap> {
+    private static class SubsumerRequestState extends RequestState.CachingRequestState<ConceptMap, ConceptMap> {
 
-        public SubsumptionBoundRetrievableRequestState(Request fromUpstream, AnswerCache<ConceptMap, ConceptMap> answerCache, int iteration) {  // TODO: Iteration shouldn't be needed
+        public SubsumerRequestState(Request fromUpstream, AnswerCache<ConceptMap, ConceptMap> answerCache, int iteration) {  // TODO: Iteration shouldn't be needed
             super(fromUpstream, answerCache, iteration, false, false);
         }
 

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -107,8 +107,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
             ConceptMap subsumerAnswer = fromDownstream.answer().conceptMap();
             if (cache.subsumes(subsumerAnswer, bounds)) {
                 cache.add(subsumerAnswer.filter(retrievable.retrieves()));
-                RequestState requestState = requestStates.get(fromUpstream);
-                Optional<Compound<?, ?>> upstreamAnswer = requestState.nextAnswer().map(AnswerState.Partial::asCompound);
+                Optional<Compound<?, ?>> upstreamAnswer = requestStates.get(fromUpstream).nextAnswer().map(AnswerState.Partial::asCompound);
                 if (upstreamAnswer.isPresent()) {
                     answerToUpstream(upstreamAnswer.get(), fromUpstream, iteration);
                 } else {
@@ -123,8 +122,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
     @Override
     protected void receiveFail(Response.Fail fromDownstream, int iteration) {
         Request fromUpstream = fromDownstream.sourceRequest().asToSubsumer().toSubsumed();
-        RequestState requestState = requestStates.get(fromUpstream);
-        sendAnswerOrFail(fromUpstream, iteration, requestState);
+        sendAnswerOrFail(fromUpstream, iteration, requestStates.get(fromUpstream));
     }
 
     private void sendAnswerOrFail(Request fromUpstream, int iteration, RequestState requestState) {

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -25,6 +25,7 @@ import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.logic.resolvable.Retrievable;
 import com.vaticle.typedb.core.reasoner.resolution.ResolverRegistry;
 import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState;
+import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState.Partial.Compound;
 import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache;
 import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache.SubsumptionAnswerCache.ConceptMapCache;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Request;
@@ -66,7 +67,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
         this.requestStates.computeIfAbsent(fromUpstream, request -> new BoundRetrievableRequestState(request, cache, iteration)); // TODO: Iteration shouldn't be needed
         BoundRetrievableRequestState requestState = this.requestStates.get(fromUpstream);
 
-        Optional<AnswerState.Partial.Compound<?, ?>> upstreamAnswer = requestState.nextAnswer().map(AnswerState.Partial::asCompound);
+        Optional<Compound<?, ?>> upstreamAnswer = requestState.nextAnswer(bounds).map(AnswerState.Partial::asCompound);
         if (upstreamAnswer.isPresent()) {
             answerToUpstream(upstreamAnswer.get(), fromUpstream, iteration);
         } else {

--- a/reasoner/resolution/resolver/BoundRetrievableResolver.java
+++ b/reasoner/resolution/resolver/BoundRetrievableResolver.java
@@ -102,6 +102,7 @@ public class BoundRetrievableResolver extends Resolver<BoundRetrievableResolver>
         Request.ToSubsumed fromUpstream = fromDownstream.sourceRequest().asToSubsumer().toSubsumed();
         if (cache.isComplete()) sendAnswerOrFail(fromUpstream, iteration, requestStates.get(fromUpstream));
         else {
+            cache.clearSources();
             cache.add(fromDownstream.answer().conceptMap().filter(retrievable.retrieves()));
             Optional<Compound<?, ?>> upstreamAnswer = requestStates.get(fromUpstream).nextAnswer().map(AnswerState.Partial::asCompound);
             if (upstreamAnswer.isPresent()) {

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -19,43 +19,27 @@
 package com.vaticle.typedb.core.reasoner.resolution.resolver;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
-import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
-import com.vaticle.typedb.core.common.iterator.Iterators;
 import com.vaticle.typedb.core.concept.ConceptManager;
 import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.logic.LogicManager;
 import com.vaticle.typedb.core.logic.Rule;
 import com.vaticle.typedb.core.logic.resolvable.Concludable;
 import com.vaticle.typedb.core.logic.resolvable.Unifier;
-import com.vaticle.typedb.core.pattern.Conjunction;
 import com.vaticle.typedb.core.reasoner.resolution.ResolverRegistry;
-import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState.Partial;
 import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache;
-import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache.ConcludableAnswerCache;
-import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache.SubsumptionAnswerCache.ConceptMapCache;
-import com.vaticle.typedb.core.reasoner.resolution.framework.ReiterationQuery;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Request;
-import com.vaticle.typedb.core.reasoner.resolution.framework.RequestState.CachingRequestState;
-import com.vaticle.typedb.core.reasoner.resolution.framework.RequestState.Exploration;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Resolver;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Response;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Response.Answer;
 import com.vaticle.typedb.core.traversal.TraversalEngine;
-import com.vaticle.typedb.core.traversal.common.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 
 public class ConcludableResolver extends Resolver<ConcludableResolver> {
 
@@ -65,11 +49,12 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
     private final Map<Driver<ConclusionResolver>, Rule> resolverRules;
     private final Concludable concludable;
     private final LogicManager logicMgr;
-    private final Map<Request, CachingRequestState<?, ConceptMap>> requestStates;
-    private final Set<Identifier.Variable.Retrievable> unboundVars;
-    private boolean isInitialised;
+    private final Map<Driver<? extends Resolver<?>>, Map<ConceptMap, Driver<BoundConcludableResolver>>> boundConcludableResolversByRoot; // TODO: We would like these not to be by root. They need to be, for now, for reiteration purposes.
     protected final Map<Driver<? extends Resolver<?>>, Map<ConceptMap, AnswerCache<?, ConceptMap>>> cacheRegistersByRoot;
     protected final Map<Driver<? extends Resolver<?>>, Integer> iterationByRoot;
+    private final Map<Driver<? extends Resolver<?>>, SubsumptionTracker> subsumptionTrackers;
+    private final Map<Driver<? extends Resolver<?>>, Map<Request, Request>> requestMapByRoot;
+    private boolean isInitialised;
 
     public ConcludableResolver(Driver<ConcludableResolver> driver, Concludable concludable,
                                ResolverRegistry registry, TraversalEngine traversalEngine, ConceptManager conceptMgr,
@@ -80,11 +65,12 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         this.concludable = concludable;
         this.applicableRules = new LinkedHashMap<>();
         this.resolverRules = new HashMap<>();
-        this.requestStates = new HashMap<>();
-        this.unboundVars = unboundVars(concludable.pattern());
         this.isInitialised = false;
+        this.boundConcludableResolversByRoot = new HashMap<>();
         this.cacheRegistersByRoot = new HashMap<>();
         this.iterationByRoot = new HashMap<>();
+        this.requestMapByRoot = new HashMap<>();
+        this.subsumptionTrackers = new HashMap<>();
     }
 
     @Override
@@ -96,98 +82,66 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         Driver<? extends Resolver<?>> root = fromUpstream.partialAnswer().root();
         iterationByRoot.putIfAbsent(root, iteration);
         if (iteration > iterationByRoot.get(root)) prepareNextIteration(root, iteration);
-
-        if (iteration < iterationByRoot.get(root)) {
+        else if (iteration < iterationByRoot.get(root)) {
             // short circuit if the request came from a prior iteration
             failToUpstream(fromUpstream, iteration);
         } else {
-            CachingRequestState<?, ConceptMap> requestState = getOrReplaceRequestState(fromUpstream, iteration);
-            assert iteration == requestState.iteration();
-            assert cacheRegistersByRoot.get(root).containsKey(fromUpstream.partialAnswer().conceptMap());
-            nextAnswer(fromUpstream, requestState, iteration);
+            ConceptMap bounds = fromUpstream.partialAnswer().conceptMap();
+            Driver<BoundConcludableResolver> boundConcludable = getOrReplaceBoundConcludable(root, bounds);
+            // TODO: Re-enable subsumption when async bug is fixed
+            // Optional<ConceptMap> subsumer = subsumptionTrackers.computeIfAbsent(
+            //         root, r -> new SubsumptionTracker()).getSubsumer(bounds);
+            // // If there is a finished subsumer, let the BoundConcludable know that it can go there for answers
+            // Request request = subsumer
+            //         .map(conceptMap -> Request.ToSubsumed.create(
+            //                 driver(), boundConcludable, boundConcludablesByRoot.get(root).get(conceptMap),
+            //                 fromUpstream.partialAnswer()))
+            //         .orElseGet(() -> Request.create(driver(), boundConcludable, fromUpstream.partialAnswer()));
+            Request request = Request.create(driver(), boundConcludable, fromUpstream.partialAnswer());
+            requestMapByRoot.computeIfAbsent(root, r -> new HashMap<>()).put(request, fromUpstream);
+            requestFromDownstream(request, fromUpstream, iteration);
         }
     }
 
     private void prepareNextIteration(Driver<? extends Resolver<?>> root, int iteration) {
         iterationByRoot.put(root, iteration);
-        cacheRegistersByRoot.get(root).clear();
+        cacheRegistersByRoot.remove(root);
+        requestMapByRoot.remove(root);
+    }
+
+    private Driver<BoundConcludableResolver> getOrReplaceBoundConcludable(Driver<? extends Resolver<?>> root, ConceptMap bounds) {
+        return boundConcludableResolversByRoot.computeIfAbsent(root, r -> new HashMap<>()).computeIfAbsent(bounds, b -> {
+            LOG.debug("{}: Creating a new BoundConcludableResolver for bounds: {}", name(), bounds);
+            // TODO: We could use the bounds to prune the applicable rules further
+            return registry.registerBoundConcludable(concludable, bounds, resolverRules, applicableRules);
+        });
     }
 
     @Override
     protected void receiveAnswer(Answer fromDownstream, int iteration) {
-        LOG.trace("{}: received Answer: {}", name(), fromDownstream);
-        if (isTerminated()) return;
-
-        Request toDownstream = fromDownstream.sourceRequest();
-        Request fromUpstream = fromUpstream(toDownstream);
-        Driver<? extends Resolver<?>> root = fromUpstream.partialAnswer().root();
-
-        if (iteration < iterationByRoot.get(root)) {
-            // short circuit if the request came from a prior iteration
-            failToUpstream(fromUpstream, iteration);
-        } else {
-            CachingRequestState<?, ConceptMap> requestState = this.requestStates.get(fromUpstream);
-            assert requestState.isExploration();
-            requestState.asExploration().newAnswer(fromDownstream.answer());
-            assert iteration == requestState.iteration();
-            assert cacheRegistersByRoot.get(root).containsKey(fromUpstream.partialAnswer().conceptMap());
-            nextAnswer(fromUpstream, requestState, iteration);
-        }
-    }
-
-    /*
-    When we only require 1 answer (eg. when the conjunction is already fully bound), we can short circuit
-    and prevent exploration of further rules.
-
-    One latency optimisation we could do here, is keep track of how many N repeated requests are received,
-    forward them downstream (to parallelise searching for the single answer), and when the first one finds an answer,
-    we respond for all N ahead of time. Then, when the rules actually return an answer to this concludable, we do nothing.
-     */
-    private void answerFound(Partial.Compound<?, ?> upstreamAnswer, Request fromUpstream, int iteration) {
-        CachingRequestState<?, ConceptMap> requestState = this.requestStates.get(fromUpstream);
-        if (requestState.isExploration() && requestState.asExploration().singleAnswerRequired()) {
-            requestState.asExploration().downstreamManager().clearDownstreams();
-            requestState.answerCache().setComplete();
-        }
-        answerToUpstream(upstreamAnswer, fromUpstream, iteration);
-    }
-
-    @Override
-    protected void receiveFail(Response.Fail fromDownstream, int iteration) {
-        LOG.trace("{}: received Fail: {}", name(), fromDownstream);
-        if (isTerminated()) return;
-
-        Request toDownstream = fromDownstream.sourceRequest();
-        Request fromUpstream = fromUpstream(toDownstream);
-
-        if (iteration < iterationByRoot.get(fromUpstream.partialAnswer().root())) {
+        if (iteration < iterationByRoot.get(fromDownstream.answer().root())) {
             // short circuit old iteration failed messages to upstream
-            failToUpstream(fromUpstream, iteration);
+            failToUpstream(fromDownstream.sourceRequest(), iteration);
         } else {
-            CachingRequestState<?, ConceptMap> requestState = this.requestStates.get(fromUpstream);
-            assert iteration == requestState.iteration();
-            if (requestState.isExploration()) {
-                requestState.asExploration().downstreamManager().removeDownstream(fromDownstream.sourceRequest());
-            }
-            nextAnswer(fromUpstream, requestState, iteration);
+            answerToUpstream(fromDownstream.answer(),
+                             requestMapByRoot.get(fromDownstream.answer().root()).get(fromDownstream.sourceRequest()),
+                             iteration);
         }
     }
 
-    public void receiveReiterationQuery(ReiterationQuery.Request request) {
-        boolean reiterate = cacheRegistersByRoot.containsKey(request.sender()) &&
-                iterate(cacheRegistersByRoot.get(request.sender()).values())
-                    .filter(AnswerCache::requiresReiteration).first().isPresent();
-        driver().execute(actor -> actor.respondToReiterationQuery(request, reiterate));
-    }
-
-    private void respondToReiterationQuery(ReiterationQuery.Request request, boolean reiterate) {
-        request.onResponse().accept(ReiterationQuery.Response.create(driver(), reiterate));
-    }
-
     @Override
-    public void terminate(Throwable cause) {
-        super.terminate(cause);
-        requestStates.clear();
+    protected void receiveFail(Response.Fail fail, int iteration) {
+        if (iteration < iterationByRoot.get(fail.sourceRequest().partialAnswer().root())) {
+            // short circuit old iteration failed messages to upstream
+            failToUpstream(fail.sourceRequest(), iteration);
+        } else {
+            Request request = fail.sourceRequest();
+            subsumptionTrackers
+                    .computeIfAbsent(request.partialAnswer().root(), r -> new SubsumptionTracker())
+                    .addFinished(request.partialAnswer().conceptMap());
+            failToUpstream(requestMapByRoot.get(fail.sourceRequest().partialAnswer().root()).get(request),
+                           iteration);
+        }
     }
 
     @Override
@@ -206,236 +160,6 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
                     }
                 }));
         if (!isTerminated()) isInitialised = true;
-    }
-
-    private void nextAnswer(Request fromUpstream, CachingRequestState<?, ConceptMap> requestState, int iteration) {
-        Optional<Partial.Compound<?, ?>> upstreamAnswer = requestState.nextAnswer().map(Partial::asCompound);
-        if (upstreamAnswer.isPresent()) {
-            answerFound(upstreamAnswer.get(), fromUpstream, iteration);
-        } else {
-            Exploration exploration;
-            if (requestState.isExploration() && !requestState.answerCache().isComplete()) {
-                if ((exploration = requestState.asExploration()).downstreamManager().hasDownstream()) {
-                    requestFromDownstream(exploration.downstreamManager().nextDownstream(), fromUpstream, iteration);
-                } else {
-                    requestState.answerCache().setComplete(); // TODO: The cache should not be set as complete during recursion
-                    failToUpstream(fromUpstream, iteration);
-                }
-            } else {
-                failToUpstream(fromUpstream, iteration);
-            }
-        }
-    }
-
-    private CachingRequestState<?, ConceptMap> getOrReplaceRequestState(Request fromUpstream, int iteration) {
-        if (!requestStates.containsKey(fromUpstream)) {
-            CachingRequestState<?, ConceptMap> requestState = createRequestState(fromUpstream, iteration);
-            requestStates.put(fromUpstream, requestState);
-        } else {
-            CachingRequestState<?, ConceptMap> requestState = this.requestStates.get(fromUpstream);
-
-            if (requestState.iteration() < iteration) {
-                // when the same request for the next iteration the first time, re-initialise required state
-                CachingRequestState<?, ConceptMap> newRequestState = createRequestState(fromUpstream, iteration);
-                this.requestStates.put(fromUpstream, newRequestState);
-            }
-        }
-        return requestStates.get(fromUpstream);
-    }
-
-    protected CachingRequestState<?, ConceptMap> createRequestState(Request fromUpstream, int iteration) {
-        LOG.debug("{}: Creating new Responses for iteration{}, request: {}", name(), iteration, fromUpstream);
-        Driver<? extends Resolver<?>> root = fromUpstream.partialAnswer().root();
-        cacheRegistersByRoot.putIfAbsent(root, new HashMap<>());
-        Map<ConceptMap, AnswerCache<?, ConceptMap>> cacheRegister = cacheRegistersByRoot.get(root);
-        ConceptMap answerFromUpstream = fromUpstream.partialAnswer().conceptMap();
-        CachingRequestState<?, ConceptMap> requestState;
-        assert fromUpstream.partialAnswer().isConcludable();
-        if (fromUpstream.partialAnswer().asConcludable().isExplain()) {
-            if (cacheRegister.containsKey(answerFromUpstream)) {
-                if (cacheRegister.get(answerFromUpstream).isConceptMapCache()) {
-                    // We have a cache already which we must evict to use a cache suitable for explaining
-                    ConcludableAnswerCache answerCache = new ConcludableAnswerCache(cacheRegister, answerFromUpstream);
-                    cacheRegister.put(answerFromUpstream, answerCache);
-                    requestState = new Explain(fromUpstream, answerCache, iteration);
-                    requestState.asExploration().downstreamManager().addDownstreams(ruleDownstreams(fromUpstream));
-                } else if (cacheRegister.get(answerFromUpstream).isConcludableAnswerCache()) {
-                    ConcludableAnswerCache answerCache = cacheRegister.get(answerFromUpstream).asConcludableAnswerCache();
-                    requestState = new FollowingExplain(fromUpstream, answerCache, iteration);
-                } else {
-                    throw TypeDBException.of(ILLEGAL_STATE);
-                }
-            } else {
-                ConcludableAnswerCache answerCache = new ConcludableAnswerCache(cacheRegister, answerFromUpstream);
-                cacheRegister.put(answerFromUpstream, answerCache);
-                requestState = new Explain(fromUpstream, answerCache, iteration);
-                requestState.asExploration().downstreamManager().addDownstreams(ruleDownstreams(fromUpstream));
-            }
-        } else if (fromUpstream.partialAnswer().asConcludable().isMatch()) {
-            if (cacheRegister.containsKey(answerFromUpstream)) {
-                if (cacheRegister.get(answerFromUpstream).isConceptMapCache()) {
-                    ConceptMapCache answerCache = cacheRegister.get(answerFromUpstream).asConceptMapCache();
-                    requestState = new FollowingMatch(fromUpstream, answerCache, iteration);
-                } else if (cacheRegister.get(answerFromUpstream).isConcludableAnswerCache()) {
-                    ConcludableAnswerCache answerCache = cacheRegister.get(answerFromUpstream).asConcludableAnswerCache();
-                    requestState = new FollowingExplain(fromUpstream, answerCache, iteration);
-                } else {
-                    throw TypeDBException.of(ILLEGAL_STATE);
-                }
-            } else {
-                ConceptMapCache answerCache = new ConceptMapCache(cacheRegister, answerFromUpstream,
-                                                                  () -> traversalIterator(concludable.pattern(),
-                                                                                          answerFromUpstream));
-                cacheRegister.put(answerFromUpstream, answerCache);
-                answerCache.completeIfSubsumerComplete();
-                boolean singleAnswerRequired = answerFromUpstream.concepts().keySet().containsAll(unboundVars);
-                requestState = new Match(fromUpstream, answerCache, iteration, singleAnswerRequired);
-                requestState.asExploration().downstreamManager().addDownstreams(ruleDownstreams(fromUpstream));
-            }
-        } else {
-            throw TypeDBException.of(ILLEGAL_STATE);
-        }
-        return requestState;
-    }
-
-    private List<Request> ruleDownstreams(Request fromUpstream) {
-        // loop termination: when receiving a new request, we check if we have seen it before from this root query
-        // if we have, we do not allow rules to be registered as possible downstreams
-        List<Request> downstreams = new ArrayList<>();
-        Partial.Concludable<?> partialAnswer = fromUpstream.partialAnswer().asConcludable();
-        for (Map.Entry<Driver<ConclusionResolver>, Set<Unifier>> entry : applicableRules.entrySet()) {
-            Driver<ConclusionResolver> conclusionResolver = entry.getKey();
-            for (Unifier unifier : entry.getValue()) {
-                Optional<? extends Partial.Conclusion<?, ?>> unified = partialAnswer.toDownstream(
-                        unifier, resolverRules.get(conclusionResolver));
-                unified.ifPresent(
-                        conclusion -> downstreams.add(Request.create(driver(), conclusionResolver, conclusion)));
-            }
-        }
-        return downstreams;
-    }
-
-    private static Set<Identifier.Variable.Retrievable> unboundVars(Conjunction conjunction) {
-        Set<Identifier.Variable.Retrievable> missingBounds = new HashSet<>();
-        iterate(conjunction.variables()).filter(var -> var.id().isRetrievable()).forEachRemaining(var -> {
-            if (var.isType() && !var.asType().label().isPresent()) missingBounds.add(var.asType().id().asRetrievable());
-            else if (var.isThing() && !var.asThing().iid().isPresent())
-                missingBounds.add(var.asThing().id().asRetrievable());
-        });
-        return missingBounds;
-    }
-
-    private class FollowingMatch extends CachingRequestState<ConceptMap, ConceptMap> {
-
-        public FollowingMatch(Request fromUpstream, AnswerCache<ConceptMap, ConceptMap> answerCache, int iteration) {
-            super(fromUpstream, answerCache, iteration, true, true);
-        }
-
-        @Override
-        protected FunctionalIterator<? extends Partial<?>> toUpstream(ConceptMap conceptMap) {
-            return Iterators.single(fromUpstream.partialAnswer().asConcludable().asMatch().toUpstreamLookup(
-                    conceptMap, concludable.isInferredAnswer(conceptMap)));
-        }
-
-    }
-
-    private class Match extends CachingRequestState<ConceptMap, ConceptMap> implements Exploration {
-
-        private final DownstreamManager downstreamManager;
-        private final boolean singleAnswerRequired;
-
-        public Match(Request fromUpstream, AnswerCache<ConceptMap, ConceptMap> answerCache,
-                     int iteration, boolean singleAnswerRequired) {
-            super(fromUpstream, answerCache, iteration, true, false);
-            this.downstreamManager = new DownstreamManager();
-            this.singleAnswerRequired = singleAnswerRequired;
-        }
-
-        @Override
-        public boolean isExploration() {
-            return true;
-        }
-
-        @Override
-        public Exploration asExploration() {
-            return this;
-        }
-
-        @Override
-        public DownstreamManager downstreamManager() {
-            return downstreamManager;
-        }
-
-        @Override
-        public void newAnswer(Partial<?> partial) {
-            if (!answerCache.isComplete()) answerCache.add(partial.conceptMap());
-        }
-
-        @Override
-        public boolean singleAnswerRequired() {
-            return singleAnswerRequired;
-        }
-
-        @Override
-        protected FunctionalIterator<? extends Partial<?>> toUpstream(ConceptMap conceptMap) {
-            return Iterators.single(fromUpstream.partialAnswer().asConcludable().asMatch().toUpstreamLookup(
-                    conceptMap, concludable.isInferredAnswer(conceptMap)));
-        }
-    }
-
-    private static class FollowingExplain extends CachingRequestState<Partial.Concludable<?>, ConceptMap> {
-
-        public FollowingExplain(Request fromUpstream, AnswerCache<Partial.Concludable<?>, ConceptMap> answerCache,
-                                int iteration) {
-            super(fromUpstream, answerCache, iteration, true, true);
-        }
-
-        @Override
-        protected FunctionalIterator<? extends Partial<?>> toUpstream(Partial.Concludable<?> partial) {
-            return Iterators.single(partial.asExplain().toUpstreamInferred());
-        }
-    }
-
-    private static class Explain extends CachingRequestState<Partial.Concludable<?>, ConceptMap> implements Exploration {
-
-        private final DownstreamManager downstreamManager;
-
-        public Explain(Request fromUpstream, AnswerCache<Partial.Concludable<?>, ConceptMap> answerCache,
-                       int iteration) {
-            super(fromUpstream, answerCache, iteration, false, false);
-            this.downstreamManager = new DownstreamManager();
-        }
-
-        @Override
-        public boolean isExploration() {
-            return true;
-        }
-
-        @Override
-        public Exploration asExploration() {
-            return this;
-        }
-
-        @Override
-        public DownstreamManager downstreamManager() {
-            return downstreamManager;
-        }
-
-        @Override
-        public void newAnswer(Partial<?> partial) {
-            if (!answerCache.isComplete()) answerCache.add(partial.asConcludable());
-        }
-
-        @Override
-        public boolean singleAnswerRequired() {
-            return false;
-        }
-
-        @Override
-        protected FunctionalIterator<? extends Partial<?>> toUpstream(Partial.Concludable<?> partial) {
-            return Iterators.single(partial.asExplain().toUpstreamInferred());
-        }
-
     }
 
 }

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -110,6 +110,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         cacheRegistersByRoot.remove(root);
         requestMapByRoot.remove(root);
         subsumptionTrackers.remove(root);
+        boundConcludableResolversByRoot.remove(root);
     }
 
     private Driver<BoundConcludableResolver> getOrReplaceBoundConcludable(Driver<? extends Resolver<?>> root, ConceptMap bounds) {

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -116,7 +116,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         return boundConcludableResolversByRoot.computeIfAbsent(root, r -> new HashMap<>()).computeIfAbsent(bounds, b -> {
             LOG.debug("{}: Creating a new BoundConcludableResolver for bounds: {}", name(), bounds);
             // TODO: We could use the bounds to prune the applicable rules further
-            return registry.registerBoundConcludable(concludable, bounds, resolverRules, applicableRules);
+            return registry.registerBoundConcludable(concludable, bounds, resolverRules, applicableRules, root, iterationByRoot.get(root));
         });
     }
 

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -81,8 +81,10 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
 
         Driver<? extends Resolver<?>> root = fromUpstream.partialAnswer().root();
         iterationByRoot.putIfAbsent(root, iteration);
-        if (iteration > iterationByRoot.get(root)) prepareNextIteration(root, iteration);
-        else if (iteration < iterationByRoot.get(root)) {
+        if (iteration > iterationByRoot.get(root)) {
+            prepareNextIteration(root, iteration);
+        }
+        if (iteration < iterationByRoot.get(root)) {
             // short circuit if the request came from a prior iteration
             failToUpstream(fromUpstream, iteration);
         } else {
@@ -107,6 +109,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         iterationByRoot.put(root, iteration);
         cacheRegistersByRoot.remove(root);
         requestMapByRoot.remove(root);
+        subsumptionTrackers.remove(root);
     }
 
     private Driver<BoundConcludableResolver> getOrReplaceBoundConcludable(Driver<? extends Resolver<?>> root, ConceptMap bounds) {

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -285,7 +285,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
                 ConceptMapCache answerCache = new ConceptMapCache(cacheRegister, answerFromUpstream);
                 cacheRegister.put(answerFromUpstream, answerCache);
                 if (!answerCache.completeIfSubsumerComplete()) {
-                    answerCache.addSource(traversalIterator(concludable.pattern(), answerFromUpstream));
+                    answerCache.addToSource(traversalIterator(concludable.pattern(), answerFromUpstream));
                 }
                 boolean singleAnswerRequired = answerFromUpstream.concepts().keySet().containsAll(unboundVars);
                 requestState = new Match(fromUpstream, answerCache, iteration, singleAnswerRequired);

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -283,11 +283,11 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
                     throw TypeDBException.of(ILLEGAL_STATE);
                 }
             } else {
-                ConceptMapCache answerCache = new ConceptMapCache(cacheRegister, answerFromUpstream);
+                ConceptMapCache answerCache = new ConceptMapCache(cacheRegister, answerFromUpstream,
+                                                                  () -> traversalIterator(concludable.pattern(),
+                                                                                          answerFromUpstream));
                 cacheRegister.put(answerFromUpstream, answerCache);
-                if (!answerCache.completeIfSubsumerComplete()) {
-                    answerCache.addToSource(traversalIterator(concludable.pattern(), answerFromUpstream));
-                }
+                answerCache.completeIfSubsumerComplete();
                 boolean singleAnswerRequired = answerFromUpstream.concepts().keySet().containsAll(unboundVars);
                 requestState = new Match(fromUpstream, answerCache, iteration, singleAnswerRequired);
                 requestState.asExploration().downstreamManager().addDownstreams(ruleDownstreams(fromUpstream));

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -307,8 +307,8 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
             for (Unifier unifier : entry.getValue()) {
                 Optional<? extends Partial.Conclusion<?, ?>> unified = partialAnswer.toDownstream(
                         unifier, resolverRules.get(conclusionResolver));
-                unified.ifPresent(conclusion -> downstreams.add(
-                        Request.create(driver(), conclusionResolver, conclusion)));
+                unified.ifPresent(
+                        conclusion -> downstreams.add(Request.create(driver(), conclusionResolver, conclusion)));
             }
         }
         return downstreams;

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -25,6 +25,7 @@ import com.vaticle.typedb.core.concept.ConceptManager;
 import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.logic.LogicManager;
 import com.vaticle.typedb.core.logic.Rule;
+import com.vaticle.typedb.core.logic.resolvable.Concludable;
 import com.vaticle.typedb.core.logic.resolvable.Unifier;
 import com.vaticle.typedb.core.pattern.Conjunction;
 import com.vaticle.typedb.core.reasoner.resolution.ResolverRegistry;
@@ -62,7 +63,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
 
     private final LinkedHashMap<Driver<ConclusionResolver>, Set<Unifier>> applicableRules;
     private final Map<Driver<ConclusionResolver>, Rule> resolverRules;
-    private final com.vaticle.typedb.core.logic.resolvable.Concludable concludable;
+    private final Concludable concludable;
     private final LogicManager logicMgr;
     private final Map<Request, CachingRequestState<?, ConceptMap>> requestStates;
     private final Set<Identifier.Variable.Retrievable> unboundVars;
@@ -70,7 +71,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
     protected final Map<Driver<? extends Resolver<?>>, Map<ConceptMap, AnswerCache<?, ConceptMap>>> cacheRegistersByRoot;
     protected final Map<Driver<? extends Resolver<?>>, Integer> iterationByRoot;
 
-    public ConcludableResolver(Driver<ConcludableResolver> driver, com.vaticle.typedb.core.logic.resolvable.Concludable concludable,
+    public ConcludableResolver(Driver<ConcludableResolver> driver, Concludable concludable,
                                ResolverRegistry registry, TraversalEngine traversalEngine, ConceptManager conceptMgr,
                                LogicManager logicMgr, boolean resolutionTracing) {
         super(driver, ConcludableResolver.class.getSimpleName() + "(pattern: " + concludable.pattern() + ")",

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 
@@ -74,14 +73,16 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
         } else {
             ConceptMap bounds = fromUpstream.partialAnswer().conceptMap();
             Driver<BoundRetrievableResolver> boundRetrievable = getOrReplaceBoundRetrievable(root, bounds);
-            Optional<ConceptMap> subsumer = subsumptionTrackers.computeIfAbsent(
-                    root, r -> new SubsumptionTracker()).getSubsumer(bounds);
-            // If there is a finished subsumer, let the BoundRetrievable know that it can go there for answers
-            Request request = subsumer
-                    .map(conceptMap -> Request.ToSubsumed.create(
-                            driver(), boundRetrievable, boundRetrievablesByRoot.get(root).get(conceptMap),
-                            fromUpstream.partialAnswer()))
-                    .orElseGet(() -> Request.create(driver(), boundRetrievable, fromUpstream.partialAnswer()));
+            // TODO: Re-enable subsumption when async bug is fixed
+            // Optional<ConceptMap> subsumer = subsumptionTrackers.computeIfAbsent(
+            //         root, r -> new SubsumptionTracker()).getSubsumer(bounds);
+            // // If there is a finished subsumer, let the BoundRetrievable know that it can go there for answers
+            // Request request = subsumer
+            //         .map(conceptMap -> Request.ToSubsumed.create(
+            //                 driver(), boundRetrievable, boundRetrievablesByRoot.get(root).get(conceptMap),
+            //                 fromUpstream.partialAnswer()))
+            //         .orElseGet(() -> Request.create(driver(), boundRetrievable, fromUpstream.partialAnswer()));
+            Request request = Request.create(driver(), boundRetrievable, fromUpstream.partialAnswer());
             requestMapByRoot.computeIfAbsent(root, r -> new HashMap<>()).put(request, fromUpstream);
             requestFromDownstream(request, fromUpstream, iteration);
         }

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -115,6 +115,11 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
     }
 
     @Override
+    public void terminate(Throwable cause) {
+        super.terminate(cause);
+    }
+
+    @Override
     protected void receiveFail(Response.Fail fail, int iteration) {
         if (iteration < iterationByRoot.get(fail.sourceRequest().partialAnswer().root())) {
             // short circuit old iteration failed messages to upstream

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -101,20 +101,16 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
 
     @Override
     protected void receiveAnswer(Answer fromDownstream, int iteration) {
-        answerToUpstream(fromDownstream.answer(), requestMap.get(unpackRequest(fromDownstream.sourceRequest())), iteration);
+        answerToUpstream(fromDownstream.answer(), requestMap.get(fromDownstream.sourceRequest()), iteration);
     }
 
     @Override
     protected void receiveFail(Response.Fail fromDownstream, int iteration) {
-        Request request = unpackRequest(fromDownstream.sourceRequest());
+        Request request = fromDownstream.sourceRequest();
         subsumptionTrackers
                 .computeIfAbsent(request.partialAnswer().root(), r -> new SubsumptionTracker())
                 .addFinished(request.partialAnswer().conceptMap());
         failToUpstream(requestMap.get(request), iteration);
-    }
-
-    private static Request unpackRequest(Request request) {
-        return request.isToSubsumed() ? request.asToSubsumed() : request;
     }
 
     @Override

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -18,17 +18,11 @@
 package com.vaticle.typedb.core.reasoner.resolution.resolver;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
-import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
-import com.vaticle.typedb.core.common.iterator.Iterators;
 import com.vaticle.typedb.core.concept.ConceptManager;
 import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.logic.resolvable.Retrievable;
 import com.vaticle.typedb.core.reasoner.resolution.ResolverRegistry;
-import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState.Partial;
-import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache;
-import com.vaticle.typedb.core.reasoner.resolution.framework.AnswerCache.SubsumptionAnswerCache.ConceptMapCache;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Request;
-import com.vaticle.typedb.core.reasoner.resolution.framework.RequestState.CachingRequestState;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Resolver;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Response;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Response.Answer;
@@ -38,7 +32,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 
@@ -47,8 +40,8 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
     private static final Logger LOG = LoggerFactory.getLogger(RetrievableResolver.class);
 
     private final Retrievable retrievable;
-    private final Map<Request, RetrievableRequestState> requestStates;
-    protected final Map<Driver<? extends Resolver<?>>, Map<ConceptMap, AnswerCache<ConceptMap, ConceptMap>>> cacheRegistersByRoot;
+    protected final Map<Driver<? extends Resolver<?>>, Map<ConceptMap, Driver<BoundRetrievableResolver>>> boundRetrievablesByRoot;
+    private final Map<Driver<BoundRetrievableResolver>, Integer> boundRetrievableIterations;
     protected final Map<Driver<? extends Resolver<?>>, Integer> iterationByRoot;
 
     public RetrievableResolver(Driver<RetrievableResolver> driver, Retrievable retrievable, ResolverRegistry registry,
@@ -56,9 +49,9 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
         super(driver, RetrievableResolver.class.getSimpleName() + "(pattern: " + retrievable.pattern() + ")",
               registry, traversalEngine, conceptMgr, resolutionTracing);
         this.retrievable = retrievable;
-        this.requestStates = new HashMap<>();
-        this.cacheRegistersByRoot = new HashMap<>();
+        this.boundRetrievablesByRoot = new HashMap<>();
         this.iterationByRoot = new HashMap<>();
+        this.boundRetrievableIterations = new HashMap<>();
     }
 
     @Override
@@ -69,32 +62,34 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
         Driver<? extends Resolver<?>> root = fromUpstream.partialAnswer().root();
         iterationByRoot.putIfAbsent(root, iteration);
         if (iteration > iterationByRoot.get(root)) {
-            prepareNextIteration(fromUpstream.partialAnswer().root(), iteration);
+            prepareNextIteration(root, iteration);
         }
 
-        if (iteration < iterationByRoot.get(fromUpstream.partialAnswer().root())) {
+        if (iteration < iterationByRoot.get(root)) {
             // short circuit old iteration failed messages to upstream
             failToUpstream(fromUpstream, iteration);
         } else {
-            RetrievableRequestState requestState = getOrReplaceRequestState(fromUpstream, iteration);
-            assert iteration == requestState.iteration();
-            nextAnswer(fromUpstream, requestState, iteration);
+            ConceptMap bounds = fromUpstream.partialAnswer().conceptMap();
+            Driver<BoundRetrievableResolver> boundRetrievable = getOrReplaceBoundRetrievable(root, bounds, iteration);
+            Request request = Request.create(driver(), boundRetrievable, fromUpstream.partialAnswer());
+            requestFromDownstream(request, fromUpstream, iteration);
         }
     }
 
     private void prepareNextIteration(Driver<? extends Resolver<?>> root, int iteration) {
         iterationByRoot.put(root, iteration);
-        cacheRegistersByRoot.get(root).clear();
+        boundRetrievablesByRoot.get(root).clear();
+        boundRetrievableIterations.clear();
     }
 
     @Override
     protected void receiveAnswer(Answer fromDownstream, int iteration) {
-        throw TypeDBException.of(ILLEGAL_STATE);
+        answerToUpstream(fromDownstream.answer(), fromDownstream.sourceRequest(), iteration);
     }
 
     @Override
     protected void receiveFail(Response.Fail fromDownstream, int iteration) {
-        throw TypeDBException.of(ILLEGAL_STATE);
+        failToUpstream(fromDownstream.sourceRequest(), iteration);
     }
 
     @Override
@@ -102,56 +97,29 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
         throw TypeDBException.of(ILLEGAL_STATE);
     }
 
-    private RetrievableRequestState getOrReplaceRequestState(Request fromUpstream, int iteration) {
-        if (!requestStates.containsKey(fromUpstream)) {
-            requestStates.put(fromUpstream, createRequestState(fromUpstream, iteration));
+    private Driver<BoundRetrievableResolver> getOrReplaceBoundRetrievable(Driver<? extends Resolver<?>> root,
+                                                                          ConceptMap bounds, int iteration) {
+        boundRetrievablesByRoot.computeIfAbsent(root, x -> new HashMap<>());
+        Driver<BoundRetrievableResolver> boundRetrievable;
+        if (!boundRetrievablesByRoot.get(root).containsKey(bounds)) {
+            boundRetrievable = putBoundRetrievable(root, bounds, iteration);
         } else {
-            RetrievableRequestState requestState = this.requestStates.get(fromUpstream);
-
-            if (requestState.iteration() < iteration) {
+            boundRetrievable = boundRetrievablesByRoot.get(root).get(bounds);
+            if (boundRetrievableIterations.get(boundRetrievable) < iteration) {
                 // when the same request for the next iteration the first time, re-initialise required state
-                RetrievableRequestState requestStateNextIter = createRequestState(fromUpstream, iteration);
-                this.requestStates.put(fromUpstream, requestStateNextIter);
+                boundRetrievable = putBoundRetrievable(root, bounds, iteration);
             }
         }
-        return requestStates.get(fromUpstream);
+        return boundRetrievable;
     }
 
-    protected RetrievableRequestState createRequestState(Request fromUpstream, int iteration) {
-        LOG.debug("{}: Creating a new RequestState for iteration:{}, request: {}", name(), iteration, fromUpstream);
-        assert fromUpstream.partialAnswer().isRetrievable();
-        Driver<? extends Resolver<?>> root = fromUpstream.partialAnswer().root();
-        cacheRegistersByRoot.putIfAbsent(root, new HashMap<>());
-        Map<ConceptMap, AnswerCache<ConceptMap, ConceptMap>> cacheRegister = cacheRegistersByRoot.get(root);
-        AnswerCache<ConceptMap, ConceptMap> answerCache = cacheRegister.computeIfAbsent(
-                fromUpstream.partialAnswer().conceptMap(), upstreamAns -> {
-                    ConceptMapCache newCache = new ConceptMapCache(cacheRegister, upstreamAns);
-                    if (!newCache.completeIfSubsumerComplete()) newCache.addSource(traversalIterator(retrievable.pattern(), upstreamAns));
-                    return newCache;
-                });
-        return new RetrievableRequestState(fromUpstream, answerCache, iteration);
+    protected Driver<BoundRetrievableResolver> putBoundRetrievable(Driver<? extends Resolver<?>> root,
+                                                                   ConceptMap bounds, int iteration) {
+        LOG.debug("{}: Creating a new BoundRetrievableResolver for iteration:{}, bounds: {}", name(), iteration, bounds);
+        Driver<BoundRetrievableResolver> boundRetrievable = registry.registerBoundRetrievable(retrievable, bounds);
+        boundRetrievablesByRoot.get(root).put(bounds, boundRetrievable);
+        boundRetrievableIterations.put(boundRetrievable, iteration);
+        return boundRetrievable;
     }
 
-    private void nextAnswer(Request fromUpstream, RetrievableRequestState requestState, int iteration) {
-        Optional<Partial.Compound<?, ?>> upstreamAnswer = requestState.nextAnswer().map(Partial::asCompound);
-        if (upstreamAnswer.isPresent()) {
-            answerToUpstream(upstreamAnswer.get(), fromUpstream, iteration);
-        } else {
-            requestStates.get(fromUpstream).answerCache().setComplete();
-            failToUpstream(fromUpstream, iteration);
-        }
-    }
-
-    private static class RetrievableRequestState extends CachingRequestState<ConceptMap, ConceptMap> {
-
-        public RetrievableRequestState(Request fromUpstream, AnswerCache<ConceptMap, ConceptMap> answerCache, int iteration) {
-            super(fromUpstream, answerCache, iteration, false, false);
-        }
-
-        @Override
-        protected FunctionalIterator<? extends Partial<?>> toUpstream(ConceptMap answer) {
-            return Iterators.single(fromUpstream.partialAnswer().asRetrievable()
-                                            .aggregateToUpstream(answer));
-        }
-    }
 }

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -119,7 +119,8 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
                     .computeIfAbsent(fromDownstream.answer().root(), r -> new HashMap<>())
                     .computeIfAbsent(fromDownstream.sourceRequest(), request -> new HashSet<>());
             if (p.contains(fromDownstream.answer().conceptMap())) {
-                LOG.debug("Request send: {}\nAnswer received: {}\nRetrievable: {}", fromDownstream.sourceRequest(), fromDownstream, retrievable);
+                throw new RuntimeException(String.format("Request send: %s\nAnswer received: %s\nRetrievable: %s",
+                                           fromDownstream.sourceRequest(), fromDownstream, retrievable));
             }
             p.add(fromDownstream.answer().conceptMap());
             answerToUpstream(fromDownstream.answer(),

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -83,7 +83,7 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
                 // If there is a finished subsumer, let the BoundRetrievable know that it can go there for answers
                 Driver<BoundRetrievableResolver> subsumer = boundRetrievablesByRoot.get(root).get(finishedSubsumingBounds.get());
                 request = Request.ToSubsumed.create(driver(), boundRetrievable, subsumer, fromUpstream.partialAnswer());
-                requestMap.put(request.asToSubsumed().toRequest(), fromUpstream);
+                requestMap.put(request.asToSubsumed(), fromUpstream);
             } else {
                 request = Request.create(driver(), boundRetrievable, fromUpstream.partialAnswer());
                 requestMap.put(request, fromUpstream);
@@ -114,7 +114,7 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
     }
 
     private static Request unpackRequest(Request request) {
-        return request.isToSubsumed() ? request.asToSubsumed().toRequest() : request;
+        return request.isToSubsumed() ? request.asToSubsumed() : request;
     }
 
     @Override

--- a/reasoner/resolution/resolver/SubsumptionTracker.java
+++ b/reasoner/resolution/resolver/SubsumptionTracker.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.vaticle.typedb.core.reasoner.resolution.resolver;
+
+import com.vaticle.typedb.core.concept.Concept;
+import com.vaticle.typedb.core.concept.answer.ConceptMap;
+import com.vaticle.typedb.core.traversal.common.Identifier;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+class SubsumptionTracker {
+
+    private final Map<ConceptMap, Set<ConceptMap>> subsumersMap;
+    private final Set<ConceptMap> finishedStates;
+    private final Map<ConceptMap, ConceptMap> finishedMapping;
+
+    public SubsumptionTracker() {
+        this.finishedStates = new HashSet<>();
+        this.subsumersMap = new HashMap<>();
+        this.finishedMapping = new HashMap<>();
+    }
+
+    public void addFinished(ConceptMap conceptMap) {
+        this.finishedStates.add(conceptMap);
+    }
+
+    public void clear() {
+        finishedStates.clear();
+    }
+
+    public Optional<ConceptMap> getSubsumer(ConceptMap unfinished) {
+        if (finishedMapping.containsKey(unfinished)) return Optional.of(finishedMapping.get(unfinished));
+        else {
+            Optional<ConceptMap> finishedSubsumer = findFinishedSubsumer(
+                    subsumersMap.computeIfAbsent(unfinished, this::subsumingConceptMaps));
+            finishedSubsumer.ifPresent(conceptMap -> finishedMapping.put(unfinished, conceptMap));
+            return finishedSubsumer;
+        }
+    }
+
+    protected Optional<ConceptMap> findFinishedSubsumer(Set<ConceptMap> subsumingConceptMaps) {
+        for (ConceptMap subsumer : subsumingConceptMaps) {
+            // Gets the first complete cache we find. Getting the smallest could be more efficient.
+            if (finishedStates.contains(subsumer)) return Optional.of(subsumer);
+        }
+        return Optional.empty();
+    }
+
+    private Set<ConceptMap> subsumingConceptMaps(ConceptMap fromUpstream) {
+        Set<ConceptMap> subsumingCacheKeys = new HashSet<>();
+        Map<Identifier.Variable.Retrievable, Concept> concepts = new HashMap<>(fromUpstream.concepts());
+        powerSet(concepts.entrySet()).forEach(powerSet -> subsumingCacheKeys.add(toConceptMap(powerSet)));
+        subsumingCacheKeys.remove(fromUpstream);
+        return subsumingCacheKeys;
+    }
+
+    private <T> Set<Set<T>> powerSet(Set<T> set) {
+        Set<Set<T>> powerSet = new HashSet<>();
+        powerSet.add(set);
+        set.forEach(el -> {
+            Set<T> s = new HashSet<>(set);
+            s.remove(el);
+            powerSet.addAll(powerSet(s));
+        });
+        return powerSet;
+    }
+
+    private ConceptMap toConceptMap(Set<Map.Entry<Identifier.Variable.Retrievable, Concept>> conceptsEntrySet) {
+        HashMap<Identifier.Variable.Retrievable, Concept> map = new HashMap<>();
+        conceptsEntrySet.forEach(entry -> map.put(entry.getKey(), entry.getValue()));
+        return new ConceptMap(map);
+    }
+}

--- a/reasoner/resolution/resolver/SubsumptionTracker.java
+++ b/reasoner/resolution/resolver/SubsumptionTracker.java
@@ -43,22 +43,18 @@ class SubsumptionTracker {
         this.finishedStates.add(conceptMap);
     }
 
-    public void clear() {
-        finishedStates.clear();
-    }
-
     public Optional<ConceptMap> getSubsumer(ConceptMap unfinished) {
         if (finishedMapping.containsKey(unfinished)) return Optional.of(finishedMapping.get(unfinished));
         else {
             Optional<ConceptMap> finishedSubsumer = findFinishedSubsumer(
                     subsumersMap.computeIfAbsent(unfinished, this::subsumingConceptMaps));
-            finishedSubsumer.ifPresent(conceptMap -> finishedMapping.put(unfinished, conceptMap));
+            finishedSubsumer.ifPresent(finished -> finishedMapping.put(unfinished, finished));
             return finishedSubsumer;
         }
     }
 
-    protected Optional<ConceptMap> findFinishedSubsumer(Set<ConceptMap> subsumingConceptMaps) {
-        for (ConceptMap subsumer : subsumingConceptMaps) {
+    protected Optional<ConceptMap> findFinishedSubsumer(Set<ConceptMap> subsumers) {
+        for (ConceptMap subsumer : subsumers) {
             // Gets the first complete cache we find. Getting the smallest could be more efficient.
             if (finishedStates.contains(subsumer)) return Optional.of(subsumer);
         }
@@ -66,11 +62,11 @@ class SubsumptionTracker {
     }
 
     private Set<ConceptMap> subsumingConceptMaps(ConceptMap fromUpstream) {
-        Set<ConceptMap> subsumingCacheKeys = new HashSet<>();
+        Set<ConceptMap> subsumers = new HashSet<>();
         Map<Identifier.Variable.Retrievable, Concept> concepts = new HashMap<>(fromUpstream.concepts());
-        powerSet(concepts.entrySet()).forEach(powerSet -> subsumingCacheKeys.add(toConceptMap(powerSet)));
-        subsumingCacheKeys.remove(fromUpstream);
-        return subsumingCacheKeys;
+        powerSet(concepts.entrySet()).forEach(c -> subsumers.add(toConceptMap(c)));
+        subsumers.remove(fromUpstream);
+        return subsumers;
     }
 
     private <T> Set<Set<T>> powerSet(Set<T> set) {


### PR DESCRIPTION
## What is the goal of this PR?

We break down the actor that handles concludable parts of a query. It becomes one actor for each partial answer, plus one coordinating actor.

## What are the changes implemented in this PR?

- Split `ConcludableResolver` into `ConcludableResolver` and `BoundConcludableResolver`. 
- This required moving the reiteration messaging down into the BoundCOncludableResolvers.
- `ConcludableResolver` is almost identical to `RetrievableResolver` now so should be abstracted.