### PR TITLE
Validate encoding version and compress encoding ranges

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -149,7 +149,7 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
     }
 
     public static class Database extends ErrorMessage {
-        public static final Database DATABASE_INCOMPATIBLE_ENCODING =
+        public static final Database INCOMPATIBLE_ENCODING =
                 new Database(1, "Database '%s' has incompatible data version '%s' - this server supports " +
                         "version '%s'. (Did you copy a database across incompatible server versions?)");
         public static final Database DATABASE_MANAGER_CLOSED =

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -149,18 +149,21 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
     }
 
     public static class Database extends ErrorMessage {
+        public static final Database DATABASE_INCOMPATIBLE_ENCODING =
+                new Database(1, "Database '%s' has incompatible data version '%s' - this server supports " +
+                        "version '%s'. (Did you copy a database across incompatible server versions?)");
         public static final Database DATABASE_MANAGER_CLOSED =
-                new Database(1, "Attempted to use database manager when it has been closed.");
+                new Database(2, "Attempted to use database manager when it has been closed.");
         public static final Database DATABASE_EXISTS =
-                new Database(2, "The database with the name '%s' already exists.");
+                new Database(3, "The database with the name '%s' already exists.");
         public static final Database DATABASE_NOT_FOUND =
-                new Database(3, "The database with the name '%s' does not exist.");
+                new Database(4, "The database with the name '%s' does not exist.");
         public static final Database DATABASE_DELETED =
-                new Database(4, "Database with the name '%s' has been deleted.");
+                new Database(5, "Database with the name '%s' has been deleted.");
         public static final Database DATABASE_CLOSED =
-                new Database(5, "Attempted to open a new session from the database '%s' that has been closed.");
+                new Database(6, "Attempted to open a new session from the database '%s' that has been closed.");
         public static final Database DATABASE_NAME_RESERVED =
-                new Database(6, "Database name must not start with an underscore.");
+                new Database(7, "Database name must not start with an underscore.");
 
         private static final String codePrefix = "DBS";
         private static final String messagePrefix = "Invalid Database Operations";
@@ -386,7 +389,9 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         private static final String codePrefix = "SCG";
         private static final String messagePrefix = "Invalid Schema Graph Operation";
 
-        TypeGraph(int number, String message) { super(codePrefix, number, messagePrefix, message); }
+        TypeGraph(int number, String message) {
+            super(codePrefix, number, messagePrefix, message);
+        }
     }
 
     public static class TypeRead extends ErrorMessage {
@@ -580,7 +585,9 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         private static final String codePrefix = "RSN";
         private static final String messagePrefix = "Reasoner Error";
 
-        Reasoner(int number, String message) { super(codePrefix, number, messagePrefix, message); }
+        Reasoner(int number, String message) {
+            super(codePrefix, number, messagePrefix, message);
+        }
     }
 
     public static class Migrator extends ErrorMessage {

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -166,7 +166,7 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Database(7, "Database name must not start with an underscore.");
 
         private static final String codePrefix = "DBS";
-        private static final String messagePrefix = "Invalid Database Operations";
+        private static final String messagePrefix = "Invalid Database Operation";
 
         Database(int number, String message) {
             super(codePrefix, number, messagePrefix, message);

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -144,7 +144,7 @@ public class Encoding {
      * The values in this class will be used as 'prefixes' within an IID for every database object,
      * and must not overlap with each other.
      *
-     * A prefix is 1 unsigned byte, up to the value of 199. Values 200-255 are reserved for TypeDB Cluster.
+     * A prefix is 1 unsigned byte, up to the value of 179. Values 180-255 are reserved for TypeDB Cluster.
      */
     public enum Prefix {
         SYSTEM(0, PrefixType.SYSTEM),

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -50,7 +50,7 @@ public class Encoding {
 
     public static final String ROCKS_DATA = "data";
     public static final String ROCKS_SCHEMA = "schema";
-    public static final int ENCODING_VERSION = 2;
+    public static final int ENCODING_VERSION = 1;
 
     public enum Key {
         PERSISTED(0, true),

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -147,25 +147,25 @@ public class Encoding {
      * A prefix is 1 unsigned byte, up to the value of 199. Values 200-255 are reserved for TypeDB Cluster.
      */
     public enum Prefix {
+        SYSTEM(0, PrefixType.SYSTEM),
         // leave large open range for future indices
-        INDEX_TYPE(0, PrefixType.INDEX),
-        INDEX_RULE(10, PrefixType.INDEX),
-        INDEX_ATTRIBUTE(20, PrefixType.INDEX),
-        STATISTICS_THINGS(50, PrefixType.STATISTICS),
-        STATISTICS_COUNT_JOB(51, PrefixType.STATISTICS),
-        STATISTICS_COUNTED(52, PrefixType.STATISTICS),
-        STATISTICS_SNAPSHOT(53, PrefixType.STATISTICS),
-        SYSTEM(70, PrefixType.SYSTEM), // TODO reorganise SYSTEM to come first when releasing an incompatible storage
+        INDEX_TYPE(20, PrefixType.INDEX),
+        INDEX_RULE(21, PrefixType.INDEX),
+        INDEX_ATTRIBUTE(30, PrefixType.INDEX),
+        STATISTICS_THINGS(60, PrefixType.STATISTICS),
+        STATISTICS_COUNT_JOB(61, PrefixType.STATISTICS),
+        STATISTICS_COUNTED(62, PrefixType.STATISTICS),
+        STATISTICS_SNAPSHOT(63, PrefixType.STATISTICS),
         VERTEX_THING_TYPE(100, PrefixType.TYPE),
         VERTEX_ENTITY_TYPE(110, PrefixType.TYPE),
-        VERTEX_ATTRIBUTE_TYPE(120, PrefixType.TYPE),
-        VERTEX_RELATION_TYPE(130, PrefixType.TYPE),
-        VERTEX_ROLE_TYPE(140, PrefixType.TYPE),
-        VERTEX_ENTITY(150, PrefixType.THING),
-        VERTEX_ATTRIBUTE(160, PrefixType.THING),
-        VERTEX_RELATION(170, PrefixType.THING),
-        VERTEX_ROLE(180, PrefixType.THING),
-        STRUCTURE_RULE(190, PrefixType.RULE);
+        VERTEX_ATTRIBUTE_TYPE(111, PrefixType.TYPE),
+        VERTEX_RELATION_TYPE(112, PrefixType.TYPE),
+        VERTEX_ROLE_TYPE(113, PrefixType.TYPE),
+        VERTEX_ENTITY(130, PrefixType.THING),
+        VERTEX_ATTRIBUTE(131, PrefixType.THING),
+        VERTEX_RELATION(132, PrefixType.THING),
+        VERTEX_ROLE(133, PrefixType.THING),
+        STRUCTURE_RULE(160, PrefixType.RULE);
 
         private static final ByteMap<Prefix> prefixByKey = ByteMap.create(
                 pair(SYSTEM.key, SYSTEM),

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -50,7 +50,7 @@ public class Encoding {
 
     public static final String ROCKS_DATA = "data";
     public static final String ROCKS_SCHEMA = "schema";
-    public static final int ENCODING_VERSION = 1;
+    public static final int ENCODING_VERSION = 2;
 
     public enum Key {
         PERSISTED(0, true),
@@ -1007,7 +1007,7 @@ public class Encoding {
 
     public enum System {
 
-        ENCODING_VERSION(0),
+        ENCODING_VERSION_KEY(0),
         TRANSACTION_DUMMY_WRITE(1);
 
         private final ByteArray bytes;

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -50,6 +50,7 @@ public class Encoding {
 
     public static final String ROCKS_DATA = "data";
     public static final String ROCKS_SCHEMA = "schema";
+    public static final int ENCODING_VERSION = 1;
 
     public enum Key {
         PERSISTED(0, true),
@@ -1006,7 +1007,8 @@ public class Encoding {
 
     public enum System {
 
-        TRANSACTION_DUMMY_WRITE(0);
+        ENCODING_VERSION(0),
+        TRANSACTION_DUMMY_WRITE(1);
 
         private final ByteArray bytes;
 

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -79,7 +79,7 @@ public class Encoding {
         PERSISTED(2),
         IMMUTABLE(3);
 
-        private int status;
+        private final int status;
 
         Status(int status) {
             this.status = status;
@@ -1007,6 +1007,7 @@ public class Encoding {
 
     public enum System {
 
+        // WARNING: do not change encoding version key, or compatibility checks may break
         ENCODING_VERSION_KEY(0),
         TRANSACTION_DUMMY_WRITE(1);
 

--- a/rocks/RocksDatabase.java
+++ b/rocks/RocksDatabase.java
@@ -55,7 +55,7 @@ import java.util.stream.Stream;
 
 import static com.vaticle.typedb.common.collection.Collections.hasIntersection;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Database.DATABASE_CLOSED;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Database.DATABASE_INCOMPATIBLE_ENCODING;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Database.INCOMPATIBLE_ENCODING;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.DIRTY_INITIALISATION;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNEXPECTED_INTERRUPTION;
@@ -69,7 +69,6 @@ import static com.vaticle.typedb.core.common.parameters.Arguments.Session.Type.S
 import static com.vaticle.typedb.core.common.parameters.Arguments.Transaction.Type.READ;
 import static com.vaticle.typedb.core.common.parameters.Arguments.Transaction.Type.WRITE;
 import static com.vaticle.typedb.core.graph.common.Encoding.ENCODING_VERSION;
-import static com.vaticle.typedb.core.graph.common.Encoding.System.ENCODING_VERSION_KEY;
 import static java.util.Comparator.reverseOrder;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -138,8 +137,8 @@ public class RocksDatabase implements TypeDB.Database {
         try (RocksSession.Schema session = createAndOpenSession(SCHEMA, new Options.Session()).asSchema()) {
             try (RocksTransaction.Schema txn = session.initialisationTransaction()) {
                 if (txn.graph().isInitialised()) throw TypeDBException.of(DIRTY_INITIALISATION);
+                txn.schemaStorage().initialiseEncoding();
                 txn.graph().initialise();
-                txn.schemaStorage().putUntracked(ENCODING_VERSION_KEY.bytes(), ByteArray.encodeInt(ENCODING_VERSION));
                 txn.commit();
             }
         }
@@ -148,19 +147,17 @@ public class RocksDatabase implements TypeDB.Database {
     protected void load() {
         try (RocksSession.Schema session = createAndOpenSession(SCHEMA, new Options.Session()).asSchema()) {
             try (RocksTransaction.Schema txn = session.initialisationTransaction()) {
-                validateEncodingVersion(txn);
+                validateEncoding(txn.schemaStorage());
                 schemaKeyGenerator.sync(txn.schemaStorage());
                 dataKeyGenerator.sync(txn.schemaStorage(), txn.dataStorage());
             }
         }
     }
 
-    private void validateEncodingVersion(RocksTransaction.Schema txn) {
-        ByteArray encoding = txn.schemaStorage().get(ENCODING_VERSION_KEY.bytes());
-        if (encoding == null || encoding.isEmpty()) { // no or missing encoding version is version 1
-            throw TypeDBException.of(DATABASE_INCOMPATIBLE_ENCODING, name(), 1, ENCODING_VERSION);
-        } else if (encoding.decodeInt() < ENCODING_VERSION || encoding.decodeInt() > ENCODING_VERSION) {
-            throw TypeDBException.of(DATABASE_INCOMPATIBLE_ENCODING, name(), encoding.decodeInt(), ENCODING_VERSION);
+    private void validateEncoding(RocksStorage.Schema schemaStorage) {
+        int encoding = schemaStorage.getEncoding();
+        if (encoding != ENCODING_VERSION) {
+            throw TypeDBException.of(INCOMPATIBLE_ENCODING, name(), encoding, ENCODING_VERSION);
         }
     }
 

--- a/rocks/RocksDatabase.java
+++ b/rocks/RocksDatabase.java
@@ -157,7 +157,7 @@ public class RocksDatabase implements TypeDB.Database {
 
     private void validateEncodingVersion(RocksTransaction.Schema txn) {
         ByteArray encoding = txn.schemaStorage().get(ENCODING_VERSION_KEY.bytes());
-        if (encoding == null) { // no encoding version is version 1
+        if (encoding == null || encoding.isEmpty()) { // no or missing encoding version is version 1
             throw TypeDBException.of(DATABASE_INCOMPATIBLE_ENCODING, name(), 1, ENCODING_VERSION);
         } else if (encoding.decodeInt() < ENCODING_VERSION || encoding.decodeInt() > ENCODING_VERSION) {
             throw TypeDBException.of(DATABASE_INCOMPATIBLE_ENCODING, name(), encoding.decodeInt(), ENCODING_VERSION);

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -54,6 +54,8 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILL
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.RESOURCE_CLOSED;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_DATA_READ_VIOLATION;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_SCHEMA_READ_VIOLATION;
+import static com.vaticle.typedb.core.graph.common.Encoding.ENCODING_VERSION;
+import static com.vaticle.typedb.core.graph.common.Encoding.System.ENCODING_VERSION_KEY;
 import static com.vaticle.typedb.core.graph.common.Encoding.System.TRANSACTION_DUMMY_WRITE;
 
 public abstract class RocksStorage implements Storage {
@@ -300,6 +302,15 @@ public abstract class RocksStorage implements Storage {
         public Schema(RocksDatabase database, RocksTransaction transaction) {
             super(database.rocksSchema, transaction);
             this.schemaKeyGenerator = database.schemaKeyGenerator();
+        }
+
+        public void initialiseEncoding() {
+            putUntracked(ENCODING_VERSION_KEY.bytes(), ByteArray.encodeInt(ENCODING_VERSION));
+        }
+
+        public int getEncoding() {
+            ByteArray encoding = get(ENCODING_VERSION_KEY.bytes());
+            return encoding == null || encoding.isEmpty() ? 0 : encoding.decodeInt();
         }
 
         @Override


### PR DESCRIPTION
## What is the goal of this PR?

On the rare occasion we change the data format or break backward compatibility, we should prevent users from  copy-pasting their databases across incompatible server versions. We now write a data encoding version into the schema database on creation, and validate it against the server's data encoding version on open. Users will receive an exception and the server will refuse to start when given an incompatible database.

**non backward-compatible change**

## What are the changes implemented in this PR?

* Introduce `Encoding.ENCODING_VERSION`, which is written on database creation, and validated on database open
* The key used to store the encoding version is `Encoding.System.ENCODING_VERSION_KEY`
* We also compress the `Encoding.Prefix` range to allow more room to grow in the future.
  * TypeDB Cluster now has prefix range 180+

Implements #6376