### PR TITLE
Fix iterators to recycle sub-iterators correctly

### DIFF
--- a/common/iterator/FlatMappedIterator.java
+++ b/common/iterator/FlatMappedIterator.java
@@ -73,5 +73,6 @@ class FlatMappedIterator<T, U> extends AbstractFunctionalIterator<U> {
     @Override
     public void recycle() {
         sourceIterator.recycle();
+        if (currentIterator != null) currentIterator.recycle();
     }
 }

--- a/traversal/scanner/GraphIterator.java
+++ b/traversal/scanner/GraphIterator.java
@@ -86,6 +86,11 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
         }
     }
 
+    private void setCompleted() {
+        state = State.COMPLETED;
+        recycle();
+    }
+
     @Override
     public boolean hasNext() {
         try {
@@ -93,11 +98,11 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
             else if (state == State.FETCHED) return true;
             else if (state == State.INIT) {
                 if (computeFirst(1)) state = State.FETCHED;
-                else state = State.COMPLETED;
+                else  setCompleted();
             } else if (state == State.EMPTY) {
                 computeNextSeekPos = edgeCount;
                 if (computeNext(edgeCount)) state = State.FETCHED;
-                else state = State.COMPLETED;
+                else setCompleted();
             } else {
                 throw TypeDBException.of(ILLEGAL_STATE);
             }
@@ -344,6 +349,8 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
 
     @Override
     public void recycle() {
+        iterators.values().forEach(FunctionalIterator::recycle);
+        iterators.clear();
     }
 
     public static class Scopes {

--- a/traversal/scanner/GraphIterator.java
+++ b/traversal/scanner/GraphIterator.java
@@ -33,6 +33,7 @@ import com.vaticle.typedb.core.traversal.procedure.ProcedureEdge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,6 +46,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILL
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.RESOURCE_CLOSED;
 import static java.util.stream.Collectors.toMap;
 
+@NotThreadSafe
 public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
 
     private static final Logger LOG = LoggerFactory.getLogger(GraphIterator.class);
@@ -86,11 +88,6 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
         }
     }
 
-    private void setCompleted() {
-        state = State.COMPLETED;
-        recycle();
-    }
-
     @Override
     public boolean hasNext() {
         try {
@@ -98,7 +95,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
             else if (state == State.FETCHED) return true;
             else if (state == State.INIT) {
                 if (computeFirst(1)) state = State.FETCHED;
-                else  setCompleted();
+                else setCompleted();
             } else if (state == State.EMPTY) {
                 computeNextSeekPos = edgeCount;
                 if (computeNext(edgeCount)) state = State.FETCHED;
@@ -118,6 +115,11 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
             }
             throw e;
         }
+    }
+
+    private void setCompleted() {
+        state = State.COMPLETED;
+        recycle();
     }
 
     private boolean computeFirst(int pos) {

--- a/traversal/scanner/GraphIterator.java
+++ b/traversal/scanner/GraphIterator.java
@@ -352,7 +352,6 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
     @Override
     public void recycle() {
         iterators.values().forEach(FunctionalIterator::recycle);
-        iterators.clear();
     }
 
     public static class Scopes {


### PR DESCRIPTION
## What is the goal of this PR?

All TypeDB iterators (`FunctionalIterators`) correctly release resources when asked to `recycle()`, allowing things like RocksDB iterators to be reused and preventing a memory leak. We discover and fix two remaining places where iterators were not releasing resources correctly: `FlatMapped` and `GraphIterator`.

## What are the changes implemented in this PR?

* Discover that it's possible to cause a "memory leak" / growing amount of memory in a long-lived transaction. This is caused by both `FlatMapped` iterators and `GraphIterator` (eg. the traversal executor) not releasing sub-iterators correctly.
* Fix both `FlatMapped` and `GraphIterator` to release their iterators when completing