### PR TITLE
Allow setting a type as abstract given only indirect instances

### DIFF
--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -41,6 +41,9 @@ public interface AttributeType extends ThingType {
     @Override
     FunctionalIterator<? extends Attribute> getInstances();
 
+    @Override
+    FunctionalIterator<? extends Attribute> getInstancesExplicit();
+
     void setSupertype(AttributeType superType);
 
     boolean isKeyable();
@@ -149,6 +152,9 @@ public interface AttributeType extends ThingType {
         @Override
         FunctionalIterator<? extends Attribute.Boolean> getInstances();
 
+        @Override
+        FunctionalIterator<? extends Attribute.Boolean> getInstancesExplicit();
+
         Attribute.Boolean put(boolean value);
 
         Attribute.Boolean put(boolean value, boolean isInferred);
@@ -166,6 +172,9 @@ public interface AttributeType extends ThingType {
 
         @Override
         FunctionalIterator<? extends Attribute.Long> getInstances();
+
+        @Override
+        FunctionalIterator<? extends Attribute.Long> getInstancesExplicit();
 
         Attribute.Long put(long value);
 
@@ -185,6 +194,9 @@ public interface AttributeType extends ThingType {
         @Override
         FunctionalIterator<? extends Attribute.Double> getInstances();
 
+        @Override
+        FunctionalIterator<? extends Attribute.Double> getInstancesExplicit();
+
         Attribute.Double put(double value);
 
         Attribute.Double put(double value, boolean isInferred);
@@ -202,6 +214,9 @@ public interface AttributeType extends ThingType {
 
         @Override
         FunctionalIterator<? extends Attribute.String> getInstances();
+
+        @Override
+        FunctionalIterator<? extends Attribute.String> getInstancesExplicit();
 
         void setRegex(Pattern regex);
 
@@ -226,6 +241,9 @@ public interface AttributeType extends ThingType {
 
         @Override
         FunctionalIterator<? extends Attribute.DateTime> getInstances();
+
+        @Override
+        FunctionalIterator<? extends Attribute.DateTime> getInstancesExplicit();
 
         Attribute.DateTime put(LocalDateTime value);
 

--- a/concept/type/EntityType.java
+++ b/concept/type/EntityType.java
@@ -32,6 +32,9 @@ public interface EntityType extends ThingType {
     @Override
     FunctionalIterator<? extends Entity> getInstances();
 
+    @Override
+    FunctionalIterator<? extends Entity> getInstancesExplicit();
+
     void setSupertype(EntityType superType);
 
     Entity create();

--- a/concept/type/RelationType.java
+++ b/concept/type/RelationType.java
@@ -32,6 +32,9 @@ public interface RelationType extends ThingType {
     @Override
     FunctionalIterator<? extends Relation> getInstances();
 
+    @Override
+    FunctionalIterator<? extends Relation> getInstancesExplicit();
+
     void setSupertype(RelationType superType);
 
     void setRelates(String roleLabel);

--- a/concept/type/ThingType.java
+++ b/concept/type/ThingType.java
@@ -37,6 +37,8 @@ public interface ThingType extends Type {
 
     FunctionalIterator<? extends Thing> getInstances();
 
+    FunctionalIterator<? extends Thing> getInstancesExplicit();
+
     void setAbstract();
 
     void unsetAbstract();

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -99,14 +99,6 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
     }
 
     @Override
-    public void setAbstract() {
-        if (getInstancesExplicit().first().isPresent()) {
-            throw exception(TypeDBException.of(TYPE_HAS_INSTANCES_SET_ABSTRACT, getLabel()));
-        }
-        vertex.isAbstract(true);
-    }
-
-    @Override
     public void unsetAbstract() {
         if (getSubtypes().anyMatch(sub -> !sub.equals(this))) {
             throw exception(TypeDBException.of(ATTRIBUTE_UNSET_ABSTRACT_HAS_SUBTYPES, getLabel()));

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -22,6 +22,7 @@ import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.iterator.Iterators;
 import com.vaticle.typedb.core.concept.thing.Attribute;
+import com.vaticle.typedb.core.concept.thing.Thing;
 import com.vaticle.typedb.core.concept.thing.impl.AttributeImpl;
 import com.vaticle.typedb.core.concept.type.AttributeType;
 import com.vaticle.typedb.core.concept.type.RoleType;
@@ -48,6 +49,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.AT
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.ATTRIBUTE_UNSET_ABSTRACT_HAS_SUBTYPES;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.ROOT_TYPE_MUTATION;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.TYPE_HAS_INSTANCES_SET_ABSTRACT;
+import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
 import static com.vaticle.typedb.core.common.iterator.Iterators.link;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.OWNS;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.OWNS_KEY;
@@ -362,6 +364,11 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
         }
 
         @Override
+        public FunctionalIterator<AttributeImpl<?>> getInstancesExplicit() {
+            return empty();
+        }
+
+        @Override
         public void setOwns(AttributeType attributeType, boolean isKey) {
             throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
         }
@@ -421,6 +428,11 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
         @Override
         public FunctionalIterator<AttributeImpl.Boolean> getInstances() {
             return instances(v -> new AttributeImpl.Boolean(v.asAttribute().asBoolean()));
+        }
+
+        @Override
+        public FunctionalIterator<AttributeImpl.Boolean> getInstancesExplicit() {
+            return instancesExplicit(v -> new AttributeImpl.Boolean(v.asAttribute().asBoolean()));
         }
 
         @Override
@@ -557,6 +569,11 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
         }
 
         @Override
+        public FunctionalIterator<AttributeImpl.Long> getInstancesExplicit() {
+            return instancesExplicit(v -> new AttributeImpl.Long(v.asAttribute().asLong()));
+        }
+
+        @Override
         public ValueType getValueType() {
             return ValueType.LONG;
         }
@@ -690,6 +707,11 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
         }
 
         @Override
+        public FunctionalIterator<AttributeImpl.Double> getInstancesExplicit() {
+            return instancesExplicit(v -> new AttributeImpl.Double(v.asAttribute().asDouble()));
+        }
+
+        @Override
         public ValueType getValueType() {
             return ValueType.DOUBLE;
         }
@@ -820,6 +842,11 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
         @Override
         public FunctionalIterator<AttributeImpl.String> getInstances() {
             return instances(v -> new AttributeImpl.String(v.asAttribute().asString()));
+        }
+
+        @Override
+        public FunctionalIterator<AttributeImpl.String> getInstancesExplicit() {
+            return instancesExplicit(v -> new AttributeImpl.String(v.asAttribute().asString()));
         }
 
         @Override
@@ -992,6 +1019,11 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
         @Override
         public FunctionalIterator<AttributeImpl.DateTime> getInstances() {
             return instances(v -> new AttributeImpl.DateTime(v.asAttribute().asDateTime()));
+        }
+
+        @Override
+        public FunctionalIterator<AttributeImpl.DateTime> getInstancesExplicit() {
+            return instancesExplicit(v -> new AttributeImpl.DateTime(v.asAttribute().asDateTime()));
         }
 
         @Override

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -100,7 +100,7 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
 
     @Override
     public void setAbstract() {
-        if (getInstances().first().isPresent()) {
+        if (getInstancesExplicit().first().isPresent()) {
             throw exception(TypeDBException.of(TYPE_HAS_INSTANCES_SET_ABSTRACT, getLabel()));
         }
         vertex.isAbstract(true);

--- a/concept/type/impl/EntityTypeImpl.java
+++ b/concept/type/impl/EntityTypeImpl.java
@@ -83,6 +83,11 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
     }
 
     @Override
+    public FunctionalIterator<EntityImpl> getInstancesExplicit() {
+        return instancesExplicit(EntityImpl::of);
+    }
+
+    @Override
     public List<TypeDBException> validate() {
         return super.validate();
     }

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -55,7 +55,7 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
         super(graphMgr, vertex);
         if (vertex.encoding() != RELATION_TYPE) {
             throw exception(TypeDBException.of(TYPE_ROOT_MISMATCH, vertex.label(),
-                                               RELATION_TYPE.root().label(), vertex.encoding().root().label()));
+                    RELATION_TYPE.root().label(), vertex.encoding().root().label()));
         }
     }
 
@@ -81,13 +81,12 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
 
     @Override
     public void setAbstract() {
-        if (!isAbstract()) {
-            if (getInstancesExplicit().first().isPresent()) {
-                throw exception(TypeDBException.of(TYPE_HAS_INSTANCES_SET_ABSTRACT, getLabel()));
-            }
-            vertex.isAbstract(true);
-            declaredRoles().forEachRemaining(RoleTypeImpl::setAbstract);
+        if (isAbstract()) return;
+        if (getInstancesExplicit().first().isPresent()) {
+            throw exception(TypeDBException.of(TYPE_HAS_INSTANCES_SET_ABSTRACT, getLabel()));
         }
+        vertex.isAbstract(true);
+        declaredRoles().forEachRemaining(RoleTypeImpl::setAbstract);
     }
 
     @Override
@@ -268,10 +267,14 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
     }
 
     @Override
-    public boolean isRelationType() { return true; }
+    public boolean isRelationType() {
+        return true;
+    }
 
     @Override
-    public RelationTypeImpl asRelationType() { return this; }
+    public RelationTypeImpl asRelationType() {
+        return this;
+    }
 
     public static class Root extends RelationTypeImpl {
 
@@ -281,7 +284,9 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
         }
 
         @Override
-        public boolean isRoot() { return true; }
+        public boolean isRoot() {
+            return true;
+        }
 
         @Override
         public void setLabel(String label) {

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -81,7 +81,9 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
 
     @Override
     public void setAbstract() {
-        if (getInstances().first().isPresent()) throw exception(TypeDBException.of(TYPE_HAS_INSTANCES_SET_ABSTRACT, getLabel()));
+        if (getInstancesExplicit().first().isPresent()) {
+            throw exception(TypeDBException.of(TYPE_HAS_INSTANCES_SET_ABSTRACT, getLabel()));
+        }
         vertex.isAbstract(true);
         declaredRoles().forEachRemaining(RoleTypeImpl::setAbstract);
     }

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -114,6 +114,11 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
     }
 
     @Override
+    public FunctionalIterator<RelationImpl> getInstancesExplicit() {
+        return instancesExplicit(RelationImpl::of);
+    }
+
+    @Override
     public void setRelates(String roleLabel) {
         validateIsNotDeleted();
         TypeVertex roleTypeVertex = graphMgr.schema().getType(roleLabel, vertex.label());

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -81,11 +81,13 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
 
     @Override
     public void setAbstract() {
-        if (getInstancesExplicit().first().isPresent()) {
-            throw exception(TypeDBException.of(TYPE_HAS_INSTANCES_SET_ABSTRACT, getLabel()));
+        if (!isAbstract()) {
+            if (getInstancesExplicit().first().isPresent()) {
+                throw exception(TypeDBException.of(TYPE_HAS_INSTANCES_SET_ABSTRACT, getLabel()));
+            }
+            vertex.isAbstract(true);
+            declaredRoles().forEachRemaining(RoleTypeImpl::setAbstract);
         }
-        vertex.isAbstract(true);
-        declaredRoles().forEachRemaining(RoleTypeImpl::setAbstract);
     }
 
     @Override

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -22,6 +22,7 @@ import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.iterator.Iterators;
 import com.vaticle.typedb.core.concept.thing.Attribute;
+import com.vaticle.typedb.core.concept.thing.Thing;
 import com.vaticle.typedb.core.concept.thing.impl.AttributeImpl;
 import com.vaticle.typedb.core.concept.thing.impl.EntityImpl;
 import com.vaticle.typedb.core.concept.thing.impl.RelationImpl;
@@ -65,6 +66,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.TY
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.TYPE_HAS_INSTANCES_SET_ABSTRACT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.TYPE_HAS_SUBTYPES;
 import static com.vaticle.typedb.core.common.iterator.Iterators.compareSize;
+import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
 import static com.vaticle.typedb.core.common.iterator.Iterators.link;
 import static com.vaticle.typedb.core.common.iterator.Iterators.loop;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.OWNS;
@@ -515,6 +517,11 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
                         throw exception(TypeDBException.of(UNRECOGNISED_VALUE));
                 }
             });
+        }
+
+        @Override
+        public FunctionalIterator<ThingImpl> getInstancesExplicit() {
+            return empty();
         }
 
         @Override

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -101,13 +101,12 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
 
     @Override
     public void setAbstract() {
-        if (!isAbstract()) {
-            validateIsNotDeleted();
-            if (getInstancesExplicit().first().isPresent()) {
-                throw exception(TypeDBException.of(TYPE_HAS_INSTANCES_SET_ABSTRACT, getLabel()));
-            }
-            vertex.isAbstract(true);
+        if (isAbstract()) return;
+        validateIsNotDeleted();
+        if (getInstancesExplicit().first().isPresent()) {
+            throw exception(TypeDBException.of(TYPE_HAS_INSTANCES_SET_ABSTRACT, getLabel()));
         }
+        vertex.isAbstract(true);
     }
 
     @Override
@@ -173,10 +172,10 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
         else if ((edge = vertex.outs().edge(OWNS, attVertex)) != null) edge.delete();
         else if (this.getOwns().anyMatch(attr -> attr.equals(attributeType))) {
             throw exception(TypeDBException.of(INVALID_UNDEFINE_INHERITED_OWNS,
-                                               this.getLabel().toString(), attributeType.getLabel().toString()));
+                    this.getLabel().toString(), attributeType.getLabel().toString()));
         } else {
             throw exception(TypeDBException.of(INVALID_UNDEFINE_NONEXISTENT_OWNS,
-                                               this.getLabel().toString(), attributeType.getLabel().toString()));
+                    this.getLabel().toString(), attributeType.getLabel().toString()));
         }
     }
 
