### PR TITLE
Refactor Conclusion Resolver

### DIFF
--- a/concept/thing/Thing.java
+++ b/concept/thing/Thing.java
@@ -125,6 +125,14 @@ public interface Thing extends Concept {
     boolean hasInferred(Attribute attribute);
 
     /**
+     * Check whether a non-inferred Has edge to a given attribute instance exists
+     *
+     * @param attribute
+     * @return
+     */
+    boolean hasNonInferred(Attribute attribute);
+
+    /**
      * Get all {@code RoleType} types this {@code Thing} is playing in a {@code Relation}.
      *
      * @return an iterator stream of {@code RoleType} types that this {@code Thing} plays.

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -193,6 +193,12 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
     }
 
     @Override
+    public boolean hasNonInferred(Attribute attribute) {
+        ThingEdge hasEdge = readableVertex().outs().edge(HAS, ((ThingImpl) attribute).readableVertex());
+        return hasEdge != null && !hasEdge.isInferred();
+    }
+
+    @Override
     public FunctionalIterator<? extends RoleType> getPlaying() {
         return readableVertex().outs().edge(PLAYING).to().map(ThingVertex::type)
                 .map(v -> RoleTypeImpl.of(readableVertex().graphs(), v));

--- a/concurrent/actor/Actor.java
+++ b/concurrent/actor/Actor.java
@@ -17,6 +17,9 @@
 
 package com.vaticle.typedb.core.concurrent.actor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -25,9 +28,11 @@ import java.util.function.Function;
 @ThreadSafe
 public abstract class Actor<ACTOR extends Actor<ACTOR>> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(Actor.class);
     private static final String ERROR_ACTOR_DRIVER_IS_NULL = "driver() must not be null.";
     private final Driver<ACTOR> driver;
     private final String name;
+    private boolean terminated;
 
     public static <A extends Actor<A>> Driver<A> driver(Function<Driver<A>, A> actorFn, ActorExecutorGroup service) {
         return new Driver<>(actorFn, service);
@@ -38,6 +43,7 @@ public abstract class Actor<ACTOR extends Actor<ACTOR>> {
     protected Actor(Driver<ACTOR> driver, String name) {
         this.driver = driver;
         this.name = name;
+        this.terminated = false;
     }
 
     protected Driver<ACTOR> driver() {
@@ -48,6 +54,13 @@ public abstract class Actor<ACTOR extends Actor<ACTOR>> {
     public String name() {
         return name;
     }
+
+    public void terminate(Throwable cause) {
+        LOG.debug("Actor terminated. ", cause);
+        this.terminated = true;
+    }
+
+    public boolean isTerminated() { return terminated; }
 
     public static class Driver<ACTOR extends Actor<ACTOR>> {
 

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -530,7 +530,7 @@ public class Rule {
                     assert rp.roleType().isPresent() && rp.roleType().get().label().isPresent()
                             && whenConcepts.contains(playerId);
                     traversal.player(playerId, whenConcepts.get(playerId).asThing().getIID(),
-                                     set(getRole(rp, relationType, whenConcepts).getLabel())); // TODO include inheritance
+                                     set(roleType(rp, relationType, whenConcepts).getLabel())); // TODO include inheritance
                 });
                 return traversalEng.relations(traversal).map(conceptMgr::conceptMap)
                         .map(conceptMap -> conceptMap.get(relationId).asRelation());
@@ -547,7 +547,7 @@ public class Rule {
                 }
             }
 
-            private RoleType getRole(RelationConstraint.RolePlayer rp, RelationType scope, ConceptMap whenConcepts) {
+            private RoleType roleType(RelationConstraint.RolePlayer rp, RelationType scope, ConceptMap whenConcepts) {
                 if (rp.roleType().get().reference().isName()) {
                     return whenConcepts.get(rp.roleType().get().reference().asName()).asRoleType();
                 } else {
@@ -562,7 +562,7 @@ public class Rule {
                 com.vaticle.typedb.core.concept.thing.Relation relation = relationType.create(true);
                 thenConcepts.put(isa().owner().id(), relation);
                 relation().players().forEach(rp -> {
-                    RoleType role = getRole(rp, relationType, whenConcepts);
+                    RoleType role = roleType(rp, relationType, whenConcepts);
                     Thing player = whenConcepts.get(rp.player().id()).asThing();
                     relation.addPlayer(role, player, true);
                     thenConcepts.putIfAbsent(rp.roleType().get().id(), role);
@@ -578,7 +578,7 @@ public class Rule {
                 thenConcepts.put(isa().type().id(), relationType);
                 thenConcepts.put(isa().owner().id(), relation);
                 relation().players().forEach(rp -> {
-                    RoleType role = getRole(rp, relationType, whenConcepts);
+                    RoleType role = roleType(rp, relationType, whenConcepts);
                     Thing player = whenConcepts.get(rp.player().id()).asThing();
                     thenConcepts.putIfAbsent(rp.roleType().get().id(), role);
                     thenConcepts.putIfAbsent(rp.player().id(), player);

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -498,21 +498,21 @@ public class Rule {
                 if (isa.type().label().isPresent()) {
                     if (!inserted.getType().getLabel().equals(isa.type().label().get().properLabel())) return false;
                 } else if (!inserted.getType().getLabel().equals(whenConcepts.get(isa.type().id().asRetrievable()).asType().getLabel())) return false;
-                Map<Label, Map<Concept, Integer>> relationMap = new HashMap<>();
+                Map<String, Map<Concept, Integer>> relationMap = new HashMap<>();
                 relation.players().forEach(player -> {
                     assert player.roleType().isPresent(); // Must be present to be insertable
                     TypeVariable roleType = player.roleType().get();
-                    Label roleTypeLabel = roleType.label().map(LabelConstraint::properLabel)
-                            .orElseGet(() -> whenConcepts.get(roleType.id().asRetrievable()).asType().getLabel());
-                    Map<Concept, Integer> played = relationMap.computeIfAbsent(roleTypeLabel, p -> new HashMap<>());
+                    String descopedRoleTypeLabel = roleType.label().map(LabelConstraint::properLabel)
+                            .orElseGet(() -> whenConcepts.get(roleType.id().asRetrievable()).asType().getLabel()).name();
+                    Map<Concept, Integer> played = relationMap.computeIfAbsent(descopedRoleTypeLabel, p -> new HashMap<>());
                     Concept playerConcept = whenConcepts.get(player.player().id());
                     played.computeIfPresent(playerConcept, (p, count) -> count + 1);
                     played.putIfAbsent(playerConcept, 1);
                 });
-                Map<Label, Map<Concept, Integer>> insertedMap = new HashMap<>();
+                Map<String, Map<Concept, Integer>> insertedMap = new HashMap<>();
                 inserted.getPlayersByRoleType().forEach((role, players) -> {
                     players.forEach(player -> {
-                        Map<Concept, Integer> playerEntry = insertedMap.computeIfAbsent(role.getLabel(), r -> new HashMap<>());
+                        Map<Concept, Integer> playerEntry = insertedMap.computeIfAbsent(role.getLabel().name(), r -> new HashMap<>());
                         playerEntry.computeIfPresent(player, (p, count) -> count + 1);
                         playerEntry.putIfAbsent(player, 1);
                     });

--- a/pattern/variable/ThingVariable.java
+++ b/pattern/variable/ThingVariable.java
@@ -110,7 +110,7 @@ public class ThingVariable extends Variable implements AlphaEquivalent<ThingVari
         constraints().forEach(constraint -> constraint.addTo(traversal));
     }
 
-    private void constrain(ThingConstraint constraint) {
+    public void constrain(ThingConstraint constraint) {
         constraints.add(constraint);
         if (constraint.isIID()) {
             if (iidConstraint != null && !iidConstraint.equals(constraint)) {

--- a/pattern/variable/ThingVariable.java
+++ b/pattern/variable/ThingVariable.java
@@ -110,7 +110,7 @@ public class ThingVariable extends Variable implements AlphaEquivalent<ThingVari
         constraints().forEach(constraint -> constraint.addTo(traversal));
     }
 
-    public void constrain(ThingConstraint constraint) {
+    void constrain(ThingConstraint constraint) {
         constraints.add(constraint);
         if (constraint.isIID()) {
             if (iidConstraint != null && !iidConstraint.equals(constraint)) {

--- a/pattern/variable/ThingVariable.java
+++ b/pattern/variable/ThingVariable.java
@@ -110,7 +110,7 @@ public class ThingVariable extends Variable implements AlphaEquivalent<ThingVari
         constraints().forEach(constraint -> constraint.addTo(traversal));
     }
 
-    void constrain(ThingConstraint constraint) {
+    private void constrain(ThingConstraint constraint) {
         constraints.add(constraint);
         if (constraint.isIID()) {
             if (iidConstraint != null && !iidConstraint.equals(constraint)) {

--- a/reasoner/resolution/ResolverRegistry.java
+++ b/reasoner/resolution/ResolverRegistry.java
@@ -235,21 +235,12 @@ public class ResolverRegistry {
     }
 
     public Actor.Driver<BoundConclusionResolver> registerBoundConclusion(
-            Rule.Conclusion conclusion, ConceptMap bounds, Actor.Driver<ConditionResolver> conditionResolver,
-            boolean explain) {
+            Rule.Conclusion conclusion, ConceptMap bounds, Actor.Driver<ConditionResolver> conditionResolver) {
         LOG.debug("Register BoundConclusionResolver, pattern: {} bounds: {}", conclusion.conjunction(), bounds);
         Actor.Driver<BoundConclusionResolver> resolver;
-        if (explain) {
-            // TODO: Use explain resolver
-            resolver = Actor.driver(driver -> new BoundConclusionResolver(
-                    driver, conclusion, bounds, conditionResolver, materialiser, this, traversalEngine, conceptMgr,
-                    resolutionTracing), executorService);
-        } else {
-            // TODO: Use match resolver
-            resolver = Actor.driver(driver -> new BoundConclusionResolver(
-                    driver, conclusion, bounds, conditionResolver, materialiser, this, traversalEngine, conceptMgr,
-                    resolutionTracing), executorService);
-        }
+        resolver = Actor.driver(driver -> new BoundConclusionResolver(
+                driver, conclusion, bounds, conditionResolver, materialiser, this, traversalEngine, conceptMgr,
+                resolutionTracing), executorService);
         resolvers.add(resolver);
         if (terminated.get()) throw TypeDBException.of(RESOLUTION_TERMINATED); // guard races without synchronized
         return resolver;

--- a/reasoner/resolution/framework/ResolutionTracer.java
+++ b/reasoner/resolution/framework/ResolutionTracer.java
@@ -62,15 +62,15 @@ public final class ResolutionTracer {
         return INSTANCE;
     }
 
-    synchronized void request(String sender, String receiver, int iteration, String conceptMap) {
+    public synchronized void request(String sender, String receiver, int iteration, String conceptMap) {
         addMessage(sender, receiver, iteration, EdgeType.REQUEST, conceptMap);
     }
 
-    synchronized void responseAnswer(String sender, String receiver, int iteration, String conceptMap) {
+    public synchronized void responseAnswer(String sender, String receiver, int iteration, String conceptMap) {
         addMessage(sender, receiver, iteration, EdgeType.ANSWER, conceptMap);
     }
 
-    synchronized void responseExhausted(String sender, String receiver, int iteration) {
+    public synchronized void responseExhausted(String sender, String receiver, int iteration) {
         addMessage(sender, receiver, iteration, EdgeType.EXHAUSTED, "");
     }
 

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -79,12 +79,12 @@ public abstract class Resolver<RESOLVER extends Resolver<RESOLVER>> extends Acto
             String code = ((TypeDBException) e).code().get();
             if (code.equals(RESOURCE_CLOSED.code())) {
                 LOG.debug("Resolver interrupted by resource close: {}", e.getMessage());
-                registry.terminateResolvers(e);
+                registry.terminate(e);
                 return;
             }
         }
         LOG.error("Actor exception", e);
-        registry.terminateResolvers(e);
+        registry.terminate(e);
     }
 
     public abstract void receiveRequest(Request fromUpstream, int iteration);
@@ -110,8 +110,9 @@ public abstract class Resolver<RESOLVER extends Resolver<RESOLVER>> extends Acto
     // TODO: Rename to sendRequest or request
     protected void requestFromDownstream(Request request, Request fromUpstream, int iteration) {
         LOG.trace("{} : Sending a new answer Request to downstream: {}", name(), request);
-        if (resolutionTracing) ResolutionTracer.get().request(this.name(), request.receiver().name(), iteration,
-                                                              request.partialAnswer().conceptMap().concepts().keySet().toString());
+        if (resolutionTracing) ResolutionTracer.get().request(
+                this.name(), request.receiver().name(), iteration,
+                request.partialAnswer().conceptMap().concepts().keySet().toString());
         // TODO: we may overwrite if multiple identical requests are sent, when to clean up?
         requestRouter.put(request, fromUpstream);
         Driver<? extends Resolver<?>> receiver = request.receiver();

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -58,7 +58,6 @@ public abstract class Resolver<RESOLVER extends Resolver<RESOLVER>> extends Acto
     protected final TraversalEngine traversalEngine;
     protected final ConceptManager conceptMgr;
     protected final boolean resolutionTracing;
-    private boolean terminated;
 
     protected Resolver(Driver<RESOLVER> driver, String name, ResolverRegistry registry, TraversalEngine traversalEngine,
                        ConceptManager conceptMgr, boolean resolutionTracing) {
@@ -67,7 +66,6 @@ public abstract class Resolver<RESOLVER extends Resolver<RESOLVER>> extends Acto
         this.traversalEngine = traversalEngine;
         this.conceptMgr = conceptMgr;
         this.resolutionTracing = resolutionTracing;
-        this.terminated = false;
         this.requestRouter = new HashMap<>();
         // Note: initialising downstream actors in constructor will create all actors ahead of time, so it is non-lazy
         // additionally, it can cause deadlock within ResolverRegistry as different threads initialise actors
@@ -92,13 +90,6 @@ public abstract class Resolver<RESOLVER extends Resolver<RESOLVER>> extends Acto
     protected abstract void receiveAnswer(Response.Answer fromDownstream, int iteration);
 
     protected abstract void receiveFail(Response.Fail fromDownstream, int iteration);
-
-    public void terminate(Throwable cause) {
-        LOG.debug("Resolver terminated. ", cause);
-        this.terminated = true;
-    }
-
-    public boolean isTerminated() { return terminated; }
 
     protected abstract void initialiseDownstreamResolvers(); //TODO: This method should only be required of the coordinating actors
 

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -100,7 +100,7 @@ public abstract class Resolver<RESOLVER extends Resolver<RESOLVER>> extends Acto
 
     public boolean isTerminated() { return terminated; }
 
-    protected abstract void initialiseDownstreamResolvers();
+    protected abstract void initialiseDownstreamResolvers(); //TODO: This method should only be required of the coordinating actors
 
     protected Request fromUpstream(Request toDownstream) {
         assert requestRouter.containsKey(toDownstream);

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -57,7 +57,7 @@ public abstract class Resolver<RESOLVER extends Resolver<RESOLVER>> extends Acto
     protected final ResolverRegistry registry;
     protected final TraversalEngine traversalEngine;
     protected final ConceptManager conceptMgr;
-    private final boolean resolutionTracing;
+    protected final boolean resolutionTracing;
     private boolean terminated;
 
     protected Resolver(Driver<RESOLVER> driver, String name, ResolverRegistry registry, TraversalEngine traversalEngine,

--- a/reasoner/resolution/resolver/BoundConclusionResolver.java
+++ b/reasoner/resolution/resolver/BoundConclusionResolver.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.vaticle.typedb.core.reasoner.resolution.resolver;
+
+import com.vaticle.typedb.core.common.exception.TypeDBException;
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.Iterators;
+import com.vaticle.typedb.core.concept.Concept;
+import com.vaticle.typedb.core.concept.ConceptManager;
+import com.vaticle.typedb.core.concept.answer.ConceptMap;
+import com.vaticle.typedb.core.concurrent.actor.Actor;
+import com.vaticle.typedb.core.logic.Rule;
+import com.vaticle.typedb.core.reasoner.resolution.ResolverRegistry;
+import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState;
+import com.vaticle.typedb.core.reasoner.resolution.framework.Request;
+import com.vaticle.typedb.core.reasoner.resolution.framework.RequestState;
+import com.vaticle.typedb.core.reasoner.resolution.framework.Resolver;
+import com.vaticle.typedb.core.reasoner.resolution.framework.Response;
+import com.vaticle.typedb.core.traversal.GraphTraversal;
+import com.vaticle.typedb.core.traversal.TraversalEngine;
+import com.vaticle.typedb.core.traversal.common.Identifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
+
+public class BoundConclusionResolver extends Resolver<BoundConclusionResolver> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BoundConclusionResolver.class);
+    private final ConceptMap bounds;
+    private final Driver<ConditionResolver> conditionResolver;
+    private final Rule.Conclusion conclusion;
+    private final Map<Request, ConclusionRequestState<? extends AnswerState.Partial.Concludable<?>>> requestStates;
+
+    public BoundConclusionResolver(Driver<BoundConclusionResolver> driver, Rule.Conclusion conclusion, ConceptMap bounds,
+                                   Actor.Driver<ConditionResolver> conditionResolver,
+                                   ResolverRegistry registry, TraversalEngine traversalEngine,
+                                   ConceptManager conceptMgr, boolean resolutionTracing) {
+        super(driver, initName(conclusion, bounds), registry, traversalEngine, conceptMgr, resolutionTracing);
+        this.bounds = bounds;
+        this.conditionResolver = conditionResolver;
+        this.conclusion = conclusion;
+        this.requestStates = new HashMap<>();
+    }
+
+    private static String initName(Rule.Conclusion conclusion, ConceptMap bounds) {
+        return BoundConclusionResolver.class.getSimpleName() + "(pattern: " + conclusion.conjunction() + " bounds: " +
+                bounds.toString() + ")";
+    }
+
+    @Override
+    public void receiveRequest(Request fromUpstream, int iteration) {
+        LOG.trace("{}: received Request: {}", name(), fromUpstream);
+        if (isTerminated()) return;
+        if (fromUpstream.isToSubsumed()) {
+            assert fromUpstream.partialAnswer().conceptMap().equals(bounds);
+            receiveSubsumedRequest(fromUpstream.asToSubsumed(), iteration);
+        } else if (fromUpstream.isToSubsumer()) {
+            receiveSubsumerRequest(fromUpstream.asToSubsumer(), iteration);
+        } else {
+            assert fromUpstream.partialAnswer().conceptMap().equals(bounds);
+            receiveDirectRequest(fromUpstream, iteration);
+        }
+    }
+
+    private void receiveSubsumedRequest(Request.ToSubsumed fromUpstream, int iteration) {
+        throw TypeDBException.of(ILLEGAL_STATE);
+//        RequestState requestState = requestStates.computeIfAbsent(
+//                fromUpstream, request -> new BoundRequestState(request, cache, iteration));
+//        if (cache.sourceExhausted()) {
+//            sendAnswerOrFail(fromUpstream, iteration, requestState);
+//        } else {
+//            cache.clearSource();
+//            Optional<? extends AnswerState.Partial<?>> upstreamAnswer;
+//            upstreamAnswer = requestState.nextAnswer();
+//            if (upstreamAnswer.isPresent()) {
+//                answerToUpstream(upstreamAnswer.get(), fromUpstream, iteration);
+//            } else {
+//                requestFromSubsumer(fromUpstream, iteration);
+//            }
+//        }
+    }
+
+    private void receiveSubsumerRequest(Request.ToSubsumer fromUpstream, int iteration) {
+        throw TypeDBException.of(ILLEGAL_STATE);
+//        sendAnswerOrFail(fromUpstream, iteration, requestStates.computeIfAbsent(
+//                fromUpstream, request -> new SubsumerRequestState(request, cache, iteration)));
+    }
+
+    private void receiveDirectRequest(Request fromUpstream, int iteration) {
+        requestStates.computeIfAbsent(fromUpstream, r -> createRequestState(fromUpstream, iteration));
+        sendAnswerOrSearchDownstreamOrFail(fromUpstream, requestStates.get(fromUpstream), iteration);
+    }
+
+    @Override
+    protected void receiveAnswer(Response.Answer fromDownstream, int iteration) {
+        LOG.trace("{}: received Answer: {}", name(), fromDownstream);
+        if (isTerminated()) return;
+        Request toDownstream = fromDownstream.sourceRequest();
+        Request fromUpstream = fromUpstream(toDownstream);
+        ConclusionRequestState<? extends AnswerState.Partial.Concludable<?>> requestState = this.requestStates.get(fromUpstream);
+        if (!requestState.isComplete()) {
+            FunctionalIterator<Map<Identifier.Variable, Concept>> materialisations = conclusion
+                    .materialise(fromDownstream.answer().conceptMap(), traversalEngine, conceptMgr);
+            if (!materialisations.hasNext()) throw TypeDBException.of(ILLEGAL_STATE);
+            requestState.newMaterialisedAnswers(fromDownstream.answer(), materialisations);
+        }
+        sendAnswerOrSearchDownstreamOrFail(fromUpstream, requestState, iteration);
+    }
+
+    private void sendAnswerOrSearchDownstreamOrFail(Request fromUpstream, ConclusionRequestState<?> requestState, int iteration) {
+        Optional<? extends AnswerState.Partial<?>> upstreamAnswer = requestState.nextAnswer();
+        if (upstreamAnswer.isPresent()) {
+            answerToUpstream(upstreamAnswer.get(), fromUpstream, iteration);
+        } else if (!requestState.isComplete() && requestState.downstreamManager().hasDownstream()) {
+            requestFromDownstream(requestState.downstreamManager().nextDownstream(), fromUpstream, iteration);
+        } else {
+            requestState.setComplete();
+            failToUpstream(fromUpstream, iteration);
+        }
+    }
+
+    @Override
+    protected void receiveFail(Response.Fail fromDownstream, int iteration) {
+        LOG.trace("{}: received Fail: {}", name(), fromDownstream);
+        if (isTerminated()) return;
+
+        Request toDownstream = fromDownstream.sourceRequest();
+        Request fromUpstream = fromUpstream(toDownstream);
+        ConclusionRequestState<?> requestState = this.requestStates.get(fromUpstream);
+
+        if (iteration < requestState.iteration()) {
+            // short circuit old iteration fail messages to upstream
+            failToUpstream(fromUpstream, iteration);
+            return;
+        }
+
+        requestState.downstreamManager().removeDownstream(fromDownstream.sourceRequest());
+        sendAnswerOrSearchDownstreamOrFail(fromUpstream, requestState, iteration);
+    }
+
+    @Override
+    protected void initialiseDownstreamResolvers() {
+        throw TypeDBException.of(ILLEGAL_STATE);
+    }
+
+    private ConclusionRequestState<?> createRequestState(Request fromUpstream, int iteration) {
+        LOG.debug("{}: Creating a new ConclusionResponse for request: {}", name(), fromUpstream);
+
+        ConclusionRequestState<?> requestState;
+        if (fromUpstream.partialAnswer().asConclusion().isExplain()) {
+            requestState = new ConclusionRequestState.Explaining(fromUpstream, iteration);
+        } else if (fromUpstream.partialAnswer().asConclusion().isMatch()) {
+            requestState = new ConclusionRequestState.Rule(fromUpstream, iteration);
+        } else {
+            throw TypeDBException.of(ILLEGAL_STATE);
+        }
+
+        assert fromUpstream.partialAnswer().isConclusion();
+        AnswerState.Partial.Conclusion<?, ?> partialAnswer = fromUpstream.partialAnswer().asConclusion();
+        // we do a extra traversal to expand the partial answer if we already have the concept that is meant to be generated
+        // and if there's extra variables to be populated
+        if (!requestState.isComplete()) {
+            assert conclusion.retrievableIds().containsAll(partialAnswer.conceptMap().concepts().keySet());
+            if (conclusion.generating().isPresent() && conclusion.retrievableIds().size() > partialAnswer.conceptMap().concepts().size() &&
+                    partialAnswer.conceptMap().concepts().containsKey(conclusion.generating().get().id())) {
+                FunctionalIterator<AnswerState.Partial.Compound<?, ?>> completedDownstreamAnswers = candidateAnswers(partialAnswer);
+                completedDownstreamAnswers.forEachRemaining(answer -> requestState.downstreamManager()
+                        .addDownstream(Request.create(driver(), conditionResolver, answer)));
+            } else {
+                Set<Identifier.Variable.Retrievable> named = iterate(conclusion.retrievableIds()).filter(Identifier::isName).toSet();
+                AnswerState.Partial.Compound<?, ?> downstreamAnswer = partialAnswer.toDownstream(named);
+                requestState.downstreamManager().addDownstream(Request.create(driver(), conditionResolver, downstreamAnswer));
+            }
+        }
+        return requestState;
+    }
+
+    private FunctionalIterator<AnswerState.Partial.Compound<?, ?>> candidateAnswers(AnswerState.Partial.Conclusion<?, ?> partialAnswer) {
+        GraphTraversal traversal = boundTraversal(conclusion.conjunction().traversal(), partialAnswer.conceptMap());
+        FunctionalIterator<ConceptMap> answers = traversalEngine.iterator(traversal).map(conceptMgr::conceptMap);
+        Set<Identifier.Variable.Retrievable> named = iterate(conclusion.retrievableIds()).filter(Identifier::isName).toSet();
+        return answers.map(ans -> partialAnswer.extend(ans).toDownstream(named));
+    }
+
+    private static abstract class ConclusionRequestState<CONCLUDABLE extends AnswerState.Partial.Concludable<?>> extends RequestState {
+
+        private final DownstreamManager downstreamManager;
+        protected FunctionalIterator<CONCLUDABLE> answerIterator;
+        private boolean complete;
+
+        protected ConclusionRequestState(Request fromUpstream, int iteration) {
+            super(fromUpstream, iteration);
+            this.downstreamManager = new DownstreamManager();
+            this.answerIterator = Iterators.empty();
+            this.complete = false;
+        }
+
+        public DownstreamManager downstreamManager() {
+            return downstreamManager;
+        }
+
+        public boolean isComplete() {
+            // TODO: Placeholder for re-introducing caching
+            return complete;
+        }
+
+        public void setComplete() {
+            // TODO: Placeholder for re-introducing caching. Should only be used once Conclusion caching works in
+            //  recursive settings
+            complete = true;
+        }
+
+        protected abstract FunctionalIterator<CONCLUDABLE> toUpstream(AnswerState.Partial<?> fromDownstream,
+                                                                      Map<Identifier.Variable, Concept> answer);
+
+        public void newMaterialisedAnswers(AnswerState.Partial<?> fromDownstream,
+                                           FunctionalIterator<Map<Identifier.Variable, Concept>> materialisations) {
+            this.answerIterator = this.answerIterator
+                    .link(materialisations.flatMap(m -> toUpstream(fromDownstream, m)));
+        }
+
+        private static class Rule extends ConclusionRequestState<AnswerState.Partial.Concludable.Match<?>> {
+
+            private final Set<ConceptMap> deduplicationSet;
+
+            public Rule(Request fromUpstream, int iteration) {
+                super(fromUpstream, iteration);
+                this.deduplicationSet = new HashSet<>();
+            }
+
+            @Override
+            protected FunctionalIterator<AnswerState.Partial.Concludable.Match<?>> toUpstream(AnswerState.Partial<?> fromDownstream,
+                                                                                              Map<Identifier.Variable, Concept> answer) {
+                return fromDownstream.asConclusion().asMatch().aggregateToUpstream(answer);
+            }
+
+            @Override
+            public Optional<AnswerState.Partial.Concludable.Match<?>> nextAnswer() {
+                if (!answerIterator.hasNext()) return Optional.empty();
+                while (answerIterator.hasNext()) {
+                    AnswerState.Partial.Concludable.Match<?> ans = answerIterator.next();
+                    if (!deduplicationSet.contains(ans.conceptMap())) {
+                        deduplicationSet.add(ans.conceptMap());
+                        return Optional.of(ans);
+                    }
+                }
+                return Optional.empty();
+            }
+
+        }
+
+        private static class Explaining extends ConclusionRequestState<AnswerState.Partial.Concludable.Explain> {
+
+            public Explaining(Request fromUpstream, int iteration) {
+                super(fromUpstream, iteration);
+            }
+
+            @Override
+            protected FunctionalIterator<AnswerState.Partial.Concludable.Explain> toUpstream(AnswerState.Partial<?> fromDownstream,
+                                                                                             Map<Identifier.Variable, Concept> answer) {
+                return fromDownstream.asConclusion().asExplain().aggregateToUpstream(answer);
+            }
+
+            @Override
+            public Optional<AnswerState.Partial.Concludable.Explain> nextAnswer() {
+                if (!answerIterator.hasNext()) return Optional.empty();
+                return Optional.of(answerIterator.next());
+            }
+        }
+    }
+}

--- a/reasoner/resolution/resolver/BoundConclusionResolver.java
+++ b/reasoner/resolution/resolver/BoundConclusionResolver.java
@@ -31,6 +31,7 @@ import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState;
 import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState.Partial.Concludable;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Request;
 import com.vaticle.typedb.core.reasoner.resolution.framework.RequestState;
+import com.vaticle.typedb.core.reasoner.resolution.framework.ResolutionTracer;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Resolver;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Response;
 import com.vaticle.typedb.core.traversal.GraphTraversal;
@@ -140,6 +141,9 @@ public class BoundConclusionResolver extends Resolver<BoundConclusionResolver> {
     }
 
     private void requestFromMaterialiser(Materialiser.Request request, Request fromUpstream, int iteration) {
+        if (resolutionTracing) ResolutionTracer.get().request(
+                this.name(), request.receiver().name(), iteration,
+                request.partialAnswer().conceptMap().concepts().keySet().toString());
         materialiserRequestRouter.put(request, new Pair<>(fromUpstream, iteration));
         materialiser.execute(actor -> actor.receiveRequest(request));
     }

--- a/reasoner/resolution/resolver/BoundConclusionResolver.java
+++ b/reasoner/resolution/resolver/BoundConclusionResolver.java
@@ -212,9 +212,9 @@ public class BoundConclusionResolver extends Resolver<BoundConclusionResolver> {
 
         ConclusionRequestState<?> requestState;
         if (fromUpstream.partialAnswer().asConclusion().isExplain()) {
-            requestState = new ConclusionRequestState.Explaining(fromUpstream, iteration);
+            requestState = new ConclusionRequestState.Explain(fromUpstream, iteration);
         } else if (fromUpstream.partialAnswer().asConclusion().isMatch()) {
-            requestState = new ConclusionRequestState.Rule(fromUpstream, iteration);
+            requestState = new ConclusionRequestState.Match(fromUpstream, iteration);
         } else {
             throw TypeDBException.of(ILLEGAL_STATE);
         }
@@ -323,11 +323,11 @@ public class BoundConclusionResolver extends Resolver<BoundConclusionResolver> {
             }
         }
 
-        private static class Rule extends ConclusionRequestState<Concludable.Match<?>> {
+        private static class Match extends ConclusionRequestState<Concludable.Match<?>> {
 
             private final Set<ConceptMap> deduplicationSet;
 
-            public Rule(Request fromUpstream, int iteration) {
+            private Match(Request fromUpstream, int iteration) {
                 super(fromUpstream, iteration);
                 this.deduplicationSet = new HashSet<>();
             }
@@ -352,9 +352,9 @@ public class BoundConclusionResolver extends Resolver<BoundConclusionResolver> {
             }
         }
 
-        private static class Explaining extends ConclusionRequestState<Concludable.Explain> {
+        private static class Explain extends ConclusionRequestState<Concludable.Explain> {
 
-            public Explaining(Request fromUpstream, int iteration) {
+            private Explain(Request fromUpstream, int iteration) {
                 super(fromUpstream, iteration);
             }
 

--- a/reasoner/resolution/resolver/BoundConclusionResolver.java
+++ b/reasoner/resolution/resolver/BoundConclusionResolver.java
@@ -286,10 +286,6 @@ public class BoundConclusionResolver extends Resolver<BoundConclusionResolver> {
             this.materialisation = this.materialisation.link(toUpstream(fromDownstream, materialisation));
         }
 
-        public boolean waiting() {
-            return waiting > 0;
-        }
-
         public void addToQueue(Request fromUpstream, int iteration) {
             queue.add(new Pair<>(fromUpstream, iteration));
         }
@@ -300,6 +296,10 @@ public class BoundConclusionResolver extends Resolver<BoundConclusionResolver> {
 
         public void emptyQueue() {
             queue.clear();
+        }
+
+        public boolean waiting() {
+            return waiting > 0;
         }
 
         public void incrementWaiting() {

--- a/reasoner/resolution/resolver/BoundConclusionResolver.java
+++ b/reasoner/resolution/resolver/BoundConclusionResolver.java
@@ -257,7 +257,6 @@ public class BoundConclusionResolver extends Resolver<BoundConclusionResolver> {
         private boolean complete;
         protected FunctionalIterator<CONCLUDABLE> materialisations;
 
-
         protected ConclusionRequestState(Request fromUpstream, int iteration, List<Request> conditionDownstreams) {
             super(fromUpstream, iteration);
             this.downstreamManager = new DownstreamManager(conditionDownstreams);

--- a/reasoner/resolution/resolver/ConclusionResolver.java
+++ b/reasoner/resolution/resolver/ConclusionResolver.java
@@ -18,277 +18,56 @@
 package com.vaticle.typedb.core.reasoner.resolution.resolver;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
-import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
-import com.vaticle.typedb.core.common.iterator.Iterators;
-import com.vaticle.typedb.core.concept.Concept;
 import com.vaticle.typedb.core.concept.ConceptManager;
-import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.logic.Rule;
 import com.vaticle.typedb.core.reasoner.resolution.ResolverRegistry;
 import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState.Partial;
-import com.vaticle.typedb.core.reasoner.resolution.framework.Request;
-import com.vaticle.typedb.core.reasoner.resolution.framework.RequestState;
 import com.vaticle.typedb.core.reasoner.resolution.framework.Resolver;
-import com.vaticle.typedb.core.reasoner.resolution.framework.Response;
-import com.vaticle.typedb.core.traversal.GraphTraversal;
 import com.vaticle.typedb.core.traversal.TraversalEngine;
-import com.vaticle.typedb.core.traversal.common.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 
-public class ConclusionResolver extends Resolver<ConclusionResolver> {
+public class ConclusionResolver extends Coordinator<ConclusionResolver, BoundConclusionResolver> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConclusionResolver.class);
 
     private final Rule.Conclusion conclusion;
-    private final Map<Request, ConclusionRequestState<?>> requestStates;
-    private Driver<ConditionResolver> ruleResolver;
-    private boolean isInitialised;
+    private Driver<ConditionResolver> conditionResolver;
 
     public ConclusionResolver(Driver<ConclusionResolver> driver, Rule.Conclusion conclusion, ResolverRegistry registry,
                               TraversalEngine traversalEngine, ConceptManager conceptMgr, boolean resolutionTracing) {
         super(driver, ConclusionResolver.class.getSimpleName() + "(" + conclusion + ")",
               registry, traversalEngine, conceptMgr, resolutionTracing);
         this.conclusion = conclusion;
-        this.requestStates = new HashMap<>();
         this.isInitialised = false;
-    }
-
-    @Override
-    public void receiveRequest(Request fromUpstream, int iteration) {
-        LOG.trace("{}: received Request: {}", name(), fromUpstream);
-        if (!isInitialised) initialiseDownstreamResolvers();
-        if (isTerminated()) return;
-
-        ConclusionRequestState<?> requestState = getOrReplaceRequestState(fromUpstream, iteration);
-
-        if (iteration < requestState.iteration()) {
-            // short circuit if the request came from a prior iteration
-            failToUpstream(fromUpstream, iteration);
-        } else {
-            assert iteration == requestState.iteration();
-            nextAnswer(fromUpstream, requestState, iteration);
-        }
-    }
-
-    @Override
-    protected void receiveAnswer(Response.Answer fromDownstream, int iteration) {
-        LOG.trace("{}: received Answer: {}", name(), fromDownstream);
-        if (isTerminated()) return;
-
-        Request toDownstream = fromDownstream.sourceRequest();
-        Request fromUpstream = fromUpstream(toDownstream);
-        ConclusionRequestState<? extends Partial.Concludable<?>> requestState = this.requestStates.get(fromUpstream);
-        if (!requestState.isComplete()) {
-            FunctionalIterator<Map<Identifier.Variable, Concept>> materialisations = conclusion
-                    .materialise(fromDownstream.answer().conceptMap(), traversalEngine, conceptMgr);
-            if (!materialisations.hasNext()) throw TypeDBException.of(ILLEGAL_STATE);
-            requestState.newMaterialisedAnswers(fromDownstream.answer(), materialisations);
-        }
-        nextAnswer(fromUpstream, requestState, iteration);
-    }
-
-    @Override
-    protected void receiveFail(Response.Fail fromDownstream, int iteration) {
-        LOG.trace("{}: received Fail: {}", name(), fromDownstream);
-        if (isTerminated()) return;
-
-        Request toDownstream = fromDownstream.sourceRequest();
-        Request fromUpstream = fromUpstream(toDownstream);
-        ConclusionRequestState<?> requestState = this.requestStates.get(fromUpstream);
-
-        if (iteration < requestState.iteration()) {
-            // short circuit old iteration fail messages to upstream
-            failToUpstream(fromUpstream, iteration);
-            return;
-        }
-
-        requestState.downstreamManager().removeDownstream(fromDownstream.sourceRequest());
-        nextAnswer(fromUpstream, requestState, iteration);
-    }
-
-    @Override
-    public void terminate(Throwable cause) {
-        super.terminate(cause);
-        requestStates.clear();
     }
 
     @Override
     protected void initialiseDownstreamResolvers() {
         LOG.debug("{}: initialising downstream resolvers", name());
         try {
-            ruleResolver = registry.registerCondition(conclusion.rule().condition());
+            conditionResolver = registry.registerCondition(conclusion.rule().condition());
             isInitialised = true;
         } catch (TypeDBException e) {
             terminate(e);
         }
     }
 
-    private void nextAnswer(Request fromUpstream, ConclusionRequestState<?> requestState, int iteration) {
-        Optional<? extends Partial<?>> upstreamAnswer = requestState.nextAnswer();
-        if (upstreamAnswer.isPresent()) {
-            answerToUpstream(upstreamAnswer.get(), fromUpstream, iteration);
-        } else if (!requestState.isComplete() && requestState.downstreamManager().hasDownstream()) {
-            requestFromDownstream(requestState.downstreamManager().nextDownstream(), fromUpstream, iteration);
-        } else {
-            requestState.setComplete();
-            failToUpstream(fromUpstream, iteration);
-        }
-    }
-
-    private ConclusionRequestState<?> getOrReplaceRequestState(Request fromUpstream, int iteration) {
-        if (!requestStates.containsKey(fromUpstream)) {
-            requestStates.put(fromUpstream, createRequestState(fromUpstream, iteration));
-        } else {
-            ConclusionRequestState<?> requestState = this.requestStates.get(fromUpstream);
-
-            if (requestState.iteration() < iteration) {
-                // when the same request for the next iteration the first time, re-initialise required state
-                ConclusionRequestState<?> requestStateNextIter = createRequestState(fromUpstream, iteration);
-                this.requestStates.put(fromUpstream, requestStateNextIter);
-            }
-        }
-        return requestStates.get(fromUpstream);
-    }
-
-    private ConclusionRequestState<?> createRequestState(Request fromUpstream, int iteration) {
-        LOG.debug("{}: Creating a new ConclusionResponse for request: {}", name(), fromUpstream);
-
-        ConclusionRequestState<?> requestState;
-        if (fromUpstream.partialAnswer().asConclusion().isExplain()) {
-            requestState = new ConclusionRequestState.Explaining(fromUpstream, iteration);
-        } else if (fromUpstream.partialAnswer().asConclusion().isMatch()) {
-            requestState = new ConclusionRequestState.Rule(fromUpstream, iteration);
-        } else {
-            throw TypeDBException.of(ILLEGAL_STATE);
-        }
-
-        assert fromUpstream.partialAnswer().isConclusion();
-        Partial.Conclusion<?, ?> partialAnswer = fromUpstream.partialAnswer().asConclusion();
-        // we do a extra traversal to expand the partial answer if we already have the concept that is meant to be generated
-        // and if there's extra variables to be populated
-        if (!requestState.isComplete()) {
-            assert conclusion.retrievableIds().containsAll(partialAnswer.conceptMap().concepts().keySet());
-            if (conclusion.generating().isPresent() && conclusion.retrievableIds().size() > partialAnswer.conceptMap().concepts().size() &&
-                    partialAnswer.conceptMap().concepts().containsKey(conclusion.generating().get().id())) {
-                FunctionalIterator<Partial.Compound<?, ?>> completedDownstreamAnswers = candidateAnswers(partialAnswer);
-                completedDownstreamAnswers.forEachRemaining(answer -> requestState.downstreamManager()
-                        .addDownstream(Request.create(driver(), ruleResolver, answer)));
-            } else {
-                Set<Identifier.Variable.Retrievable> named = iterate(conclusion.retrievableIds()).filter(Identifier::isName).toSet();
-                Partial.Compound<?, ?> downstreamAnswer = partialAnswer.toDownstream(named);
-                requestState.downstreamManager().addDownstream(Request.create(driver(), ruleResolver, downstreamAnswer));
-            }
-        }
-        return requestState;
-    }
-
-    private FunctionalIterator<Partial.Compound<?, ?>> candidateAnswers(Partial.Conclusion<?, ?> partialAnswer) {
-        GraphTraversal traversal = boundTraversal(conclusion.conjunction().traversal(), partialAnswer.conceptMap());
-        FunctionalIterator<ConceptMap> answers = traversalEngine.iterator(traversal).map(conceptMgr::conceptMap);
-        Set<Identifier.Variable.Retrievable> named = iterate(conclusion.retrievableIds()).filter(Identifier::isName).toSet();
-        return answers.map(ans -> partialAnswer.extend(ans).toDownstream(named));
+    @Override
+    Driver<BoundConclusionResolver> getOrReplaceWorker(Driver<? extends Resolver<?>> root, Partial<?> partial) {
+        return workersByRoot.computeIfAbsent(root, r -> new HashMap<>()).computeIfAbsent(partial.conceptMap(), p -> {
+            LOG.debug("{}: Creating a new BoundConclusionResolver for bounds: {}", name(), partial);
+            return registry.registerBoundConclusion(conclusion, partial.conceptMap(), conditionResolver,
+                                                    partial.asConclusion().isExplain());
+        });
     }
 
     @Override
     public String toString() {
         return name();
     }
-
-    private static abstract class ConclusionRequestState<CONCLUDABLE extends Partial.Concludable<?>> extends RequestState {
-
-        private final DownstreamManager downstreamManager;
-        protected FunctionalIterator<CONCLUDABLE> answerIterator;
-        private boolean complete;
-
-        protected ConclusionRequestState(Request fromUpstream, int iteration) {
-            super(fromUpstream, iteration);
-            this.downstreamManager = new DownstreamManager();
-            this.answerIterator = Iterators.empty();
-            this.complete = false;
-        }
-
-        public DownstreamManager downstreamManager() {
-            return downstreamManager;
-        }
-
-        public boolean isComplete() {
-            // TODO: Placeholder for re-introducing caching
-            return complete;
-        }
-
-        public void setComplete() {
-            // TODO: Placeholder for re-introducing caching. Should only be used once Conclusion caching works in
-            //  recursive settings
-            complete = true;
-        }
-
-        protected abstract FunctionalIterator<CONCLUDABLE> toUpstream(Partial<?> fromDownstream,
-                                                                      Map<Identifier.Variable, Concept> answer);
-
-        public void newMaterialisedAnswers(Partial<?> fromDownstream,
-                                           FunctionalIterator<Map<Identifier.Variable, Concept>> materialisations) {
-            this.answerIterator = this.answerIterator
-                    .link(materialisations.flatMap(m -> toUpstream(fromDownstream, m)));
-        }
-
-        private static class Rule extends ConclusionRequestState<Partial.Concludable.Match<?>> {
-
-            private final Set<ConceptMap> deduplicationSet;
-
-            public Rule(Request fromUpstream, int iteration) {
-                super(fromUpstream, iteration);
-                this.deduplicationSet = new HashSet<>();
-            }
-
-            @Override
-            protected FunctionalIterator<Partial.Concludable.Match<?>> toUpstream(Partial<?> fromDownstream,
-                                                                                  Map<Identifier.Variable, Concept> answer) {
-                return fromDownstream.asConclusion().asMatch().aggregateToUpstream(answer);
-            }
-
-            @Override
-            public Optional<Partial.Concludable.Match<?>> nextAnswer() {
-                if (!answerIterator.hasNext()) return Optional.empty();
-                while (answerIterator.hasNext()) {
-                    Partial.Concludable.Match<?> ans = answerIterator.next();
-                    if (!deduplicationSet.contains(ans.conceptMap())) {
-                        deduplicationSet.add(ans.conceptMap());
-                        return Optional.of(ans);
-                    }
-                }
-                return Optional.empty();
-            }
-
-        }
-
-        private static class Explaining extends ConclusionRequestState<Partial.Concludable.Explain> {
-
-            public Explaining(Request fromUpstream, int iteration) {
-                super(fromUpstream, iteration);
-            }
-
-            @Override
-            protected FunctionalIterator<Partial.Concludable.Explain> toUpstream(Partial<?> fromDownstream,
-                                                                                 Map<Identifier.Variable, Concept> answer) {
-                return fromDownstream.asConclusion().asExplain().aggregateToUpstream(answer);
-            }
-
-            @Override
-            public Optional<Partial.Concludable.Explain> nextAnswer() {
-                if (!answerIterator.hasNext()) return Optional.empty();
-                return Optional.of(answerIterator.next());
-            }
-        }
-    }
-
 }

--- a/reasoner/resolution/resolver/ConclusionResolver.java
+++ b/reasoner/resolution/resolver/ConclusionResolver.java
@@ -61,8 +61,7 @@ public class ConclusionResolver extends Coordinator<ConclusionResolver, BoundCon
     Driver<BoundConclusionResolver> getOrReplaceWorker(Driver<? extends Resolver<?>> root, Partial<?> partial) {
         return workersByRoot.computeIfAbsent(root, r -> new HashMap<>()).computeIfAbsent(partial.conceptMap(), p -> {
             LOG.debug("{}: Creating a new BoundConclusionResolver for bounds: {}", name(), partial);
-            return registry.registerBoundConclusion(conclusion, partial.conceptMap(), conditionResolver,
-                                                    partial.asConclusion().isExplain());
+            return registry.registerBoundConclusion(conclusion, partial.conceptMap(), conditionResolver);
         });
     }
 

--- a/reasoner/resolution/resolver/Materialiser.java
+++ b/reasoner/resolution/resolver/Materialiser.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.vaticle.typedb.core.reasoner.resolution.resolver;
+
+import com.vaticle.typedb.core.common.exception.TypeDBException;
+import com.vaticle.typedb.core.concept.Concept;
+import com.vaticle.typedb.core.concept.ConceptManager;
+import com.vaticle.typedb.core.concurrent.actor.Actor;
+import com.vaticle.typedb.core.logic.Rule;
+import com.vaticle.typedb.core.reasoner.resolution.ResolverRegistry;
+import com.vaticle.typedb.core.reasoner.resolution.answer.AnswerState;
+import com.vaticle.typedb.core.traversal.TraversalEngine;
+import com.vaticle.typedb.core.traversal.common.Identifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.RESOURCE_CLOSED;
+
+public class Materialiser extends Actor<Materialiser> {
+    private static final Logger LOG = LoggerFactory.getLogger(Materialiser.class);
+
+    private final ResolverRegistry registry;
+    private final TraversalEngine traversalEngine;
+    private final ConceptManager conceptMgr;
+    private boolean terminated;
+
+    public Materialiser(Driver<Materialiser> driver, ResolverRegistry registry, TraversalEngine traversalEngine,
+                        ConceptManager conceptMgr, boolean resolutionTracing) {
+        super(driver, Materialiser.class.getSimpleName());
+        this.registry = registry;
+        this.traversalEngine = traversalEngine;
+        this.conceptMgr = conceptMgr;
+        this.terminated = false;
+    }
+
+    public void receiveRequest(Request request) {
+        if (terminated) return;
+        Optional<Map<Identifier.Variable, Concept>> materialisation = request.conclusion()
+                .materialise(request.partialAnswer().conceptMap(), traversalEngine, conceptMgr);
+        Response response = new Response(request, materialisation.orElse(null), request.partialAnswer());
+        request.sender().execute(actor -> actor.receiveMaterialisation(response));
+    }
+
+    @Override
+    protected void exception(Throwable e) {
+        if (e instanceof TypeDBException && ((TypeDBException) e).code().isPresent()) {
+            String code = ((TypeDBException) e).code().get();
+            if (code.equals(RESOURCE_CLOSED.code())) {
+                LOG.debug("Resolver interrupted by resource close: {}", e.getMessage());
+                registry.terminate(e);
+                return;
+            }
+        }
+        LOG.error("Actor exception", e);
+        registry.terminate(e);
+    }
+
+    public void terminate(Throwable cause) {
+        LOG.debug("Materialiser terminated. ", cause);
+        this.terminated = true;
+    }
+
+    public static class Request {
+
+        private final Driver<BoundConclusionResolver> sender;
+        private final Actor.Driver<Materialiser> receiver;
+        private final Rule.Conclusion conclusion;
+        private final AnswerState.Partial<?> partialAnswer;
+
+        private Request(Actor.Driver<BoundConclusionResolver> sender, Actor.Driver<Materialiser> receiver,
+                        Rule.Conclusion conclusion, AnswerState.Partial<?> partialAnswer) {
+            this.sender = sender;
+            this.receiver = receiver;
+            this.conclusion = conclusion;
+            this.partialAnswer = partialAnswer;
+        }
+
+        public static Request create(Actor.Driver<BoundConclusionResolver> sender, Actor.Driver<Materialiser> receiver,
+                                     Rule.Conclusion conclusion, AnswerState.Partial<?> partialAnswer) {
+            return new Request(sender, receiver, conclusion, partialAnswer);
+        }
+
+        public Rule.Conclusion conclusion() {
+            return conclusion;
+        }
+
+        public AnswerState.Partial<?> partialAnswer() {
+            return partialAnswer;
+        }
+
+        @Override
+        public String toString() {
+            return "Request{" +
+                    "sender=" + sender +
+                    ", receiver=" + receiver +
+                    ", conclusion=" + conclusion +
+                    '}';
+        }
+
+        public Driver<BoundConclusionResolver> sender() {
+            return sender;
+        }
+    }
+
+    static class Response {
+
+        private final Request request;
+        private final Map<Identifier.Variable, Concept> materialisation;
+        private final AnswerState.Partial<?> partialAnswer;
+
+        private Response(Request request, @Nullable Map<Identifier.Variable, Concept> materialisation, AnswerState.Partial<?> partialAnswer) {
+            this.request = request;
+            this.materialisation = materialisation;
+            this.partialAnswer = partialAnswer;
+        }
+
+        public Optional<Map<Identifier.Variable, Concept>> materialisation() {
+            return Optional.ofNullable(materialisation);
+        }
+
+        public AnswerState.Partial<?> partialAnswer() {
+            return partialAnswer;
+        }
+
+        public Request sourceRequest() {
+            return request;
+        }
+    }
+}

--- a/reasoner/resolution/resolver/Materialiser.java
+++ b/reasoner/resolution/resolver/Materialiser.java
@@ -44,7 +44,6 @@ public class Materialiser extends Actor<Materialiser> {
     private final TraversalEngine traversalEngine;
     private final ConceptManager conceptMgr;
     private final boolean resolutionTracing;
-    private boolean terminated;
 
     public Materialiser(Driver<Materialiser> driver, ResolverRegistry registry, TraversalEngine traversalEngine,
                         ConceptManager conceptMgr, boolean resolutionTracing) {
@@ -53,11 +52,10 @@ public class Materialiser extends Actor<Materialiser> {
         this.traversalEngine = traversalEngine;
         this.conceptMgr = conceptMgr;
         this.resolutionTracing = resolutionTracing;
-        this.terminated = false;
     }
 
     public void receiveRequest(Request request) {
-        if (terminated) return;
+        if (isTerminated()) return;
         Optional<Map<Identifier.Variable, Concept>> materialisation = request.conclusion()
                 .materialise(request.partialAnswer().conceptMap(), traversalEngine, conceptMgr);
         if (resolutionTracing) {
@@ -84,11 +82,6 @@ public class Materialiser extends Actor<Materialiser> {
         }
         LOG.error("Actor exception", e);
         registry.terminate(e);
-    }
-
-    public void terminate(Throwable cause) {
-        LOG.debug("Materialiser terminated. ", cause);
-        this.terminated = true;
     }
 
     public static class Request {

--- a/test/behaviour/reasoner/verification/Materialiser.java
+++ b/test/behaviour/reasoner/verification/Materialiser.java
@@ -140,7 +140,6 @@ public class Materialiser {
             requiresReiteration = false;
             traverse(rule.when()).forEachRemaining(conditionAns -> {
                 rule.conclusion().materialise(conditionAns, tx.traversal(), tx.concepts());
-//                        .ifPresent(m -> requiresReiteration = true);
                 traverse(rule.conclusion().conjunction(), conditionAns.filter(rule.conclusion().retrievableIds()))
                         .map(conclusionAns -> new ConceptMap(filterRetrievable(conclusionAns)))
                         .filter(thenConcludable::isInferredAnswer)

--- a/test/behaviour/reasoner/verification/Materialiser.java
+++ b/test/behaviour/reasoner/verification/Materialiser.java
@@ -109,7 +109,6 @@ public class Materialiser {
 
     private class Rule {
         private final com.vaticle.typedb.core.logic.Rule rule;
-        private final Concludable thenConcludable;
         private final Map<ConceptMap, Materialisation> conditionAnsMaterialisations;
         private boolean requiresReiteration;
 
@@ -121,7 +120,6 @@ public class Materialiser {
             Set<Concludable> concludables = Concludable.create(this.rule.then());
             assert concludables.size() == 1;
             // Use a concludable for the conclusion for the convenience of its isInferredAnswer method
-            this.thenConcludable = iterate(concludables).next();
         }
 
         private boolean materialise() {

--- a/test/integration/logic/RuleTest.java
+++ b/test/integration/logic/RuleTest.java
@@ -48,6 +48,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.vaticle.typedb.common.collection.Collections.map;
@@ -112,9 +113,9 @@ public class RuleTest {
                     ConceptMap whenAnswer = new ConceptMap(map(pair(Identifier.Variable.name("x"), people.get(0)),
                                                                pair(Identifier.Variable.name("y"), people.get(1))));
 
-                    List<Map<Identifier.Variable, Concept>> materialisations = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr).toList();
-                    assertEquals(1, materialisations.size());
-                    assertEquals(5, materialisations.get(0).size());
+                    Optional<Map<Identifier.Variable, Concept>> materialisation = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr);
+                    assertTrue(materialisation.isPresent());
+                    assertEquals(5, materialisation.get().size());
 
                     RelationType friendship = conceptMgr.getRelationType("friendship");
                     List<? extends Relation> friendshipInstances = friendship.getInstances().toList();
@@ -168,13 +169,8 @@ public class RuleTest {
                     ConceptMap whenAnswer = new ConceptMap(map(pair(Identifier.Variable.name("x"), people.get(0)),
                                                                pair(Identifier.Variable.name("y"), people.get(1))));
 
-                    List<Map<Identifier.Variable, Concept>> materialisations = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr).toList();
-                    assertEquals(1, materialisations.size());
-                    assertEquals(5, materialisations.get(0).size());
-                    friendshipInstances = friendship.getInstances().toList();
-                    assertEquals(1, friendshipInstances.size());
-                    assertEquals(friendshipInstances.get(0), materialisations.get(0).get(Identifier.Variable.anon(0)));
-                    assertEquals(friendship, materialisations.get(0).get(Identifier.Variable.label("friendship")));
+                    Optional<Map<Identifier.Variable, Concept>> materialisation = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr);
+                    assertFalse(materialisation.isPresent());
                 }
             }
         }
@@ -215,9 +211,9 @@ public class RuleTest {
                     Rule rule = txn.logic().getRule("old-milk-is-not-good");
                     ConceptMap whenAnswer = new ConceptMap(map(pair(Identifier.Variable.name("x"), milkInst),
                                                                pair(Identifier.Variable.name("a"), ageInDays10)));
-                    List<Map<Identifier.Variable, Concept>> materialisations = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr).toList();
-                    assertEquals(1, materialisations.size());
-                    assertEquals(2, materialisations.get(0).size());
+                    Optional<Map<Identifier.Variable, Concept>> materialisation = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr);
+                    assertTrue(materialisation.isPresent());
+                    assertEquals(2, materialisation.get().size());
 
                     List<? extends Attribute> ageInDaysOwned = milkInst.getHas(ageInDays).toList();
                     assertEquals(1, ageInDaysOwned.size());
@@ -261,9 +257,9 @@ public class RuleTest {
 
                     Rule rule = txn.logic().getRule("old-milk-is-not-good");
                     ConceptMap whenAnswer = new ConceptMap(map(pair(Identifier.Variable.name("x"), milkInst)));
-                    List<Map<Identifier.Variable, Concept>> materialisations = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr).toList();
-                    assertEquals(1, materialisations.size());
-                    assertEquals(3, materialisations.get(0).size());
+                    Optional<Map<Identifier.Variable, Concept>> materialisation = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr);
+                    assertTrue(materialisation.isPresent());
+                    assertEquals(3, materialisation.get().size());
 
                     AttributeType isStillGood = conceptMgr.getAttributeType("is-still-good");
                     List<? extends Attribute> isStillGoodOwned = milkInst.getHas(isStillGood).toList();

--- a/test/integration/reasoner/ReasonerTest.java
+++ b/test/integration/reasoner/ReasonerTest.java
@@ -165,7 +165,7 @@ public class ReasonerTest {
                 txn.commit();
             }
             try (RocksTransaction txn = singleThreadElgTransaction(session, Arguments.Transaction.Type.READ)) {
-                txn.reasoner().resolverRegistry().terminateResolvers(new RuntimeException());
+                txn.reasoner().resolverRegistry().terminate(new RuntimeException());
                 try {
                     List<ConceptMap> ans = txn.query().match(TypeQL.parseQuery("match $x isa is-still-good;").asMatch()).toList();
                 } catch (TypeDBException e) {

--- a/test/integration/reasoner/resolution/ResolutionTest.java
+++ b/test/integration/reasoner/resolution/ResolutionTest.java
@@ -142,7 +142,7 @@ public class ResolutionTest {
                 }
 
                 Exception e = new RuntimeException();
-                registry.terminateResolvers(e);
+                registry.terminate(e);
                 Throwable receivedException = exceptions.poll(100, TimeUnit.MILLISECONDS);
                 assertEquals(e, receivedException);
             }


### PR DESCRIPTION
## What is the goal of this PR?

As per the refactors to the actors for Concludables and Retrievables, we break down rule conclusion actors into one actor per set of bounds being evaluated. This requires a single actor to perform materialisation such that the put operations of materialisations don't suffer race conditions. This approach should better distribute the work done and the cleaner architecture will accelerate development.

## What are the changes implemented in this PR?

- `ConclusionResolver` spawns `BoundConclusionResolver`s
- `Materialiser` actor to synchronise put operations.

Part of #6356 