### PR TITLE
Make partition manager class extendable

### DIFF
--- a/database/CorePartitionManager.java
+++ b/database/CorePartitionManager.java
@@ -18,7 +18,6 @@
 
 package com.vaticle.typedb.core.database;
 
-import com.vaticle.typedb.core.common.collection.ByteArray;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.graph.common.Storage.Key;
 import org.rocksdb.AbstractImmutableNativeReference;
@@ -29,16 +28,13 @@ import org.rocksdb.RocksDBException;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
 
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.collection.Collections.map;
-import static com.vaticle.typedb.common.collection.Collections.pair;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static com.vaticle.typedb.core.graph.common.Encoding.ValueType.STRING_ENCODING;
 import static com.vaticle.typedb.core.graph.common.Storage.Key.Partition.DEFAULT;
 import static com.vaticle.typedb.core.graph.common.Storage.Key.Partition.FIXED_START_EDGE;
 import static com.vaticle.typedb.core.graph.common.Storage.Key.Partition.OPTIMISATION_EDGE;
@@ -130,19 +126,19 @@ public abstract class CorePartitionManager {
                     configuration.defaultCFOptions()
             );
             descriptors[VARIABLE_START_EDGE_HANDLE_INDEX] = new ColumnFamilyDescriptor(
-                    ByteArray.encodeString(VARIABLE_START_EDGE.name(), STRING_ENCODING).getBytes(),
+                    VARIABLE_START_EDGE.encoding().partitionName().get().getBytes(),
                     configuration.variableStartEdgeCFOptions()
             );
             descriptors[FIXED_START_EDGE_HANDLE_INDEX] = new ColumnFamilyDescriptor(
-                    ByteArray.encodeString(FIXED_START_EDGE.name(), STRING_ENCODING).getBytes(),
+                    FIXED_START_EDGE.encoding().partitionName().get().getBytes(),
                     configuration.fixedStartEdgeCFOptions()
             );
             descriptors[OPTIMISATION_EDGE_HANDLE_INDEX] = new ColumnFamilyDescriptor(
-                    ByteArray.encodeString(OPTIMISATION_EDGE.name(), STRING_ENCODING).getBytes(),
+                    OPTIMISATION_EDGE.encoding().partitionName().get().getBytes(),
                     configuration.optimisationEdgeCFOptions()
             );
             descriptors[STATISTICS_HANDLE_INDEX] = new ColumnFamilyDescriptor(
-                    ByteArray.encodeString(STATISTICS.name(), STRING_ENCODING).getBytes(),
+                    STATISTICS.encoding().partitionName().get().getBytes(),
                     configuration.statisticsCFOptions()
             );
             return Arrays.asList(descriptors);