@@ -202,7 +201,7 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
         if (!attributeType.isKeyable()) {
             throw exception(TypeDBException.of(OWNS_KEY_VALUE_TYPE, attributeType.getLabel(), attributeType.getValueType().name()));
         } else if (link(getSupertype().getOwns(attributeType.getValueType(), true),
-                        getSupertype().overriddenOwns(false, true)).anyMatch(a -> a.equals(attributeType))) {
+                getSupertype().overriddenOwns(false, true)).anyMatch(a -> a.equals(attributeType))) {
             throw exception(TypeDBException.of(OWNS_KEY_NOT_AVAILABLE, attributeType.getLabel()));
         }
 
@@ -210,9 +209,11 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
             // TODO: These ownership and uniqueness checks should be parallelised to scale better
             getInstances().forEachRemaining(thing -> {
                 FunctionalIterator<? extends Attribute> attrs = thing.getHas(attributeType);
-                if (!attrs.hasNext()) throw exception(TypeDBException.of(OWS_KEY_PRECONDITION_OWNERSHIP_KEY_TOO_MANY, vertex.label(), attVertex.label()));
+                if (!attrs.hasNext())
+                    throw exception(TypeDBException.of(OWS_KEY_PRECONDITION_OWNERSHIP_KEY_TOO_MANY, vertex.label(), attVertex.label()));
                 Attribute attr = attrs.next();
-                if (attrs.hasNext()) throw exception(TypeDBException.of(OWS_KEY_PRECONDITION_OWNERSHIP_KEY_MISSING, vertex.label(), attVertex.label()));
+                if (attrs.hasNext())
+                    throw exception(TypeDBException.of(OWS_KEY_PRECONDITION_OWNERSHIP_KEY_MISSING, vertex.label(), attVertex.label()));
                 else if (compareSize(attr.getOwners(this), 1) != 0) {
                     throw exception(TypeDBException.of(OWNS_KEY_PRECONDITION_UNIQUENESS, attVertex.label(), vertex.label()));
                 }
@@ -228,8 +229,8 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
     private void ownsKey(AttributeTypeImpl attributeType, AttributeTypeImpl overriddenType) {
         ownsKey(attributeType);
         override(OWNS_KEY, attributeType, overriddenType,
-                 getSupertype().getOwns(attributeType.getValueType()),
-                 declaredOwns(false));
+                getSupertype().getOwns(attributeType.getValueType()),
+                declaredOwns(false));
     }
 
     private void ownsAttribute(AttributeTypeImpl attributeType) {
@@ -247,8 +248,8 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
     private void ownsAttribute(AttributeTypeImpl attributeType, AttributeTypeImpl overriddenType) {
         this.ownsAttribute(attributeType);
         override(OWNS, attributeType, overriddenType,
-                 getSupertype().getOwns(attributeType.getValueType()),
-                 link(getSupertype().getOwns(true), declaredOwns(false)));
+                getSupertype().getOwns(attributeType.getValueType()),
+                link(getSupertype().getOwns(true), declaredOwns(false)));
     }
 
     private FunctionalIterator<AttributeTypeImpl> declaredOwns(boolean onlyKey) {
@@ -348,7 +349,7 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
         validateIsNotDeleted();
         setPlays(roleType);
         override(Encoding.Edge.Type.PLAYS, roleType, overriddenType, getSupertype().getPlays(),
-                 vertex.outs().edge(Encoding.Edge.Type.PLAYS).to().map(v -> RoleTypeImpl.of(graphMgr, v)));
+                vertex.outs().edge(Encoding.Edge.Type.PLAYS).to().map(v -> RoleTypeImpl.of(graphMgr, v)));
     }
 
     @Override
