### PR TITLE
Make sure all deploy jobs deploy tested artifacts

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -131,6 +131,7 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-20.04
+      dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD

--- a/test/integration/traversal/TraversalTest.java
+++ b/test/integration/traversal/TraversalTest.java
@@ -128,12 +128,12 @@ public class TraversalTest {
             $role type friendship:friend;
             */
             /*
-		    1: ($rel-type *--[RELATES]--> $role)
-		    2: ($rel-type <--[ISA]--* $rel) { isTransitive: true }
-		    3: ($role <--[ISA]--* $rel:$role:$friend:1) { isTransitive: true }
-		    4: ($rel *--[RELATING]--> $rel:$role:$friend:1)
-		    5: ($rel:$role:$friend:1 <--[PLAYING]--* $friend)
-      		*/
+                    1: ($rel-type *--[RELATES]--> $role)
+                    2: ($rel-type <--[ISA]--* $rel) { isTransitive: true }
+                    3: ($role <--[ISA]--* $rel:$role:$friend:1) { isTransitive: true }
+                    4: ($rel *--[RELATING]--> $rel:$role:$friend:1)
+                    5: ($rel:$role:$friend:1 <--[PLAYING]--* $friend)
+            */
             GraphProcedure.Builder proc = GraphProcedure.builder(5);
             ProcedureVertex.Type rel_type = proc.namedType("rel-type", true);
             rel_type.props().labels(set(Label.of("friendship")));


### PR DESCRIPTION
## What is the goal of this PR?

Eliminate the possibility of deploying incorrect artifacts by making sure `deploy-*` jobs depend on `test-assembly-linux-targz` job

## What are the changes implemented in this PR?

Depend on `test-assembly-linux-targz` job in `deploy-artifact-snapshot`