### PR TITLE
Record overridden vertex in both stored directed type edges

### DIFF
--- a/graph/edge/impl/TypeEdgeImpl.java
+++ b/graph/edge/impl/TypeEdgeImpl.java
@@ -140,7 +140,8 @@ public abstract class TypeEdgeImpl implements TypeEdge {
                     else graph.storage().putUntracked(outIID().bytes());
                 }
                 if (encoding.in() != null) {
-                    graph.storage().putUntracked(inIID().bytes());
+                    if (overridden != null) graph.storage().putUntracked(inIID().bytes(), overridden.iid().bytes());
+                    else graph.storage().putUntracked(inIID().bytes());
                 }
             }
         }
@@ -231,12 +232,7 @@ public abstract class TypeEdgeImpl implements TypeEdge {
 
             deleted = new AtomicBoolean(false);
 
-            if (iid.isOutwards()) {
-                this.overriddenIID = overriddenIID;
-            } else {
-                this.overriddenIID = null;
-                assert overriddenIID == null;
-            }
+            if (overriddenIID != null) this.overriddenIID = overriddenIID;
         }
 
         @Override
@@ -292,6 +288,7 @@ public abstract class TypeEdgeImpl implements TypeEdge {
             this.overridden = overridden;
             overriddenIID = overridden.iid();
             graph.storage().putUntracked(outIID.bytes(), overriddenIID.bytes());
+            graph.storage().putUntracked(inIID.bytes(), overriddenIID.bytes());
         }
 
         /**


### PR DESCRIPTION
## What is the goal of this PR?

We must record the overriden type vertex on both out AND in edges that we write into the storage layer. Not doing so meant that if we happen to read the undirected Edge object from storage using the In edge key, the overriden vertex is lost forever in the cache.


## What are the changes implemented in this PR?

* `overriden` vertex is stored as the value for both in and out type edges
* `overriden` vertex is retrieved as part of the TypeEdge