@@ -358,10 +359,10 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
         if (edge == null) {
             if (this.getPlays().anyMatch(attr -> attr.equals(roleType))) {
                 throw exception(TypeDBException.of(INVALID_UNDEFINE_INHERITED_PLAYS,
-                                                   this.getLabel().toString(), roleType.getLabel().toString()));
+                        this.getLabel().toString(), roleType.getLabel().toString()));
             } else {
                 throw exception(TypeDBException.of(INVALID_UNDEFINE_NONEXISTENT_PLAYS,
-                                                   this.getLabel().toString(), roleType.getLabel().toString()));
+                        this.getLabel().toString(), roleType.getLabel().toString()));
             }
         }
         if (getInstances().anyMatch(thing -> thing.getRelations(roleType).first().isPresent())) {
@@ -426,10 +427,14 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
     }
 
     @Override
-    public boolean isThingType() { return true; }
+    public boolean isThingType() {
+        return true;
+    }
 
     @Override
-    public ThingTypeImpl asThingType() { return this; }
+    public ThingTypeImpl asThingType() {
+        return this;
+    }
 
     private List<TypeDBException> exceptions_ownsAbstractAttType() {
         return getOwns().filter(TypeImpl::isAbstract)
@@ -451,16 +456,24 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
         }
 
         @Override
