### PR TITLE
Remove all default string encodes/decodes

### DIFF
--- a/common/collection/ByteArray.java
+++ b/common/collection/ByteArray.java
@@ -125,15 +125,9 @@ public abstract class ByteArray implements Comparable<ByteArray> {
         return Base64.getEncoder().encodeToString(getBytes());
     }
 
-    public static ByteArray.Base encodeString(String string) {
-        return of(string.getBytes());
-    }
-
     public static ByteArray.Base encodeString(String string, Charset encoding) {
         return of(string.getBytes(encoding));
     }
-
-    public abstract String decodeString();
 
     public abstract String decodeString(Charset encoding);
 
@@ -368,11 +362,6 @@ public abstract class ByteArray implements Comparable<ByteArray> {
         }
 
         @Override
-        public String decodeString() {
-            return new String(array);
-        }
-
-        @Override
         public String decodeString(Charset encoding) {
             return new String(array, encoding);
         }
@@ -483,11 +472,6 @@ public abstract class ByteArray implements Comparable<ByteArray> {
         void copyTo(byte[] destination, int pos) {
             assert pos + length <= destination.length;
             System.arraycopy(array, start, destination, pos, length);
-        }
-
-        @Override
-        public String decodeString() {
-            return new String(array, start, length);
         }
 
         @Override

--- a/graph/adjacency/impl/TypeAdjacencyImpl.java
+++ b/graph/adjacency/impl/TypeAdjacencyImpl.java
@@ -138,8 +138,8 @@ public abstract class TypeAdjacencyImpl implements TypeAdjacency {
 
         private ByteArray edgeIID(Encoding.Edge.Type encoding, TypeVertex adjacent) {
             return join(owner.iid().bytes(),
-                        direction.isOut() ? encoding.out().bytes() : encoding.in().bytes(),
-                        adjacent.iid().bytes());
+                    direction.isOut() ? encoding.out().bytes() : encoding.in().bytes(),
+                    adjacent.iid().bytes());
         }
 
         private TypeEdge newPersistedEdge(ByteArray key, ByteArray value) {

--- a/graph/common/Storage.java
+++ b/graph/common/Storage.java
@@ -49,7 +49,9 @@ public interface Storage {
 
     void close();
 
-    default boolean isSchema() { return false; }
+    default boolean isSchema() {
+        return false;
+    }
 
     default Schema asSchema() {
         throw exception(TypeDBException.of(ILLEGAL_CAST, className(this.getClass()), className(Schema.class)));
@@ -59,9 +61,13 @@ public interface Storage {
 
         KeyGenerator.Schema schemaKeyGenerator();
 
-        default boolean isSchema() { return true; }
+        default boolean isSchema() {
+            return true;
+        }
 
-        default Schema asSchema() { return this; }
+        default Schema asSchema() {
+            return this;
+        }
     }
 
     interface Data extends Storage {

--- a/graph/edge/impl/ThingEdgeImpl.java
+++ b/graph/edge/impl/ThingEdgeImpl.java
@@ -461,7 +461,8 @@ public abstract class ThingEdgeImpl implements ThingEdge {
          * {@code overriddenIID}, and that is immediately written to storage when changed.
          */
         @Override
-        public void commit() {}
+        public void commit() {
+        }
 
         /**
          * Determine the equality of a {@code Edge} against another.

--- a/graph/edge/impl/TypeEdgeImpl.java
+++ b/graph/edge/impl/TypeEdgeImpl.java
@@ -318,7 +318,8 @@ public abstract class TypeEdgeImpl implements TypeEdge {
          * {@code overriddenIID}, and that is immediately written to storage when changed.
          */
         @Override
-        public void commit() {}
+        public void commit() {
+        }
 
         /**
          * Determine the equality of a {@code Edge} against another.

--- a/graph/iid/EdgeIID.java
+++ b/graph/iid/EdgeIID.java
@@ -164,7 +164,7 @@ public abstract class EdgeIID<
             if (readableString == null) {
                 readableString = super.toString();
                 if (!suffix().isEmpty()) {
-                    readableString += "[" + suffix().bytes.length()+ ": " + suffix().toString() + "]";
+                    readableString += "[" + suffix().bytes.length() + ": " + suffix().toString() + "]";
                 }
             }
             return readableString;

--- a/graph/iid/IndexIID.java
+++ b/graph/iid/IndexIID.java
@@ -65,7 +65,7 @@ public abstract class IndexIID extends IID {
              */
             public static Label of(String label, @Nullable String scope) {
                 return new Label(join(Encoding.Index.Prefix.TYPE.prefix().bytes(),
-                                      encodeString(Encoding.Vertex.Type.scopedLabel(label, scope), STRING_ENCODING)));
+                        encodeString(Encoding.Vertex.Type.scopedLabel(label, scope), STRING_ENCODING)));
             }
 
             @Override
@@ -86,7 +86,9 @@ public abstract class IndexIID extends IID {
                 super(bytes);
             }
 
-            public int length() { return bytes.length(); }
+            public int length() {
+                return bytes.length();
+            }
 
             public static class Key extends Type.Rule {
 
@@ -99,7 +101,7 @@ public abstract class IndexIID extends IID {
                  */
                 public static Key concludedVertex(VertexIID.Type typeIID, StructureIID.Rule ruleIID) {
                     return new Key(join(Encoding.Index.Prefix.TYPE.bytes(), typeIID.bytes(),
-                                        Encoding.Index.Infix.CONCLUDED_VERTEX.bytes(), ruleIID.bytes()));
+                            Encoding.Index.Infix.CONCLUDED_VERTEX.bytes(), ruleIID.bytes()));
                 }
 
                 /**
@@ -107,7 +109,7 @@ public abstract class IndexIID extends IID {
                  */
                 public static Key concludedEdgeTo(VertexIID.Type typeIID, StructureIID.Rule ruleIID) {
                     return new Key(join(Encoding.Index.Prefix.TYPE.bytes(), typeIID.bytes(),
-                                        Encoding.Index.Infix.CONCLUDED_EDGE_TO.bytes(), ruleIID.bytes()));
+                            Encoding.Index.Infix.CONCLUDED_EDGE_TO.bytes(), ruleIID.bytes()));
                 }
 
 
@@ -116,7 +118,7 @@ public abstract class IndexIID extends IID {
                  */
                 public static Key contained(VertexIID.Type typeIID, StructureIID.Rule ruleIID) {
                     return new Key(join(Encoding.Index.Prefix.TYPE.bytes(), typeIID.bytes(),
-                                        Encoding.Index.Infix.CONTAINED_TYPE.bytes(), ruleIID.bytes()));
+                            Encoding.Index.Infix.CONTAINED_TYPE.bytes(), ruleIID.bytes()));
                 }
 
                 @Override
@@ -144,7 +146,7 @@ public abstract class IndexIID extends IID {
                  */
                 public static Prefix concludedVertex(VertexIID.Type typeIID) {
                     return new Prefix(join(Encoding.Index.Prefix.TYPE.bytes(), typeIID.bytes(),
-                                           Encoding.Index.Infix.CONCLUDED_VERTEX.bytes()));
+                            Encoding.Index.Infix.CONCLUDED_VERTEX.bytes()));
                 }
 
                 /**
@@ -152,7 +154,7 @@ public abstract class IndexIID extends IID {
                  */
                 public static Prefix concludedEdgeTo(VertexIID.Type typeIID) {
                     return new Prefix(join(Encoding.Index.Prefix.TYPE.bytes(), typeIID.bytes(),
-                                           Encoding.Index.Infix.CONCLUDED_EDGE_TO.bytes()));
+                            Encoding.Index.Infix.CONCLUDED_EDGE_TO.bytes()));
                 }
 
                 /**
@@ -160,7 +162,7 @@ public abstract class IndexIID extends IID {
                  */
                 public static Prefix contained(VertexIID.Type typeIID) {
                     return new Prefix(join(Encoding.Index.Prefix.TYPE.bytes(), typeIID.bytes(),
-                                           Encoding.Index.Infix.CONTAINED_TYPE.bytes()));
+                            Encoding.Index.Infix.CONTAINED_TYPE.bytes()));
                 }
 
                 @Override
