### PR TITLE
Improve rule validation with filterable type inference

### DIFF
--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -402,8 +402,12 @@ public class Rule {
         }
 
         private void validateInsertable(LogicManager logicMgr) {
-            FunctionalIterator<Map<Identifier.Variable.Name, Label>> whenCombinations = logicMgr.typeInference().typePermutations(rule.when, false);
-            Set<Map<Identifier.Variable.Name, Label>> allowedThenCombinations = logicMgr.typeInference().typePermutations(rule.then, true).toSet();
+            Set<Identifier.Variable.Name> thenNamed = iterate(rule.then.identifiers()).filter(Identifier::isName)
+                    .map(Identifier.Variable::asName).toSet();
+            FunctionalIterator<Map<Identifier.Variable.Name, Label>> whenCombinations = logicMgr.typeInference()
+                    .typePermutations(rule.when, false, thenNamed);
+            Set<Map<Identifier.Variable.Name, Label>> allowedThenCombinations = logicMgr.typeInference()
+                    .typePermutations(rule.then, true, thenNamed).toSet();
 
             whenCombinations.forEachRemaining(nameLabelMap -> {
                 if (allowedThenCombinations.stream().noneMatch(thenMap -> nameLabelMap.entrySet().containsAll(thenMap.entrySet())))

--- a/logic/tool/TypeInference.java
+++ b/logic/tool/TypeInference.java
@@ -85,10 +85,15 @@ public class TypeInference {
         this.graphMgr = graphMgr;
     }
 
-    public FunctionalIterator<Map<Name, Label>> typePermutations(Conjunction conjunction, boolean insertable) {
+    public FunctionalIterator<Map<Name, Label>> typePermutations(Conjunction conjunction, boolean insertable,
+                                                                 Set<? extends Identifier.Variable.Retrievable> filter) {
         TraversalBuilder traversalBuilder = new TraversalBuilder(conjunction, insertable, graphMgr);
         GraphTraversal.Type traversal = traversalBuilder.traversal();
-        traversal.filter(traversalBuilder.retrievedResolvers());
+        Set<Identifier.Variable.Retrievable> resolverFilter = iterate(filter).map(id -> {
+            assert traversalBuilder.originalToResolver.containsKey(id);
+            return traversalBuilder.originalToResolver.get(id).id().asRetrievable();
+        }).toSet();
+        traversal.filter(resolverFilter);
         return traversalEng.iterator(traversal).map(vertexMap -> {
             Map<Name, Label> mapping = new HashMap<>();
             vertexMap.forEach((id, vertex) -> {


### PR DESCRIPTION
## What is the goal of this PR?

We make rule validation more efficient by allowing type inference to infer type permutations for fewer variables.

## What are the changes implemented in this PR?

* We pass the variables from the `then` of the rule into the type inference operation when getting `when` type permutations that must be insertable in the `then`. This should allow the traversal engine (if it is clever enough!) to do less work by observing the filter variables that must be returned