### PR TITLE
Utilise IID type information in type inference

### DIFF
--- a/logic/tool/TypeInference.java
+++ b/logic/tool/TypeInference.java
@@ -426,7 +426,7 @@ public class TypeInference {
         private void registerIID(TypeVariable resolver, IIDConstraint constraint) {
             TypeVertex type = graphMgr.schema().convert(VertexIID.Thing.of(constraint.iid()).type());
             if (type == null) throw TypeDBException.of(UNSATISFIABLE_PATTERN, conjunction, constraint);
-            traversal.labels(resolver.id(), type.properLabel());
+            restrict(resolver.id(), iterate(type));
         }
 
         private void registerHas(TypeVariable resolver, HasConstraint hasConstraint) {


### PR DESCRIPTION
## What is the goal of this PR?

We can use some of the information in IIDs by extracting the contained type IID and using that for type resolution, rather than ignoring IIDs completely. We had previous removed the code path within type inference that examined the IIDs within the query, following the logic that a static type checker should not validate the data specified within the query, only the structure & typing. This changed is outlined in https://github.com/vaticle/typedb/issues/6477.

## What are the changes implemented in this PR?

* extract type information from IIDs and include them in type inference
* add test to the suite of integration tests for type inference
