### PR TITLE
Update build jobs to use Ubuntu 21.04

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -31,67 +31,67 @@ build:
       owner: vaticle
       branch: master
     build-analysis:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       command: |
         SONARCLOUD_CODE_ANALYSIS_CREDENTIAL=$SONARCLOUD_CREDENTIAL \
           bazel run @vaticle_dependencies//tool/sonarcloud:code-analysis -- \
           --project-key=vaticle_typedb \
           --branch=$GRABL_BRANCH --commit-id=$GRABL_COMMIT
     dependency-analysis:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       command: |
         bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
   correctness:
     build:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       command: |
         bazel build //...
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
         bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
     build-dependency:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       command: |
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
         bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
     test-unit:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       command: |
         bazel test //common/... --test_output=streamed
         bazel test //pattern/... --test_output=streamed
         bazel test //logic/... --test_output=streamed
         bazel test //reasoner/... --test_output=streamed
     test-integration:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       command: |
         bazel test //test/integration/... --test_output=streamed
     test-behaviour-connection:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       command: |
         bazel test //test/behaviour/connection/... --test_output=streamed
     test-behaviour-concept:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       command: |
         bazel test //test/behaviour/concept/... --test_output=streamed
     test-behaviour-match:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       command: |
         bazel test //test/behaviour/typeql/language/match/... --test_output=streamed
         bazel test //test/behaviour/typeql/language/get/... --test_output=streamed
     test-behaviour-writable:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       command: |
         bazel test //test/behaviour/typeql/language/insert/... --test_output=streamed
         bazel test //test/behaviour/typeql/language/delete/... --test_output=streamed
         bazel test //test/behaviour/typeql/language/update/... --test_output=streamed
     test-behaviour-definable:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       command: |
         bazel test //test/behaviour/typeql/language/define/... --test_output=streamed
         bazel test //test/behaviour/typeql/language/undefine/... --test_output=streamed
         bazel test //test/behaviour/typeql/language/rule_validation/... --test_output=streamed
     test-behaviour-reasoner:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       command: |
         bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
@@ -106,7 +106,7 @@ build:
         # Flakey tests:
         # bazel test //test/behaviour/reasoner/tests/variable_roles:test --test_output=streamed
     test-assembly-linux-targz:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       filter:
         owner: vaticle
         branch: master
@@ -116,7 +116,7 @@ build:
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel test //test/assembly:assembly --test_output=streamed
     test-assembly-docker:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       filter:
         owner: vaticle
         branch: master
@@ -124,7 +124,7 @@ build:
       command: |
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
@@ -136,7 +136,7 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-zip -- snapshot
         bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-zip -- snapshot
     deploy-apt-snapshot:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       filter:
         owner: vaticle
         branch: master
@@ -152,7 +152,7 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //server:deploy-apt -- snapshot
         bazel run --define version=$(git rev-parse HEAD) //:deploy-apt -- snapshot
     test-deployment-apt:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       filter:
         owner: vaticle
         branch: master
@@ -166,11 +166,11 @@ release:
     branch: master
   validation:
     validate-dependencies:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       command: bazel test //:release-validate-deps --test_output=streamed
   deployment:
     deploy-github:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       filter:
         owner: vaticle
         branch: master
@@ -183,7 +183,7 @@ release:
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
         bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
     deploy-brew:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       dependencies: [deploy-github]
       filter:
         owner: vaticle
@@ -194,7 +194,7 @@ release:
         export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN DEPLOY_BREW_USERNAME=$REPO_GITHUB_USERNAME DEPLOY_BREW_EMAIL=$REPO_GITHUB_EMAIL
         bazel run --define version=$(cat VERSION) //:deploy-brew -- release
     deploy-apt-release:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       filter:
         owner: vaticle
         branch: master
@@ -210,7 +210,7 @@ release:
         bazel run --define version=$(cat VERSION) //server:deploy-apt -- release
         bazel run --define version=$(cat VERSION) //:deploy-apt -- release
     deploy-docker:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       filter:
         owner: vaticle
         branch: master
@@ -219,7 +219,7 @@ release:
         docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
         bazel run //:deploy-docker
     deploy-artifact-release:
-      image: vaticle-ubuntu-20.04
+      image: vaticle-ubuntu-21.04
       filter:
         owner: vaticle
         branch: master


### PR DESCRIPTION
## What is the goal of this PR?

We've updated the CI to use the most up-to-date Factory job image which is based on Ubuntu 21.04.

## What are the changes implemented in this PR?

1. Update job images to `vaticle-ubuntu-21.04`