### PR TITLE
Correctly apply multiple negations with the same variables

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -46,14 +46,10 @@ def vaticle_typedb_protocol():
     )
 
 def vaticle_typedb_behaviour():
-#    git_repository(
-#        name = "vaticle_typedb_behaviour",
-#        remote = "https://github.com/vaticle/typedb-behaviour",
-#        commit = "042cbf2a6c3b8b9d7a8c3b8d74e796da968523fd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
-#    )
-    native.local_repository(
+    git_repository(
         name = "vaticle_typedb_behaviour",
-        path = "../typedb-behaviour",
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "05063b44ee914ad1c71a580c8ecc6454e33c302a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -46,10 +46,14 @@ def vaticle_typedb_protocol():
     )
 
 def vaticle_typedb_behaviour():
-    git_repository(
+#    git_repository(
+#        name = "vaticle_typedb_behaviour",
+#        remote = "https://github.com/vaticle/typedb-behaviour",
+#        commit = "042cbf2a6c3b8b9d7a8c3b8d74e796da968523fd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+#    )
+    native.local_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "042cbf2a6c3b8b9d7a8c3b8d74e796da968523fd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        path = "../typedb-behaviour",
     )
 
 def vaticle_factory_tracing():

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -55,6 +55,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -206,7 +207,7 @@ public class Rule {
     }
 
     private Conjunction thenPattern(com.vaticle.typeql.lang.pattern.variable.ThingVariable<?> thenVariable, LogicManager logicMgr) {
-        Conjunction conj = new Conjunction(VariableRegistry.createFromThings(list(thenVariable)).variables(), set());
+        Conjunction conj = new Conjunction(VariableRegistry.createFromThings(list(thenVariable)).variables(), list());
         logicMgr.typeInference().infer(conj, true);
         return conj;
     }
@@ -269,7 +270,7 @@ public class Rule {
             return negatedConcludablesTriggeringRules;
         }
 
-        private FunctionalIterator<Concludable> concludables(Set<Negation> negations) {
+        private FunctionalIterator<Concludable> concludables(List<Negation> negations) {
             return iterate(negations)
                     .flatMap(neg -> {
                         assert neg.disjunction().conjunctions().size() == 1;

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -717,13 +717,13 @@ public abstract class Concludable extends Resolvable<Conjunction> {
         private final ThingVariable attribute;
 
         private Attribute(ThingVariable attribute, Set<ValueConstraint<?>> values) {
-            super(new Conjunction(set(attribute), set()));
+            super(new Conjunction(set(attribute), list()));
             this.attribute = attribute;
             this.values = values;
         }
 
         private Attribute(IsaConstraint isa) {
-            super(new Conjunction(isa.variables(), set()));
+            super(new Conjunction(isa.variables(), list()));
             attribute = isa.owner();
             values = set();
         }

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -220,8 +220,10 @@ public class Conjunction implements Pattern, Cloneable {
         if (obj == null || obj.getClass() != getClass()) return false;
         Conjunction that = (Conjunction) obj;
         // TODO: This doesn't work! It doesn't compare constraints
+        // TODO: negations should be a set not list
+        // TODO: both are corrected with https://github.com/vaticle/typedb/issues/6115
         return (this.variableSet.equals(that.variables()) &&
-                this.negations.equals(that.negations())); // TODO negations should be a set not list
+                this.negations.equals(that.negations()));
     }
 
     @Override

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.vaticle.factory.tracing.client.FactoryTracingThreadStatic.traceOnThread;
+import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNBOUNDED_NEGATION;
@@ -61,26 +62,27 @@ import static com.vaticle.typeql.lang.common.TypeQLToken.Char.CURLY_OPEN;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.NEW_LINE;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.SEMICOLON;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.SPACE;
+import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toList;
 
 public class Conjunction implements Pattern, Cloneable {
 
     private static final String TRACE_PREFIX = "conjunction.";
     private final Map<Identifier.Variable, Variable> variableMap;
     private final Set<Variable> variableSet;
-    private final Set<Negation> negations;
+    private final List<Negation> negations;
     private final int hash;
 
     private boolean isCoherent;
     private boolean isBounded;
     private Set<Identifier.Variable.Retrievable> retrieves;
 
-    public Conjunction(Set<Variable> variables, Set<Negation> negations) {
+    public Conjunction(Set<Variable> variables, List<Negation> negations) {
         this.variableSet = unmodifiableSet(variables);
         this.variableMap = parseToMap(variables);
-        this.negations = unmodifiableSet(negations);
+        this.negations = unmodifiableList(negations);
         this.hash = Objects.hash(variables, negations);
         this.isCoherent = true;
         this.isBounded = false;
@@ -110,8 +112,8 @@ public class Conjunction implements Pattern, Cloneable {
 
             if (typeQLVariables.isEmpty() && !typeQLNegations.isEmpty()) throw TypeDBException.of(UNBOUNDED_NEGATION);
             VariableRegistry registry = VariableRegistry.createFromVariables(typeQLVariables, bounds);
-            Set<Negation> typeDBNegations = typeQLNegations.isEmpty() ? set() :
-                    typeQLNegations.stream().map(n -> Negation.create(n, registry)).collect(toSet());
+            List<Negation> typeDBNegations = typeQLNegations.isEmpty() ? list() :
+                    typeQLNegations.stream().map(n -> Negation.create(n, registry)).collect(toList());
             return new Conjunction(registry.variables(), typeDBNegations);
         }
     }
@@ -163,7 +165,7 @@ public class Conjunction implements Pattern, Cloneable {
         return retrieves;
     }
 
-    public Set<Negation> negations() {
+    public List<Negation> negations() {
         return negations;
     }
 
@@ -194,7 +196,7 @@ public class Conjunction implements Pattern, Cloneable {
     @Override
     public Conjunction clone() {
         return new Conjunction(VariableCloner.cloneFromConjunction(this).variables(),
-                               iterate(this.negations).map(Negation::clone).toSet());
+                               iterate(this.negations).map(Negation::clone).toList());
     }
 
     @Override
@@ -219,7 +221,7 @@ public class Conjunction implements Pattern, Cloneable {
         Conjunction that = (Conjunction) obj;
         // TODO: This doesn't work! It doesn't compare constraints
         return (this.variableSet.equals(that.variables()) &&
-                this.negations.equals(that.negations()));
+                this.negations.equals(that.negations())); // TODO negations should be a set not list
     }
 
     @Override
@@ -283,7 +285,7 @@ public class Conjunction implements Pattern, Cloneable {
         }
 
         public Conjunction conjunction() {
-            return new Conjunction(set(variables.values()), set());
+            return new Conjunction(set(variables.values()), list());
         }
 
         public Constraint getClone(Constraint constraint) {

--- a/pattern/Disjunction.java
+++ b/pattern/Disjunction.java
@@ -87,6 +87,7 @@ public class Disjunction implements Pattern, Cloneable {
         if (o == null || getClass() != o.getClass()) return false;
 
         Disjunction that = (Disjunction) o;
+        // TODO this isn't right because it is positional-equality too!
         return this.conjunctions.equals(that.conjunctions);
     }
 

--- a/pattern/Disjunction.java
+++ b/pattern/Disjunction.java
@@ -87,7 +87,8 @@ public class Disjunction implements Pattern, Cloneable {
         if (o == null || getClass() != o.getClass()) return false;
 
         Disjunction that = (Disjunction) o;
-        // TODO should use a set-comparison
+        // TODO: should use a set-comparison
+        // TODO: corrected with https://github.com/vaticle/typedb/issues/6115
         return this.conjunctions.equals(that.conjunctions);
     }
 

--- a/pattern/Disjunction.java
+++ b/pattern/Disjunction.java
@@ -87,7 +87,7 @@ public class Disjunction implements Pattern, Cloneable {
         if (o == null || getClass() != o.getClass()) return false;
 
         Disjunction that = (Disjunction) o;
-        // TODO this isn't right because it is positional-equality too!
+        // TODO should use a set-comparison
         return this.conjunctions.equals(that.conjunctions);
     }
 

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -96,7 +96,7 @@ public class Reasoner {
     private boolean mayReason(Disjunction disjunction) {
         for (Conjunction conj : disjunction.conjunctions()) {
             Set<Variable> vars = conj.variables();
-            Set<Negation> negs = conj.negations();
+            List<Negation> negs = conj.negations();
             if (iterate(vars).flatMap(v -> iterate(v.inferredTypes())).distinct().anyMatch(this::hasRule)) return true;
             if (!negs.isEmpty() && iterate(negs).anyMatch(n -> mayReason(n.disjunction()))) return true;
         }


### PR DESCRIPTION
## What is the goal of this PR?

The parsing of a TypeQL query into server-side Disjunctions, Conjunctions, and Negations, we relied on the equality function of negations, which is still ill-defined (consequence of #6115). As a result, negations were lost when negations contain the same variables and were put in a set. Identified in #6471.


## What are the changes implemented in this PR?

* Don't rely on sets to contain negation patterns, and instead put them into a list, as we do with Variables already