-        public boolean isRoot() { return true; }
+        public boolean isRoot() {
+            return true;
+        }
 
         @Override
-        public void setLabel(String label) { throw exception(TypeDBException.of(ROOT_TYPE_MUTATION)); }
+        public void setLabel(String label) {
+            throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
+        }
 
         @Override
-        public void unsetAbstract() { throw exception(TypeDBException.of(ROOT_TYPE_MUTATION)); }
+        public void unsetAbstract() {
+            throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
+        }
 
         @Override
-        public ThingTypeImpl getSupertype() { return null; }
+        public ThingTypeImpl getSupertype() {
+            return null;
+        }
 
         @Override
         public FunctionalIterator<ThingTypeImpl> getSupertypes() {
@@ -470,20 +483,20 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
         @Override
         public FunctionalIterator<ThingTypeImpl> getSubtypes() {
             return graphMgr.schema().getSubtypes(vertex).map(v -> {
-                    switch (v.encoding()) {
-                        case THING_TYPE:
-                            assert vertex == v;
-                            return this;
-                        case ENTITY_TYPE:
-                            return EntityTypeImpl.of(graphMgr, v);
-                        case ATTRIBUTE_TYPE:
-                            return AttributeTypeImpl.of(graphMgr, v);
-                        case RELATION_TYPE:
-                            return RelationTypeImpl.of(graphMgr, v);
-                        default:
-                            throw exception(TypeDBException.of(UNRECOGNISED_VALUE));
-                    }
-                });
+                switch (v.encoding()) {
+                    case THING_TYPE:
+                        assert vertex == v;
+                        return this;
+                    case ENTITY_TYPE:
+                        return EntityTypeImpl.of(graphMgr, v);
+                    case ATTRIBUTE_TYPE:
+                        return AttributeTypeImpl.of(graphMgr, v);
+                    case RELATION_TYPE:
+                        return RelationTypeImpl.of(graphMgr, v);
+                    default:
+                        throw exception(TypeDBException.of(UNRECOGNISED_VALUE));
+                }
+            });
         }
 
         @Override

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -103,7 +103,7 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
     public void setAbstract() {
         if (!isAbstract()) {
             validateIsNotDeleted();
-            if (getInstances().first().isPresent()) {
+            if (getInstancesExplicit().first().isPresent()) {
                 throw exception(TypeDBException.of(TYPE_HAS_INSTANCES_SET_ABSTRACT, getLabel()));
             }
             vertex.isAbstract(true);

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -122,6 +122,10 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
                 .flatMap(t -> graphMgr.data().getReadable(t.vertex)).map(thingConstructor);
     }
 
+    <THING> FunctionalIterator<THING> instancesExplicit(Function<ThingVertex, THING> thingConstructor) {
+        return graphMgr.data().getReadable(vertex).map(thingConstructor);
+    }
+
     void setSuperTypeVertex(TypeVertex superTypeVertex) {
         vertex.outs().edge(SUB, ((TypeImpl) getSupertype()).vertex).delete();
         vertex.outs().put(SUB, superTypeVertex);

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,8 +48,8 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "05063b44ee914ad1c71a580c8ecc6454e33c302a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
+        commit = "5ee480f5280fcf09a8bf133efc7c0c6013792f56", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,8 +48,8 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-        commit = "99419888b6adacc23de6a6a37a76a987f82cd899", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "1ca29fde9ef185f995aac9f8baaffe6a42792168", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,7 +49,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-        commit = "5ee480f5280fcf09a8bf133efc7c0c6013792f56", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "99419888b6adacc23de6a6a37a76a987f82cd899", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/test/behaviour/concept/type/thingtype/ThingTypeSteps.java
+++ b/test/behaviour/concept/type/thingtype/ThingTypeSteps.java
@@ -133,6 +133,12 @@ public class ThingTypeSteps {
         else get_thing_type(rootLabel, typeLabel).unsetAbstract();
     }
 
+    @When("{root_label}\\( ?{type_label} ?) set abstract: {bool}; throws exception")
+    public void thing_type_set_abstract_throws(RootLabel rootLabel, String typeLabel, boolean isAbstract) {
+        if (isAbstract) assertThrows(() -> get_thing_type(rootLabel, typeLabel).setAbstract());
+        else assertThrows(() -> get_thing_type(rootLabel, typeLabel).unsetAbstract());
+    }
+
     @Then("{root_label}\\( ?{type_label} ?) is abstract: {bool}")
     public void thing_type_is_abstract(RootLabel rootLabel, String typeLabel, boolean isAbstract) {
         assertEquals(isAbstract, get_thing_type(rootLabel, typeLabel).isAbstract());


### PR DESCRIPTION
## What is the goal of this PR?

We allow setting a type as abstract when a type only has indirect instances (a child types' instances, rather than its own). This was raised in https://github.com/vaticle/typedb/issues/6494.

## What are the changes implemented in this PR?

* we introduce `getInstancesExplicit()` to get the exact instances of a type, ie. excluding the child types' instances
* setting abstractness is now only disallowed when there are explicit instances
