### PR TITLE
removes warning for deprecated bottle :unneeded

### DIFF
--- a/config/brew/typedb.rb
+++ b/config/brew/typedb.rb
@@ -21,8 +21,6 @@ class Typedb < Formula
   url "https://github.com/vaticle/typedb/releases/download/{version}/typedb-all-mac-{version}.zip"
   sha256 "{sha256}"
 
-  bottle :unneeded
-
   depends_on "openjdk@11"
 
   def setup_directory(dir)


### PR DESCRIPTION
Fixes this warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the graknlabs/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/graknlabs/homebrew-tap/Formula/grakn-core.rb:24
```

Deprecated in June 2021, [see here](https://github.com/Homebrew/brew/pull/11239).

Cross-posted from [#5](https://github.com/vaticle/homebrew-tap/pull/5). Please review: @vmax