--- a/database/RocksStorage.java
+++ b/database/RocksStorage.java
@@ -67,7 +67,7 @@ public abstract class RocksStorage implements Storage {
     // TODO: use a single read options when 'setAutoPrefixMode(true)' is available on ReadOptions API
     protected final ReadOptions readOptions;
     protected final ReadOptions readOptionsWithPrefixBloom;
-    protected final RocksPartitionManager partitionMgr;
+    protected final CorePartitionManager partitionMgr;
     protected final Snapshot snapshot;
     protected final ReadWriteLock deleteCloseSchemaWriteLock;
     protected final ConcurrentSet<RocksIterator<?>> iterators;
@@ -79,7 +79,7 @@ public abstract class RocksStorage implements Storage {
     private final WriteOptions writeOptions;
     private final AtomicBoolean isOpen;
 
-    private RocksStorage(OptimisticTransactionDB rocksDB, RocksPartitionManager partitionMgr, boolean isReadOnly) {
+    private RocksStorage(OptimisticTransactionDB rocksDB, CorePartitionManager partitionMgr, boolean isReadOnly) {
         this.isReadOnly = isReadOnly;
         this.partitionMgr = partitionMgr;
         iterators = new ConcurrentSet<>();
@@ -188,7 +188,7 @@ public abstract class RocksStorage implements Storage {
 
     static class Cache extends RocksStorage {
 
-        Cache(OptimisticTransactionDB rocksDB, RocksPartitionManager partitionMgr) {
+        Cache(OptimisticTransactionDB rocksDB, CorePartitionManager partitionMgr) {
             super(rocksDB, partitionMgr, true);
         }
 
@@ -220,7 +220,7 @@ public abstract class RocksStorage implements Storage {
 
         protected final CoreTransaction transaction;
 
-        TransactionBounded(OptimisticTransactionDB rocksDB, RocksPartitionManager partitionMgr, CoreTransaction transaction) {
+        TransactionBounded(OptimisticTransactionDB rocksDB, CorePartitionManager partitionMgr, CoreTransaction transaction) {
             super(rocksDB, partitionMgr, transaction.type().isRead());
             this.transaction = transaction;
         }

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,7 +35,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        commit = "aa549ae3a3337e6b6eba7fc00142ea646faef143", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "035ea2f8b0342ec322e0472afa19be5279557f75", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -62,6 +62,7 @@ public class Encoding {
         STATISTICS((short) 4, ByteArray.encodeString("STATISTICS", STRING_ENCODING));
 
         private final short ID;
+        // TODO: Remove partition name (https://github.com/vaticle/typedb/issues/6526)
         private final ByteArray partitionName;
 
         Partition(short ID, @Nullable ByteArray partitionName) {

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -62,7 +62,7 @@ public class Encoding {
         STATISTICS((short) 4, ByteArray.encodeString("STATISTICS", STRING_ENCODING));
 
         private final short ID;
-        // TODO: Remove partition name (https://github.com/vaticle/typedb/issues/6526)
+        // TODO: Remove partition name (See issue #6526)
         private final ByteArray partitionName;
 
         Partition(short ID, @Nullable ByteArray partitionName) {

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -52,6 +52,14 @@ public class Encoding {
     public static final String ROCKS_SCHEMA = "schema";
     public static final int ENCODING_VERSION = 1;
 
+    public interface Partition {
+        short DEFAULT = 0;
+        short VARIABLE_START_EDGE = 1;
+        short FIXED_START_EDGE = 2;
+        short OPTIMISATION_EDGE = 3;
+        short STATISTICS = 4;
+    }
+
     public enum Key {
         PERSISTED(0, true),
         BUFFERED(-1, false);

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.vaticle.typedb.common.collection.Collections.map;
@@ -44,6 +45,7 @@ import static com.vaticle.typedb.core.common.collection.Bytes.signedByte;
 import static com.vaticle.typedb.core.common.collection.Bytes.unsignedByte;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNRECOGNISED_VALUE;
+import static com.vaticle.typedb.core.graph.common.Encoding.ValueType.STRING_ENCODING;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class Encoding {
@@ -52,12 +54,28 @@ public class Encoding {
     public static final String ROCKS_SCHEMA = "schema";
     public static final int ENCODING_VERSION = 1;
 
-    public interface Partition {
-        short DEFAULT = 0;
-        short VARIABLE_START_EDGE = 1;
-        short FIXED_START_EDGE = 2;
-        short OPTIMISATION_EDGE = 3;
-        short STATISTICS = 4;
+    public enum Partition {
+        DEFAULT((short) 0, null),
+        VARIABLE_START_EDGE((short) 1, ByteArray.encodeString("VARIABLE_START_EDGE", STRING_ENCODING)),
+        FIXED_START_EDGE((short) 2, ByteArray.encodeString("FIXED_START_EDGE", STRING_ENCODING)),
+        OPTIMISATION_EDGE((short) 3, ByteArray.encodeString("OPTIMISATION_EDGE", STRING_ENCODING)),
+        STATISTICS((short) 4, ByteArray.encodeString("STATISTICS", STRING_ENCODING));
+
+        private final short ID;
+        private final ByteArray partitionName;
+
+        Partition(short ID, @Nullable ByteArray partitionName) {
+            this.ID = ID;
+            this.partitionName = partitionName;
+        }
+
+        public short ID() {
+            return ID;
+        }
+
+        public Optional<ByteArray> partitionName() {
+            return Optional.ofNullable(partitionName);
+        }
     }
 
     public enum Key {

--- a/graph/common/Storage.java
+++ b/graph/common/Storage.java
@@ -27,11 +27,15 @@ import com.vaticle.typedb.core.graph.iid.InfixIID;
 import com.vaticle.typedb.core.graph.iid.VertexIID;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 
 import static com.vaticle.typedb.common.util.Objects.className;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNRECOGNISED_VALUE;
+import static com.vaticle.typedb.core.graph.common.Encoding.ValueType.STRING_ENCODING;
 
 public interface Storage {
 
@@ -108,6 +112,15 @@ public interface Storage {
             STATISTICS(null);
 
             private final Integer fixedStartBytes;
+
+            public static Partition fromName(String name) {
+                if (name.equals(DEFAULT.name())) return DEFAULT;
+                else if (name.equals(VARIABLE_START_EDGE.name())) return VARIABLE_START_EDGE;
+                else if (name.equals(FIXED_START_EDGE.name())) return FIXED_START_EDGE;
+                else if (name.equals(OPTIMISATION_EDGE.name())) return OPTIMISATION_EDGE;
+                else if (name.equals(STATISTICS.name())) return STATISTICS;
+                else throw TypeDBException.of(UNRECOGNISED_VALUE);
+            }
 
             Partition(@Nullable Integer fixedStartBytes) {
                 this.fixedStartBytes = fixedStartBytes;

--- a/graph/common/Storage.java
+++ b/graph/common/Storage.java
@@ -27,15 +27,12 @@ import com.vaticle.typedb.core.graph.iid.InfixIID;
 import com.vaticle.typedb.core.graph.iid.VertexIID;
 
 import javax.annotation.Nullable;
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 
 import static com.vaticle.typedb.common.util.Objects.className;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNRECOGNISED_VALUE;
-import static com.vaticle.typedb.core.graph.common.Encoding.ValueType.STRING_ENCODING;
 
 public interface Storage {
 
@@ -105,25 +102,39 @@ public interface Storage {
     interface Key extends Comparable<Key> {
 
         enum Partition {
-            DEFAULT(null),
-            VARIABLE_START_EDGE(null),
-            FIXED_START_EDGE(VertexIID.Thing.DEFAULT_LENGTH + InfixIID.Thing.DEFAULT_LENGTH + VertexIID.Thing.PREFIX_W_TYPE_LENGTH),
-            OPTIMISATION_EDGE(VertexIID.Thing.DEFAULT_LENGTH + InfixIID.Thing.RolePlayer.LENGTH + VertexIID.Thing.PREFIX_W_TYPE_LENGTH),
-            STATISTICS(null);
+            DEFAULT(Encoding.Partition.DEFAULT, null),
+            VARIABLE_START_EDGE(Encoding.Partition.VARIABLE_START_EDGE, null),
+            FIXED_START_EDGE(Encoding.Partition.FIXED_START_EDGE, VertexIID.Thing.DEFAULT_LENGTH + InfixIID.Thing.DEFAULT_LENGTH + VertexIID.Thing.PREFIX_W_TYPE_LENGTH),
+            OPTIMISATION_EDGE(Encoding.Partition.OPTIMISATION_EDGE, VertexIID.Thing.DEFAULT_LENGTH + InfixIID.Thing.RolePlayer.LENGTH + VertexIID.Thing.PREFIX_W_TYPE_LENGTH),
+            STATISTICS(Encoding.Partition.STATISTICS, null);
 
+            private final short ID;
             private final Integer fixedStartBytes;
 
-            public static Partition fromName(String name) {
-                if (name.equals(DEFAULT.name())) return DEFAULT;
-                else if (name.equals(VARIABLE_START_EDGE.name())) return VARIABLE_START_EDGE;
-                else if (name.equals(FIXED_START_EDGE.name())) return FIXED_START_EDGE;
-                else if (name.equals(OPTIMISATION_EDGE.name())) return OPTIMISATION_EDGE;
-                else if (name.equals(STATISTICS.name())) return STATISTICS;
-                else throw TypeDBException.of(UNRECOGNISED_VALUE);
+            public static Partition fromId(short ID) {
+                switch (ID) {
+                    case Encoding.Partition.DEFAULT:
+                        return DEFAULT;
+                    case Encoding.Partition.VARIABLE_START_EDGE:
+                        return VARIABLE_START_EDGE;
+                    case Encoding.Partition.FIXED_START_EDGE:
+                        return FIXED_START_EDGE;
+                    case Encoding.Partition.OPTIMISATION_EDGE:
+                        return OPTIMISATION_EDGE;
+                    case Encoding.Partition.STATISTICS:
+                        return STATISTICS;
+                    default:
+                        throw TypeDBException.of(UNRECOGNISED_VALUE);
+                }
             }
 
-            Partition(@Nullable Integer fixedStartBytes) {
+            Partition(short ID, @Nullable Integer fixedStartBytes) {
+                this.ID = ID;
                 this.fixedStartBytes = fixedStartBytes;
+            }
+
+            public short ID() {
+                return ID;
             }
 
             public Optional<Integer> fixedStartBytes() {

--- a/graph/common/Storage.java
+++ b/graph/common/Storage.java
@@ -108,33 +108,32 @@ public interface Storage {
             OPTIMISATION_EDGE(Encoding.Partition.OPTIMISATION_EDGE, VertexIID.Thing.DEFAULT_LENGTH + InfixIID.Thing.RolePlayer.LENGTH + VertexIID.Thing.PREFIX_W_TYPE_LENGTH),
             STATISTICS(Encoding.Partition.STATISTICS, null);
 
-            private final short ID;
+            private final Encoding.Partition encoding;
             private final Integer fixedStartBytes;
 
-            public static Partition fromId(short ID) {
-                switch (ID) {
-                    case Encoding.Partition.DEFAULT:
-                        return DEFAULT;
-                    case Encoding.Partition.VARIABLE_START_EDGE:
-                        return VARIABLE_START_EDGE;
-                    case Encoding.Partition.FIXED_START_EDGE:
-                        return FIXED_START_EDGE;
-                    case Encoding.Partition.OPTIMISATION_EDGE:
-                        return OPTIMISATION_EDGE;
-                    case Encoding.Partition.STATISTICS:
-                        return STATISTICS;
-                    default:
-                        throw TypeDBException.of(UNRECOGNISED_VALUE);
+            public static Partition fromID(short ID) {
+                if (ID == Encoding.Partition.DEFAULT.ID()) {
+                    return DEFAULT;
+                } else if (ID == Encoding.Partition.VARIABLE_START_EDGE.ID()) {
+                    return VARIABLE_START_EDGE;
+                } else if (ID == Encoding.Partition.FIXED_START_EDGE.ID()) {
+                    return FIXED_START_EDGE;
+                } else if (ID == Encoding.Partition.OPTIMISATION_EDGE.ID()) {
+                    return OPTIMISATION_EDGE;
+                } else if (ID == Encoding.Partition.STATISTICS.ID()) {
+                    return STATISTICS;
+                } else {
+                    throw TypeDBException.of(UNRECOGNISED_VALUE);
                 }
             }
 
-            Partition(short ID, @Nullable Integer fixedStartBytes) {
-                this.ID = ID;
+            Partition(Encoding.Partition encoding, @Nullable Integer fixedStartBytes) {
+                this.encoding = encoding;
                 this.fixedStartBytes = fixedStartBytes;
             }
 
-            public short ID() {
-                return ID;
+            public Encoding.Partition encoding() {
+                return encoding;
             }
 
             public Optional<Integer> fixedStartBytes() {


### PR DESCRIPTION
## What is the goal of this PR?

The partition manager is open for extension from TypeDB Cluster. Additionally, the partitions are declared with the appropriate encodings.

## What are the changes implemented in this PR?

1. Make partition manager class extendable:
    - Relax visibility modifiers of the column family handles, allowing subclasses to override them
    - Rename the class from `RocksPartitionManager` to `CorePartitionManager`
2. Improve the extendability of the database class by adding partition manager factory methods that can be overridden by a subclass.
3. Declare partitions with proper encodings rather than enum names.