### PR TITLE
Implement transaction timeouts

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -89,18 +89,20 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Server(26, "Concept does not exist.");
         public static final Server BAD_VALUE_TYPE =
                 new Server(27, "The value type '%s' was not recognised.");
+        public static final Server TRANSACTION_EXCEEDED_MAX_SECONDS =
+                new Server(28, "Transaction exceeded maximum configured duration of '%s' seconds.");
         public static final Server EMPTY_TRANSACTION_REQUEST =
-                new Server(28, "Empty transaction request.");
+                new Server(29, "Empty transaction request.");
         public static final Server UNKNOWN_REQUEST_TYPE =
-                new Server(29, "The request message was not recognised.");
+                new Server(30, "The request message was not recognised.");
         public static final Server ITERATION_WITH_UNKNOWN_ID =
-                new Server(30, "Iteration was requested for ID '%s', but this ID does not correspond to an existing query iterator.");
+                new Server(31, "Iteration was requested for ID '%s', but this ID does not correspond to an existing query iterator.");
         public static final Server DUPLICATE_REQUEST =
-                new Server(31, "The request with ID '%s' is a duplicate.");
+                new Server(32, "The request with ID '%s' is a duplicate.");
         public static final Server ALREADY_RUNNING =
-                new Server(32, "Another instance of TypeDB server is already running at this port: '%s'.");
+                new Server(33, "Another instance of TypeDB server is already running at this port: '%s'.");
         public static final Server INCOMPATIBLE_JAVA_RUNTIME =
-                new Server(33, "Incompatible Java runtime version: '%s'. Please use Java 11 or above.");
+                new Server(34, "Incompatible Java runtime version: '%s'. Please use Java 11 or above.");
 
         private static final String codePrefix = "SRV";
         private static final String messagePrefix = "Invalid Server Operation";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -186,6 +186,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Session(2, "Attempted to open a transaction from closed session.");
         public static final Session SCHEMA_ACQUIRE_LOCK_TIMEOUT =
                 new Session(3, "Could not acquire lock for schema session. Another schema session may have been left open.");
+        public static final Session SESSION_IDLE_TIMEOUT_NOT_CONFIGURABLE =
+                new Session(4, "The session idle timeout is not configurable at the '%s' level.");
 
         private static final String codePrefix = "SSN";
         private static final String messagePrefix = "Invalid Session Operation";
@@ -230,6 +232,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Transaction(16, "Could not acquire lock for data transaction. A schema session may have been left open.");
         public static final Transaction RPC_PREFETCH_SIZE_TOO_SMALL =
                 new Transaction(17, "RPC answer streaming prefetch size must be at least 1, is set to: %d.");
+        public static final Transaction TRANSACTION_TIMEOUT_NOT_CONFIGURABLE =
+                new Transaction(18, "Transaction timeout cannot be configured at the '%s' level.");
 
         private static final String codePrefix = "TXN";
         private static final String messagePrefix = "Invalid Transaction Operation";

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -29,16 +29,15 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Reasoner.REA
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Reasoner.REASONING_CANNOT_BE_TOGGLED_PER_QUERY;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Session.SESSION_IDLE_TIMEOUT_NOT_CONFIGURABLE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_TIMEOUT_NOT_CONFIGURABLE;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options<?, ?>> {
 
-    public static final int SECOND_MILLIS = 1000;
-    public static final int MINUTE_SECONDS = 60;
-
     public static final int DEFAULT_PREFETCH_SIZE = 50;
-    public static final int DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = 30 * SECOND_MILLIS;
-    public static final int DEFAULT_TRANSACTION_TIMEOUT_MILLIS = 5 * MINUTE_SECONDS * SECOND_MILLIS;
-    public static final int DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS = 10_000;
+    public static final long DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = SECONDS.toMillis(30);
+    public static final long DEFAULT_TRANSACTION_TIMEOUT_MILLIS = MINUTES.toMillis(5);
+    public static final long DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS = SECONDS.toMillis(10);
     public static final boolean DEFAULT_INFER = false;
     public static final boolean DEFAULT_TRACE_INFERENCE = false;
     public static final boolean DEFAULT_EXPLAIN = false;
@@ -53,9 +52,9 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     private Boolean explain = null;
     private Boolean parallel = null;
     private Integer prefetchSize = null;
-    private Integer sessionIdlTimeoutMillis = null;
+    private Long sessionIdlTimeoutMillis = null;
     private Long transactionTimeoutMillis = null;
-    private Integer schemaLockAcquireTimeoutMillis = null;
+    private Long schemaLockAcquireTimeoutMillis = null;
     private Boolean readAnyReplica = null;
     protected Boolean prefetch = null;
     protected Path typeDBDir = null;
@@ -126,13 +125,13 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
         return getThis();
     }
 
