### PR TITLE
Clarify transaction consistency error messages

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -204,11 +204,11 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final Transaction TRANSACTION_DATA_READ_VIOLATION =
                 new Transaction(8, "Attempted data writes when transaction type does not allow.");
         public static final Transaction TRANSACTION_CONSISTENCY_MODIFY_DELETE_VIOLATION =
-                new Transaction(9, "The transaction modifies a key that a concurrent transaction deleted.");
+                new Transaction(9, "The transaction modifies a key that is deleted in a concurrent transaction.");
         public static final Transaction TRANSACTION_CONSISTENCY_DELETE_MODIFY_VIOLATION =
-                new Transaction(10, "The transaction deletes a key that a concurrent transaction modified.");
+                new Transaction(10, "The transaction deletes a key that is modified in concurrent transaction.");
         public static final Transaction TRANSACTION_CONSISTENCY_EXCLUSIVE_CREATE_VIOLATION =
-                new Transaction(11, "The transaction fails to exclusively create a key a concurrent transaction created.");
+                new Transaction(11, "The transaction fails to create a key that is created exclusively in a concurrent transaction.");
         public static final Transaction SESSION_DATA_VIOLATION =
                 new Transaction(12, "Attempted schema writes when session type does not allow.");
         public static final Transaction SESSION_SCHEMA_VIOLATION =

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -204,11 +204,11 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final Transaction TRANSACTION_DATA_READ_VIOLATION =
                 new Transaction(8, "Attempted data writes when transaction type does not allow.");
         public static final Transaction TRANSACTION_CONSISTENCY_MODIFY_DELETE_VIOLATION =
-                new Transaction(9, "The transaction modifies a key that has been concurrently deleted.");
+                new Transaction(9, "The transaction modifies a key that a concurrent transaction deleted.");
         public static final Transaction TRANSACTION_CONSISTENCY_DELETE_MODIFY_VIOLATION =
-                new Transaction(10, "The transaction deletes a key that is concurrently modified.");
+                new Transaction(10, "The transaction deletes a key that a concurrent transaction modified.");
         public static final Transaction TRANSACTION_CONSISTENCY_EXCLUSIVE_CREATE_VIOLATION =
-                new Transaction(11, "The transaction fails to exclusively create a key that is concurrently created.");
+                new Transaction(11, "The transaction fails to exclusively create a key a concurrent transaction created.");
         public static final Transaction SESSION_DATA_VIOLATION =
                 new Transaction(12, "Attempted schema writes when session type does not allow.");
         public static final Transaction SESSION_SCHEMA_VIOLATION =


### PR DESCRIPTION
## What is the goal of this PR?

Consistency violations throw error messages that could either be interpreted as a consistency error within the same transaction or across transactions. We clarify errors which are caused by transaction-transaction conflicts.

## What are the changes implemented in this PR?

* Clarify wording of consistency violations
