### PR TITLE
Guarantee 'match' query answer uniqueness

### DIFF
--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -203,8 +203,8 @@ public class GraphProcedure implements PermutationProcedure {
                     sv -> new GraphIterator(graphMgr, sv, this, params, filter).distinct()
             );
         } else {
+            // TODO we can reduce the size of the distinct() set if the traversal engine doesn't overgenerate as much
             return startVertex().iterator(graphMgr, params).flatMap(
-                    // TODO we can reduce the size of the distinct() set if the traversal engine doesn't overgenerate as much
                     sv -> new GraphIterator(graphMgr, sv, this, params, filter)
             ).distinct();
         }

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -176,10 +176,17 @@ public class GraphProcedure implements PermutationProcedure {
             LOG.trace(this.toString());
         }
         assertWithinFilterBounds(filter);
-        return async(startVertex().iterator(graphMgr, params).map(
-                // TODO we can reduce the size of the distinct() set if the traversal engine doesn't overgenerate as much
-                v -> new GraphIterator(graphMgr, v, this, params, filter).distinct()
-        ), parallelisation);
+        if (startVertex().id().isRetrievable() && filter.contains(startVertex().id().asVariable().asRetrievable())) {
+            return async(startVertex().iterator(graphMgr, params).map(
+                    // TODO we can reduce the size of the distinct() set if the traversal engine doesn't overgenerate as much
+                    v -> new GraphIterator(graphMgr, v, this, params, filter).distinct()
+            ), parallelisation);
+        } else {
+            // TODO we can reduce the size of the distinct() set if the traversal engine doesn't overgenerate as much
+            return async(startVertex().iterator(graphMgr, params).map(
+                    v -> new GraphIterator(graphMgr, v, this, params, filter)
+            ), parallelisation).distinct();
+        }
     }
 
     @Override
@@ -190,10 +197,17 @@ public class GraphProcedure implements PermutationProcedure {
             LOG.trace(this.toString());
         }
         assertWithinFilterBounds(filter);
-        return startVertex().iterator(graphMgr, params).flatMap(
-                // TODO we can reduce the size of the distinct() set if the traversal engine doesn't overgenerate as much
-                sv -> new GraphIterator(graphMgr, sv, this, params, filter).distinct()
-        );
+        if (startVertex().id().isRetrievable() && filter.contains(startVertex().id().asVariable().asRetrievable())) {
+            return startVertex().iterator(graphMgr, params).flatMap(
+                    // TODO we can reduce the size of the distinct() set if the traversal engine doesn't overgenerate as much
+                    sv -> new GraphIterator(graphMgr, sv, this, params, filter).distinct()
+            );
+        } else {
+            return startVertex().iterator(graphMgr, params).flatMap(
+                    // TODO we can reduce the size of the distinct() set if the traversal engine doesn't overgenerate as much
+                    sv -> new GraphIterator(graphMgr, sv, this, params, filter)
+            ).distinct();
+        }
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

TypeDB guarantees uniqueness of `match` query answers in all cases. Previously, there were cases where violations of answer uniqueness occurred, such as when the server made particular query optimisations. 

## What are the changes implemented in this PR?

* use a `distinct()` set to guarantee concept map uniqueness
  * where the distinct set is applied depends on whether the start variable is  part of the variables returned to the user
  * if the start variable is not returned, we have to use a more expensive larger distinct set to guarantee uniqueness - ther is room for optimisation in the future.

## Example of bug:

If this these two answers exist, trying to return just `$x`:
```
{$_0: 0x10, $x: 0x2}
{$_0: 0x10, $x: 0x2}
```

If the start variable is `$_0`, then the old code would only use a distinct set for the remainder of the answer, so we end up with two answers of `{$x: 0x2}`.
If the start variable was `$x`, we would end up with just one answer of `{$x: 0x2}`.