-    public int sessionIdleTimeoutMillis() {
+    public long sessionIdleTimeoutMillis() {
         if (sessionIdlTimeoutMillis != null) return sessionIdlTimeoutMillis;
         else if (parent != null) return parent.sessionIdleTimeoutMillis();
         else return DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS;
     }
 
-    public SELF sessionIdleTimeoutMillis(int idleTimeoutMillis) {
+    public SELF sessionIdleTimeoutMillis(long idleTimeoutMillis) {
         this.sessionIdlTimeoutMillis = idleTimeoutMillis;
         return getThis();
     }
@@ -148,13 +147,13 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
         else return DEFAULT_TRANSACTION_TIMEOUT_MILLIS;
     }
 
-    public int schemaLockTimeoutMillis() {
+    public long schemaLockTimeoutMillis() {
         if (schemaLockAcquireTimeoutMillis != null) return schemaLockAcquireTimeoutMillis;
         else if (parent != null) return parent.schemaLockTimeoutMillis();
         else return DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS;
     }
 
-    public SELF schemaLockTimeoutMillis(int acquireSchemaLockTimeoutMillis) {
+    public SELF schemaLockTimeoutMillis(long acquireSchemaLockTimeoutMillis) {
         this.schemaLockAcquireTimeoutMillis = acquireSchemaLockTimeoutMillis;
         return getThis();
     }
@@ -253,7 +252,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
         }
 
         @Override
-        public Transaction sessionIdleTimeoutMillis(int idleTimeoutMillis) {
+        public Transaction sessionIdleTimeoutMillis(long idleTimeoutMillis) {
             throw TypeDBException.of(SESSION_IDLE_TIMEOUT_NOT_CONFIGURABLE, className(getClass()));
         }
     }

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -22,10 +22,13 @@ import com.vaticle.typeql.lang.query.TypeQLQuery;
 
 import java.nio.file.Path;
 
+import static com.vaticle.typedb.common.util.Objects.className;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_OPERATION;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Reasoner.REASONER_TRACING_CANNOT_BE_TOGGLED_PER_QUERY;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Reasoner.REASONING_CANNOT_BE_TOGGLED_PER_QUERY;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Session.SESSION_IDLE_TIMEOUT_NOT_CONFIGURABLE;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_TIMEOUT_NOT_CONFIGURABLE;
 
 public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options<?, ?>> {
 
@@ -248,6 +251,11 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
         Transaction getThis() {
             return this;
         }
+
+        @Override
+        public Transaction sessionIdleTimeoutMillis(int idleTimeoutMillis) {
+            throw TypeDBException.of(SESSION_IDLE_TIMEOUT_NOT_CONFIGURABLE, className(getClass()));
+        }
     }
 
     public static class Query extends Options<Transaction, Query> {
@@ -284,10 +292,14 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
             throw TypeDBException.of(REASONER_TRACING_CANNOT_BE_TOGGLED_PER_QUERY);
         }
 
+        @Override
+        public Query transactionTimeoutMillis(long timeoutMillis) {
+            throw TypeDBException.of(TRANSACTION_TIMEOUT_NOT_CONFIGURABLE, className(getClass()));
+        }
+
         public Query prefetch(boolean prefetch) {
             this.prefetch = prefetch;
             return this;
         }
-
     }
 }

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -29,8 +29,12 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Reasoner.REA
 
 public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options<?, ?>> {
 
+    public static final int SECOND_MILLIS = 1000;
+    public static final int MINUTE_SECONDS = 60;
+
     public static final int DEFAULT_PREFETCH_SIZE = 50;
     public static final int DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = 30_000;
+    public static final int DEFAULT_TRANSACTION_TIMEOUT_MILLIS = 5 * MINUTE_SECONDS * SECOND_MILLIS;
     public static final int DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS = 10_000;
     public static final boolean DEFAULT_INFER = false;
     public static final boolean DEFAULT_TRACE_INFERENCE = false;
@@ -47,6 +51,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     private Boolean parallel = null;
     private Integer prefetchSize = null;
     private Integer sessionIdlTimeoutMillis = null;
+    private Long transactionTimeoutMillis = null;
     private Integer schemaLockAcquireTimeoutMillis = null;
     private Boolean readAnyReplica = null;
     protected Boolean prefetch = null;
@@ -127,6 +132,17 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     public SELF sessionIdleTimeoutMillis(int idleTimeoutMillis) {
         this.sessionIdlTimeoutMillis = idleTimeoutMillis;
         return getThis();
+    }
+
+    public SELF transactionTimeoutMillis(long timeoutMillis) {
+        this.transactionTimeoutMillis = timeoutMillis;
+        return getThis();
+    }
+
+    public long transactionTimeoutMillis() {
+        if (transactionTimeoutMillis != null) return transactionTimeoutMillis;
+        else if (parent != null) return parent.transactionTimeoutMillis();
+        else return DEFAULT_TRANSACTION_TIMEOUT_MILLIS;
     }
 
     public int schemaLockTimeoutMillis() {

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -52,7 +52,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     private Boolean explain = null;
     private Boolean parallel = null;
     private Integer prefetchSize = null;
-    private Long sessionIdlTimeoutMillis = null;
+    private Long sessionIdleTimeoutMillis = null;
     private Long transactionTimeoutMillis = null;
     private Long schemaLockAcquireTimeoutMillis = null;
     private Boolean readAnyReplica = null;
@@ -126,18 +126,13 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     }
 
     public long sessionIdleTimeoutMillis() {
-        if (sessionIdlTimeoutMillis != null) return sessionIdlTimeoutMillis;
+        if (sessionIdleTimeoutMillis != null) return sessionIdleTimeoutMillis;
         else if (parent != null) return parent.sessionIdleTimeoutMillis();
         else return DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS;
     }
 
     public SELF sessionIdleTimeoutMillis(long idleTimeoutMillis) {
-        this.sessionIdlTimeoutMillis = idleTimeoutMillis;
-        return getThis();
-    }
-
-    public SELF transactionTimeoutMillis(long timeoutMillis) {
-        this.transactionTimeoutMillis = timeoutMillis;
+        this.sessionIdleTimeoutMillis = idleTimeoutMillis;
         return getThis();
     }
 
@@ -145,6 +140,11 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
         if (transactionTimeoutMillis != null) return transactionTimeoutMillis;
         else if (parent != null) return parent.transactionTimeoutMillis();
         else return DEFAULT_TRANSACTION_TIMEOUT_MILLIS;
+    }
+
+    public SELF transactionTimeoutMillis(long timeoutMillis) {
+        this.transactionTimeoutMillis = timeoutMillis;
+        return getThis();
     }
 
     public long schemaLockTimeoutMillis() {

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -36,7 +36,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     public static final int MINUTE_SECONDS = 60;
 
     public static final int DEFAULT_PREFETCH_SIZE = 50;
-    public static final int DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = 30_000;
+    public static final int DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = 30 * SECOND_MILLIS;
     public static final int DEFAULT_TRANSACTION_TIMEOUT_MILLIS = 5 * MINUTE_SECONDS * SECOND_MILLIS;
     public static final int DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS = 10_000;
     public static final boolean DEFAULT_INFER = false;

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -39,15 +39,10 @@ def vaticle_typedb_common():
     )
 
 def vaticle_typedb_protocol():
