### PR TITLE
Idempotently finish reasoner producer

### DIFF
--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -148,7 +148,6 @@ public class ReasonerProducer implements Producer<ConceptMap> {
 
     private void finish() {
         if (!done) {
-            // query is completely terminated
             done = true;
             queue.done();
             required.set(0);

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -147,10 +147,12 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     }
 
     private void finish() {
-        // query is completely terminated
-        done = true;
-        queue.done();
-        required.set(0);
+        if (!done) {
+            // query is completely terminated
+            done = true;
+            queue.done();
+            required.set(0);
+        }
     }
 
     private void sendReiterationRequests() {


### PR DESCRIPTION
## What is the goal of this PR?

We fix a rare reasoner query termination bug by making the termination idempotent. Our producer/consumer async classes expect the queue `done()` method is only called once - reasoner rarely called it twice, causing null pointer exceptions higher up in the producer/queue call chain.

## What are the changes implemented in this PR?

* only call `queue.done()` once, the first time the reasoner producer is finished