### PR TITLE
Fix bazel server binary by preparing required directories

### DIFF
--- a/server/BUILD
+++ b/server/BUILD
@@ -95,8 +95,9 @@ native_java_libraries(
 )
 
 genrule(
-    name = "create-config-and-data-dir",
+    name = "prepare-binary-directories",
     srcs = [":config"],
+    # TODO: can we find a way to create a directory without including an empty file in the outs?
     cmd = "cp $(location :config) $(@D)/conf/ && touch $(@D)/data/empty",
     outs = ["conf/config.yml", "data/empty"]
 )
@@ -106,7 +107,7 @@ java_binary(
     main_class = "com.vaticle.typedb.core.server.TypeDBServer",
     runtime_deps = [":server-mac"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-server-bin:{pom_version}"],
-    data = [":create-config-and-data-dir"]
+    data = [":prepare-binary-directories"]
 )
 
 java_binary( # TODO: this target should not be needed if :server-deps-mac can depend directly on :server-mac (lib)
@@ -121,7 +122,7 @@ java_binary(
     main_class = "com.vaticle.typedb.core.server.TypeDBServer",
     runtime_deps = [":server-linux"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-server-bin:{pom_version}"],
-    data = ["//server:config"],
+    data = [":prepare-binary-directories"]
 )
 
 java_binary( # TODO: this target should not be needed if :server-deps-linux can depend directly on :server-linux (lib)
@@ -136,7 +137,7 @@ java_binary(
     main_class = "com.vaticle.typedb.core.server.TypeDBServer",
     runtime_deps = [":server-windows"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-server-bin:{pom_version}"],
-    data = ["//server:config"],
+    data = [":prepare-binary-directories"]
 )
 
 java_binary( # TODO: this target should not be needed if :server-deps-windows can depend directly on :server-windows (lib)

--- a/server/BUILD
+++ b/server/BUILD
@@ -94,12 +94,19 @@ native_java_libraries(
     visibility = ["//visibility:public"],
 )
 
+genrule(
+    name = "create-config-and-data-dir",
+    srcs = [":config"],
+    cmd = "cp $(location :config) $(@D)/conf/ && touch $(@D)/data/empty",
+    outs = ["conf/config.yml", "data/empty"]
+)
+
 java_binary(
     name = "server-bin-mac",
     main_class = "com.vaticle.typedb.core.server.TypeDBServer",
     runtime_deps = [":server-mac"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-server-bin:{pom_version}"],
-    data = ["//server:config"],
+    data = [":create-config-and-data-dir"]
 )
 
 java_binary( # TODO: this target should not be needed if :server-deps-mac can depend directly on :server-mac (lib)

--- a/server/BUILD
+++ b/server/BUILD
@@ -95,7 +95,7 @@ native_java_libraries(
 )
 
 genrule(
-    name = "prepare-binary-directories",
+    name = "prepare-server-directories",
     srcs = [":config"],
     # TODO: can we find a way to create a directory without including an empty file in the outs?
     cmd = "cp $(location :config) $(@D)/conf/ && touch $(@D)/data/empty",
@@ -107,7 +107,7 @@ java_binary(
     main_class = "com.vaticle.typedb.core.server.TypeDBServer",
     runtime_deps = [":server-mac"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-server-bin:{pom_version}"],
-    data = [":prepare-binary-directories"]
+    data = [":prepare-server-directories"]
 )
 
 java_binary( # TODO: this target should not be needed if :server-deps-mac can depend directly on :server-mac (lib)
@@ -122,7 +122,7 @@ java_binary(
     main_class = "com.vaticle.typedb.core.server.TypeDBServer",
     runtime_deps = [":server-linux"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-server-bin:{pom_version}"],
-    data = [":prepare-binary-directories"]
+    data = [":prepare-server-directories"]
 )
 
 java_binary( # TODO: this target should not be needed if :server-deps-linux can depend directly on :server-linux (lib)
@@ -137,7 +137,7 @@ java_binary(
     main_class = "com.vaticle.typedb.core.server.TypeDBServer",
     runtime_deps = [":server-windows"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-server-bin:{pom_version}"],
-    data = [":prepare-binary-directories"]
+    data = [":prepare-server-directories"]
 )
 
 java_binary( # TODO: this target should not be needed if :server-deps-windows can depend directly on :server-windows (lib)

--- a/server/parameters/ServerSubcommandParser.java
+++ b/server/parameters/ServerSubcommandParser.java
@@ -77,7 +77,7 @@ public class ServerSubcommandParser {
             Optional<Path> configPath = Server.configPath.parse(auxOptions);
             Config config = configPath
                     .map(path -> ConfigFactory.config(path, configOptions, configParser))
-                    .orElse(ConfigFactory.config(configOptions, configParser));
+                    .orElseGet(() -> ConfigFactory.config(configOptions, configParser));
             return new ServerSubcommand.Server(debug.parse(auxOptions), help.parse(auxOptions),
                     version.parse(auxOptions), config);
         }


### PR DESCRIPTION
## What is the goal of this PR?

We address the requirement of pre-creating directory structures before running the server binary via bazel, which was previously broken. The new requirements were caused by #6512 in which we expect the configuration file and data directory to exist at server bootup. 

## What are the changes implemented in this PR?

* Use a bazel `genrule` to pre-create the data directory, and copy the configuration file into the expected location before executing the server binary
* Fix a bug in loading of the configuration using the `ConfigFactory`, which should only load the default configuration file lazily if there is no configuration path given otherwise