-#    git_repository(
-#        name = "vaticle_typedb_protocol",
-#        remote = "https://github.com/vaticle/typedb-protocol",
-#        tag = "2.5.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
-#    )
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/flyingsilverfin/typedb-protocol",
-        commit = "4a2c87cd9de61c13a155c457b8b4dc817a423ac3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/vaticle/typedb-protocol",
+        commit = "4ce4e1339995c8982914e9fd3177273b693609b7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -39,10 +39,15 @@ def vaticle_typedb_common():
     )
 
 def vaticle_typedb_protocol():
+#    git_repository(
+#        name = "vaticle_typedb_protocol",
+#        remote = "https://github.com/vaticle/typedb-protocol",
+#        tag = "2.5.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+#    )
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/vaticle/typedb-protocol",
-        tag = "2.5.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/flyingsilverfin/typedb-protocol",
+        commit = "4a2c87cd9de61c13a155c457b8b4dc817a423ac3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/rocks/RocksSession.java
+++ b/rocks/RocksSession.java
@@ -207,7 +207,7 @@ public abstract class RocksSession implements TypeDB.Session {
             long lock = 0;
             if (type == Arguments.Transaction.Type.WRITE) {
                 try {
-                    int timeout = options.schemaLockTimeoutMillis();
+                    long timeout = options.schemaLockTimeoutMillis();
                     lock = database().schemaLock().tryReadLock(timeout, MILLISECONDS);
                     if (lock == 0) throw TypeDBException.of(DATA_ACQUIRE_LOCK_TIMEOUT);
                 } catch (InterruptedException e) {

--- a/server/TransactionService.java
+++ b/server/TransactionService.java
@@ -92,8 +92,8 @@ public class TransactionService implements StreamObserver<TransactionProto.Trans
     private volatile TypeDB.Transaction transaction;
     private volatile Options.Transaction options;
     private volatile Services services;
-    private volatile int networkLatencyMillis;
     private volatile ScheduledFuture<?> scheduledTimeout;
+    private volatile int networkLatencyMillis;
 
     private class Services {
         private final ConceptService concept = new ConceptService(TransactionService.this, transaction.concepts());

--- a/server/TransactionService.java
+++ b/server/TransactionService.java
@@ -90,10 +90,10 @@ public class TransactionService implements StreamObserver<TransactionProto.Trans
 
     private volatile SessionService sessionSvc;
     private volatile TypeDB.Transaction transaction;
+    private volatile Options.Transaction options;
     private volatile Services services;
     private volatile int networkLatencyMillis;
     private volatile ScheduledFuture<?> scheduledTimeout;
-    private volatile Options.Transaction options;
 
     private class Services {
         private final ConceptService concept = new ConceptService(TransactionService.this, transaction.concepts());

--- a/server/common/RequestReader.java
+++ b/server/common/RequestReader.java
@@ -40,6 +40,7 @@ import static com.vaticle.typedb.protocol.OptionsProto.Options.PrefetchSizeOptCa
 import static com.vaticle.typedb.protocol.OptionsProto.Options.SchemaLockAcquireTimeoutOptCase.SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS;
 import static com.vaticle.typedb.protocol.OptionsProto.Options.SessionIdleTimeoutOptCase.SESSION_IDLE_TIMEOUT_MILLIS;
 import static com.vaticle.typedb.protocol.OptionsProto.Options.TraceInferenceOptCase.TRACE_INFERENCE;
+import static com.vaticle.typedb.protocol.OptionsProto.Options.TransactionTimeoutOptCase.TRANSACTION_TIMEOUT_MILLIS;
 
 public class RequestReader {
 
@@ -65,6 +66,9 @@ public class RequestReader {
         }
         if (request.getSessionIdleTimeoutOptCase().equals(SESSION_IDLE_TIMEOUT_MILLIS)) {
             options.sessionIdleTimeoutMillis(request.getSessionIdleTimeoutMillis());
+        }
+        if (request.getTransactionTimeoutOptCase().equals(TRANSACTION_TIMEOUT_MILLIS)) {
+            options.transactionTimeoutMillis(request.getTransactionTimeoutMillis());
         }
         if (request.getSchemaLockAcquireTimeoutOptCase().equals(SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS)) {
             options.schemaLockTimeoutMillis(request.getSchemaLockAcquireTimeoutMillis());


### PR DESCRIPTION
## What is the goal of this PR?

We implement transaction timeouts (outined in https://github.com/vaticle/typedb/issues/6487), to prevent users from accidentally leaving transactions open indefinitely and leaking memory as a result. The transaction timeout is configurable via the usual transaction/session options.

## What are the changes implemented in this PR?

* Add transaction timeout that starts from the second the transaction is opened
* automatically close (with error) the transaction when the timeout occurs