### PR TITLE
Replace next() with first() to ensure resources are closed

### DIFF
--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -32,6 +32,7 @@ import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.DELETE_ROLEPLAYER_NOT_PRESENT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.RELATION_PLAYER_MISSING;
@@ -84,11 +85,11 @@ public class RelationImpl extends ThingImpl implements Relation {
     @Override
     public void removePlayer(RoleType roleType, Thing player) {
         validateIsNotDeleted();
-        FunctionalIterator<ThingVertex> role = writableVertex().outs().edge(
+        Optional<ThingVertex> role = writableVertex().outs().edge(
                 RELATING, PrefixIID.of(ROLE), ((RoleTypeImpl) roleType).vertex.iid()
-        ).to().filter(v -> v.ins().edge(PLAYING, ((ThingImpl) player).writableVertex()) != null);
-        if (role.hasNext()) {
-            RoleImpl.of(role.next()).delete();
+        ).to().filter(v -> v.ins().edge(PLAYING, ((ThingImpl) player).writableVertex()) != null).first();
+        if (role.isPresent()) {
+            RoleImpl.of(role.get()).delete();
             deleteIfNoPlayer();
         } else {
             throw exception(TypeDBException.of(DELETE_ROLEPLAYER_NOT_PRESENT, player.getType().getLabel(), roleType.getLabel().toString()));

--- a/concept/thing/impl/RoleImpl.java
+++ b/concept/thing/impl/RoleImpl.java
@@ -38,14 +38,14 @@ public class RoleImpl {
     }
 
     void optimise() {
-        ThingVertex.Write relation = vertex.ins().edge(RELATING).from().next().toWrite();
-        ThingVertex.Write player = vertex.ins().edge(PLAYING).from().next().toWrite();
+        ThingVertex.Write relation = vertex.ins().edge(RELATING).from().first().get().toWrite();
+        ThingVertex.Write player = vertex.ins().edge(PLAYING).from().first().get().toWrite();
         relation.outs().put(ROLEPLAYER, player, vertex, vertex.isInferred());
     }
 
     public void delete() {
-        ThingVertex.Write relation = vertex.ins().edge(RELATING).from().next().toWrite();
-        ThingVertex.Write player = vertex.ins().edge(PLAYING).from().next().toWrite();
+        ThingVertex.Write relation = vertex.ins().edge(RELATING).from().first().get().toWrite();
+        ThingVertex.Write player = vertex.ins().edge(PLAYING).from().first().get().toWrite();
         relation.outs().edge(ROLEPLAYER, player, vertex).delete();
         vertex.delete();
     }

--- a/concept/type/impl/RoleTypeImpl.java
+++ b/concept/type/impl/RoleTypeImpl.java
@@ -100,7 +100,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
 
     @Override
     public RelationTypeImpl getRelationType() {
-        return RelationTypeImpl.of(graphMgr, vertex.ins().edge(Encoding.Edge.Type.RELATES).from().next());
+        return RelationTypeImpl.of(graphMgr, vertex.ins().edge(Encoding.Edge.Type.RELATES).from().first().get());
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

As mentioned in #6404 we occasionally use `iterator.next()` instead of `.first()`. This can cause iterators to remain open and un-recycled until much later when finalised. We should use terminating iterator operations such as `first()` when only retriving one element from an iterator.

## What are the changes implemented in this PR?

* replace usages of a single `.next()` call with `.first().get()`