### PR TITLE
Upgrade RocksDB to 6.21.1

### DIFF
--- a/dependencies/maven/artifacts.bzl
+++ b/dependencies/maven/artifacts.bzl
@@ -40,7 +40,6 @@ artifacts = [
     "junit:junit",
     "org.rocksdb:rocksdbjni",
     "org.rocksdb:rocksdbjni-dev-mac",
-    "org.rocksdb:rocksdbjni-dev-linux",
     "org.slf4j:slf4j-api",
     "org.zeroturnaround:zt-exec"
 ]

--- a/dependencies/maven/artifacts.bzl
+++ b/dependencies/maven/artifacts.bzl
@@ -39,7 +39,7 @@ artifacts = [
     "io.netty:netty-all",
     "junit:junit",
     "org.rocksdb:rocksdbjni",
-    "org.rocksdb:rocksdbjni-dev",
+    "org.rocksdb:rocksdbjni-dev-mac",
     "org.rocksdb:rocksdbjni-dev-linux",
     "org.slf4j:slf4j-api",
     "org.zeroturnaround:zt-exec"

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -150,10 +150,10 @@
 @maven//:org_objenesis_objenesis_2_5
 @maven//:org_rocksdb_rocksdbjni
 @maven//:org_rocksdb_rocksdbjni_6_15_2
-@maven//:org_rocksdb_rocksdbjni_dev
-@maven//:org_rocksdb_rocksdbjni_dev_6_15_2
 @maven//:org_rocksdb_rocksdbjni_dev_linux
 @maven//:org_rocksdb_rocksdbjni_dev_linux_6_15_2
+@maven//:org_rocksdb_rocksdbjni_dev_mac
+@maven//:org_rocksdb_rocksdbjni_dev_mac_6_15_2
 @maven//:org_slf4j_slf4j_api
 @maven//:org_slf4j_slf4j_api_1_7_28
 @maven//:org_zeroturnaround_zt_exec

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -149,11 +149,9 @@
 @maven//:org_objenesis_objenesis
 @maven//:org_objenesis_objenesis_2_5
 @maven//:org_rocksdb_rocksdbjni
-@maven//:org_rocksdb_rocksdbjni_6_15_2
-@maven//:org_rocksdb_rocksdbjni_dev_linux
-@maven//:org_rocksdb_rocksdbjni_dev_linux_6_15_2
+@maven//:org_rocksdb_rocksdbjni_6_26_1
 @maven//:org_rocksdb_rocksdbjni_dev_mac
-@maven//:org_rocksdb_rocksdbjni_dev_mac_6_15_2
+@maven//:org_rocksdb_rocksdbjni_dev_mac_6_26_1
 @maven//:org_slf4j_slf4j_api
 @maven//:org_slf4j_slf4j_api_1_7_28
 @maven//:org_zeroturnaround_zt_exec

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "40ea2195bf58b4fc4fdf1870927c4ba429e33bc1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "6eb107f42b21e608bd1d5a865d21f433bf024ecb", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql_lang_java():

--- a/migrator/BUILD
+++ b/migrator/BUILD
@@ -72,7 +72,7 @@ native_java_libraries(
         "@maven//:org_slf4j_slf4j_api",
     ],
     mac_deps = [
-        "@maven//:org_rocksdb_rocksdbjni_dev"
+        "@maven//:org_rocksdb_rocksdbjni_dev_mac"
     ],
     linux_deps = [
         "@maven//:org_rocksdb_rocksdbjni",

--- a/rocks/BUILD
+++ b/rocks/BUILD
@@ -49,11 +49,10 @@ native_java_libraries(
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:org_slf4j_slf4j_api"
     ],
-
     mac_deps = [
         "@maven//:com_google_ortools_ortools_darwin",
         "@maven//:com_google_ortools_ortools_darwin_java",
-        "@maven//:org_rocksdb_rocksdbjni_dev",
+        "@maven//:org_rocksdb_rocksdbjni_dev_mac",
     ],
     linux_deps = [
         "@maven//:com_google_ortools_ortools_linux_x86_64",

--- a/server/BUILD
+++ b/server/BUILD
@@ -149,7 +149,7 @@ java_deps(
     target = ":server-bin-deps-mac",
     java_deps_root = "server/lib/common/",
     java_deps_root_overrides = {
-        "rocksdbjni-dev-*": "server/lib/dev/",
+        "rocksdbjni-dev-mac-*": "server/lib/dev/",
     },
     visibility = ["//:__pkg__"],
     maven_name = True,


### PR DESCRIPTION
## What is the goal of this PR?

Upgrade RocksDB to 6.21.1, the latest version.

## What are the changes implemented in this PR?

* Upgrade to the latest RocksDB
* Remove our RocksDB linux development build, as it does not work and we no longer publish it