@@ -173,7 +175,7 @@ public abstract class IndexIID extends IID {
                                 bytes.view(PrefixIID.LENGTH + VertexIID.Type.LENGTH, Encoding.Index.Infix.LENGTH)) + "]";
                         String ruleIID = "[" + (StructureIID.Rule.LENGTH) + ": " +
                                 bytes.view(PrefixIID.LENGTH + VertexIID.Type.LENGTH + Encoding.Index.Infix.LENGTH,
-                                                StructureIID.Rule.LENGTH).decodeString(STRING_ENCODING) + "]";
+                                        StructureIID.Rule.LENGTH).decodeString(STRING_ENCODING) + "]";
                         readableString = prefix + typeIID + infix + ruleIID;
                     }
                     return readableString;
@@ -185,7 +187,9 @@ public abstract class IndexIID extends IID {
 
     public static class Rule extends IndexIID {
 
-        Rule(ByteArray bytes) { super(bytes); }
+        Rule(ByteArray bytes) {
+            super(bytes);
+        }
 
         /**
          * Returns the index address of given {@code RuleStructure}

--- a/graph/iid/VertexIID.java
+++ b/graph/iid/VertexIID.java
@@ -139,7 +139,7 @@ public abstract class VertexIID extends IID {
          */
         public static VertexIID.Thing generate(KeyGenerator.Data keyGenerator, Type typeIID, Label typeLabel) {
             return new Thing(join(typeIID.encoding().instance().prefix().bytes(),
-                                  typeIID.bytes(), keyGenerator.forThing(typeIID, typeLabel)));
+                    typeIID.bytes(), keyGenerator.forThing(typeIID, typeLabel)));
         }
 
         public static VertexIID.Thing of(ByteArray bytes) {

--- a/graph/structure/impl/RuleStructureImpl.java
+++ b/graph/structure/impl/RuleStructureImpl.java
@@ -49,6 +49,7 @@ import static com.vaticle.typedb.core.common.iterator.Iterators.link;
 import static com.vaticle.typedb.core.graph.common.Encoding.Property.LABEL;
 import static com.vaticle.typedb.core.graph.common.Encoding.Property.THEN;
 import static com.vaticle.typedb.core.graph.common.Encoding.Property.WHEN;
+import static com.vaticle.typedb.core.graph.common.Encoding.ValueType.STRING_ENCODING;
 
 public abstract class RuleStructureImpl implements RuleStructure {
 
@@ -198,10 +199,14 @@ public abstract class RuleStructureImpl implements RuleStructure {
         }
 
         @Override
-        public Conjunction<? extends Pattern> when() { return when; }
+        public Conjunction<? extends Pattern> when() {
+            return when;
+        }
 
         @Override
-        public ThingVariable<?> then() { return then; }
+        public ThingVariable<?> then() {
+            return then;
+        }
 
         @Override
         public void delete() {
@@ -231,15 +236,15 @@ public abstract class RuleStructureImpl implements RuleStructure {
         }
 
         private void commitPropertyLabel() {
-            graph.storage().putUntracked(join(iid.bytes(), LABEL.infix().bytes()), encodeString(label));
+            graph.storage().putUntracked(join(iid.bytes(), LABEL.infix().bytes()), encodeString(label, STRING_ENCODING));
         }
 
         private void commitWhen() {
-            graph.storage().putUntracked(join(iid.bytes(), WHEN.infix().bytes()), encodeString(when().toString()));
+            graph.storage().putUntracked(join(iid.bytes(), WHEN.infix().bytes()), encodeString(when().toString(), STRING_ENCODING));
         }
 
         private void commitThen() {
-            graph.storage().putUntracked(join(iid.bytes(), THEN.infix().bytes()), encodeString(then().toString()));
+            graph.storage().putUntracked(join(iid.bytes(), THEN.infix().bytes()), encodeString(then().toString(), STRING_ENCODING));
         }
 
         private void indexReferences() {
@@ -252,9 +257,9 @@ public abstract class RuleStructureImpl implements RuleStructure {
 
         public Persisted(TypeGraph graph, StructureIID.Rule iid) {
             super(graph, iid,
-                  graph.storage().get(join(iid.bytes(), LABEL.infix().bytes())).decodeString(),
-                  TypeQL.parsePattern(graph.storage().get(join(iid.bytes(), WHEN.infix().bytes())).decodeString()).asConjunction(),
-                  TypeQL.parseVariable(graph.storage().get(join(iid.bytes(), THEN.infix().bytes())).decodeString()).asThing()
+                    graph.storage().get(join(iid.bytes(), LABEL.infix().bytes())).decodeString(STRING_ENCODING),
+                    TypeQL.parsePattern(graph.storage().get(join(iid.bytes(), WHEN.infix().bytes())).decodeString(STRING_ENCODING)).asConjunction(),
+                    TypeQL.parseVariable(graph.storage().get(join(iid.bytes(), THEN.infix().bytes())).decodeString(STRING_ENCODING)).asThing()
             );
         }
 
@@ -276,7 +281,7 @@ public abstract class RuleStructureImpl implements RuleStructure {
         @Override
         public void label(String label) {
             graph.rules().update(this, this.label, label);
-            graph.storage().putUntracked(join(iid.bytes(), LABEL.infix().bytes()), encodeString(label));
+            graph.storage().putUntracked(join(iid.bytes(), LABEL.infix().bytes()), encodeString(label, STRING_ENCODING));
             graph.storage().deleteUntracked(IndexIID.Rule.of(this.label).bytes());
             graph.storage().putUntracked(IndexIID.Rule.of(label).bytes(), iid.bytes());
             this.label = label;
@@ -298,7 +303,8 @@ public abstract class RuleStructureImpl implements RuleStructure {
         }
 
         @Override
-        public void commit() {}
+        public void commit() {
+        }
     }
 
 }

--- a/graph/vertex/impl/TypeVertexImpl.java
+++ b/graph/vertex/impl/TypeVertexImpl.java
@@ -48,6 +48,7 @@ import static com.vaticle.typedb.core.graph.common.Encoding.Property.LABEL;
 import static com.vaticle.typedb.core.graph.common.Encoding.Property.REGEX;
 import static com.vaticle.typedb.core.graph.common.Encoding.Property.SCOPE;
 import static com.vaticle.typedb.core.graph.common.Encoding.Property.VALUE_TYPE;
+import static com.vaticle.typedb.core.graph.common.Encoding.ValueType.STRING_ENCODING;
 import static com.vaticle.typedb.core.graph.common.Encoding.Vertex.Type.ATTRIBUTE_TYPE;
 import static com.vaticle.typedb.core.graph.common.Encoding.Vertex.Type.ENTITY_TYPE;
 import static com.vaticle.typedb.core.graph.common.Encoding.Vertex.Type.RELATION_TYPE;
@@ -366,7 +367,7 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
         }
 
         private void commitPropertyScope() {
-            graph.storage().putUntracked(join(iid.bytes(), SCOPE.infix().bytes()), encodeString(scope));
+            graph.storage().putUntracked(join(iid.bytes(), SCOPE.infix().bytes()), encodeString(scope, STRING_ENCODING));
         }
 
         private void commitPropertyAbstract() {
@@ -374,7 +375,7 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
         }
 
         private void commitPropertyLabel() {
-            graph.storage().putUntracked(join(iid.bytes(), LABEL.infix().bytes()), encodeString(label));
+            graph.storage().putUntracked(join(iid.bytes(), LABEL.infix().bytes()), encodeString(label, STRING_ENCODING));
         }
 
         private void commitPropertyValueType() {
@@ -382,7 +383,7 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
         }
 
         private void commitPropertyRegex() {
-            graph.storage().putUntracked(join(iid.bytes(), REGEX.infix().bytes()), encodeString(regex.pattern()));
+            graph.storage().putUntracked(join(iid.bytes(), REGEX.infix().bytes()), encodeString(regex.pattern(), STRING_ENCODING));
         }
     }
 
@@ -397,14 +398,14 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
 
         public Persisted(TypeGraph graph, VertexIID.Type iid) {
             super(graph, iid,
-                    graph.storage().get(join(iid.bytes(), LABEL.infix().bytes())).decodeString(),
+                    graph.storage().get(join(iid.bytes(), LABEL.infix().bytes())).decodeString(STRING_ENCODING),
                     getScope(graph, iid));
         }
 
         @Nullable
         private static String getScope(TypeGraph graph, VertexIID.Type iid) {
             ByteArray scopeBytes = graph.storage().get(join(iid.bytes(), SCOPE.infix().bytes()));
-            if (scopeBytes != null) return scopeBytes.decodeString();
+            if (scopeBytes != null) return scopeBytes.decodeString(STRING_ENCODING);
             else return null;
         }
 
@@ -422,7 +423,7 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
         public void label(String label) {
             assert !isDeleted();
             graph.update(this, this.label, scope, label, scope);
-            graph.storage().putUntracked(join(iid.bytes(), LABEL.infix().bytes()), encodeString(label));
+            graph.storage().putUntracked(join(iid.bytes(), LABEL.infix().bytes()), encodeString(label, STRING_ENCODING));
             graph.storage().deleteUntracked(IndexIID.Type.Label.of(this.label, scope).bytes());
             graph.storage().putUntracked(IndexIID.Type.Label.of(label, scope).bytes(), iid.bytes());
             this.label = label;
@@ -432,7 +433,7 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
         public void scope(String scope) {
             assert !isDeleted();
             graph.update(this, label, this.scope, label, scope);
-            graph.storage().putUntracked(join(iid.bytes(), SCOPE.infix().bytes()), encodeString(scope));
+            graph.storage().putUntracked(join(iid.bytes(), SCOPE.infix().bytes()), encodeString(scope, STRING_ENCODING));
             graph.storage().deleteUntracked(IndexIID.Type.Label.of(label, this.scope).bytes());
             graph.storage().putUntracked(IndexIID.Type.Label.of(label, scope).bytes(), iid.bytes());
             this.scope = scope;
@@ -477,7 +478,7 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
         public Pattern regex() {
             if (regexLookedUp) return regex;
             ByteArray val = graph.storage().get(join(iid.bytes(), REGEX.infix().bytes()));
-            if (val != null) regex = Pattern.compile(val.decodeString());
+            if (val != null) regex = Pattern.compile(val.decodeString(STRING_ENCODING));
             regexLookedUp = true;
             return regex;
         }
@@ -487,7 +488,7 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
             assert !isDeleted();
             if (regex == null) graph.storage().deleteUntracked(join(iid.bytes(), REGEX.infix().bytes()));
             else
-                graph.storage().putUntracked(join(iid.bytes(), REGEX.infix().bytes()), encodeString(regex.pattern()));
+                graph.storage().putUntracked(join(iid.bytes(), REGEX.infix().bytes()), encodeString(regex.pattern(), STRING_ENCODING));
             this.regex = regex;
             this.setModified();
             return this;

--- a/migrator/BUILD
+++ b/migrator/BUILD
@@ -53,6 +53,7 @@ native_java_libraries(
         "//:typedb",
         "//common:common",
         "//concurrent:concurrent",
+        "//graph:graph",
         "//concept:concept",
         "//logic:logic",
     ],

--- a/migrator/data/DataImporter.java
+++ b/migrator/data/DataImporter.java
@@ -69,6 +69,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Migrator.NO_
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Migrator.PLAYER_NOT_FOUND;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Migrator.ROLE_TYPE_NOT_FOUND;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Migrator.TYPE_NOT_FOUND;
+import static com.vaticle.typedb.core.graph.common.Encoding.ValueType.STRING_ENCODING;
 import static com.vaticle.typedb.core.migrator.data.DataProto.Item.ItemCase.HEADER;
 import static java.util.Comparator.reverseOrder;
 
@@ -474,7 +475,7 @@ public class DataImporter {
         }
 
         public void put(String originalID, ByteArray newID) {
-            ByteArray original = ByteArray.encodeString(originalID);
+            ByteArray original = ByteArray.encodeString(originalID, STRING_ENCODING);
             try {
                 storage.put(original.getBytes(), newID.getBytes());
             } catch (RocksDBException e) {
@@ -484,7 +485,7 @@ public class DataImporter {
 
         public ByteArray get(String originalID) {
             try {
-                byte[] value = storage.get(ByteArray.encodeString(originalID).getBytes());
+                byte[] value = storage.get(ByteArray.encodeString(originalID, STRING_ENCODING).getBytes());
                 assert value == null || value.length > 0;
                 if (value == null) return null;
                 else return ByteArray.of(value);


### PR DESCRIPTION
## What is the goal of this PR?

Although #6475 encoded string attributes using UTF-8, we hadn't extended it to encoded labels and rule bodies, etc. This meant that using platform defaults via Java could corrupt labels and rules when moving across operating systems.
We now specify UTF-8 for all string operations.

## What are the changes implemented in this PR?

* Remove methods that allow encoding and decode strings with default encoding, forcing all string operations to specify the encoding, which should be UTF-8
