### PR TITLE
Prevent SIGSEGV when using a closed RocksIterator

### DIFF
--- a/rocks/RocksIterator.java
+++ b/rocks/RocksIterator.java
@@ -89,7 +89,8 @@ public final class RocksIterator extends AbstractFunctionalIterator.Sorted<KeyVa
 
     @Override
     public synchronized void forward(KeyValue<ByteArray, ByteArray> target) {
-        if (state == State.INIT) initialise(target.key());
+        if (state == State.COMPLETED) return;
+        else if (state == State.INIT) initialise(target.key());
         else internalRocksIterator.seek(target.key().getBytes());
         state = State.FORWARDED;
     }


### PR DESCRIPTION
## What is the goal of this PR?

Using a RocksIterator after it is closed can cause a `SIGSEGV`, which crashes the server. #6382 introduced a new API on RocksIterator that was not protected against `close()` race conditions, which is now corrected.

## What are the changes implemented in this PR?

* since `forward()` is synchronized, we only add a check to see if the iterator is completed before performing a seek() operation on the rocks iterator. This prevents utilising a closed rocksDB resouce, which would cause the SIGSEGV