### PR TITLE
Data importer can handle an arbitary number of relations

### DIFF
--- a/common/collection/ByteArray.java
+++ b/common/collection/ByteArray.java
@@ -53,7 +53,7 @@ public abstract class ByteArray implements Comparable<ByteArray> {
         this.array = array;
     }
 
-    public static ByteArray.Base of(byte[] array) {
+    public static ByteArray of(byte[] array) {
         return new ByteArray.Base(array);
     }
 
@@ -128,13 +128,13 @@ public abstract class ByteArray implements Comparable<ByteArray> {
         return Base64.getEncoder().encodeToString(getBytes());
     }
 
-    public static ByteArray.Base encodeString(String string, Charset encoding) {
+    public static ByteArray encodeString(String string, Charset encoding) {
         return of(string.getBytes(encoding));
     }
 
     public abstract String decodeString(Charset encoding);
 
-    public static ByteArray.Base encodeUnsignedShort(int num) {
+    public static ByteArray encodeUnsignedShort(int num) {
         byte[] bytes = new byte[SHORT_SIZE];
         bytes[1] = (byte) (num);
         bytes[0] = (byte) (num >> 8);
@@ -155,7 +155,7 @@ public abstract class ByteArray implements Comparable<ByteArray> {
 
     public abstract int decodeInt();
 
-    public static ByteArray.Base encodeUUID(UUID uuid) {
+    public static ByteArray encodeUUID(UUID uuid) {
         ByteBuffer buffer = ByteBuffer.wrap(new byte[16]);
         buffer.putLong(uuid.getMostSignificantBits());
         buffer.putLong(uuid.getLeastSignificantBits());

--- a/concept/thing/Relation.java
+++ b/concept/thing/Relation.java
@@ -19,6 +19,9 @@
 package com.vaticle.typedb.core.concept.thing;
 
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Forwardable;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import com.vaticle.typedb.core.concept.type.RelationType;
 import com.vaticle.typedb.core.concept.type.RoleType;
 
@@ -36,12 +39,18 @@ public interface Relation extends Thing {
 
     void removePlayer(RoleType roleType, Thing player);
 
-    FunctionalIterator<? extends Thing> getPlayers(String roleType, String... roleTypes);
+    FunctionalIterator<Thing> getPlayers();
 
-    FunctionalIterator<? extends Thing> getPlayers(RoleType... roleTypes);
+    FunctionalIterator<Thing> getPlayers(String[] roleTypes);
+
+    FunctionalIterator<Thing> getPlayers(RoleType[] roleTypes);
+
+    Forwardable<Thing, Order.Asc> getPlayers(String roleType, String... roleTypes);
+
+    Forwardable<Thing, Order.Asc> getPlayers(RoleType roleType, RoleType... roleTypes);
 
     // TODO: This method should just return FunctionalIterator<Pair<RoleType, Thing>>
-    Map<? extends RoleType, ? extends List<? extends Thing>> getPlayersByRoleType();
+    Map<? extends RoleType, List<Thing>> getPlayersByRoleType();
 
     FunctionalIterator<? extends RoleType> getRelating();
 }

--- a/concept/thing/Relation.java
+++ b/concept/thing/Relation.java
@@ -38,9 +38,7 @@ public interface Relation extends Thing {
 
     void removePlayer(RoleType roleType, Thing player);
 
-    FunctionalIterator<Thing> getPlayers();
-
-    Forwardable<Thing, Order.Asc> getPlayers(String roleType, String... roleTypes);
+    FunctionalIterator<Thing> getPlayers(String... roleTypes);
 
     Forwardable<Thing, Order.Asc> getPlayers(RoleType roleType, RoleType... roleTypes);
 

--- a/concept/thing/Relation.java
+++ b/concept/thing/Relation.java
@@ -19,7 +19,6 @@
 package com.vaticle.typedb.core.concept.thing;
 
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
-import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Forwardable;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import com.vaticle.typedb.core.concept.type.RelationType;
@@ -40,10 +39,6 @@ public interface Relation extends Thing {
     void removePlayer(RoleType roleType, Thing player);
 
     FunctionalIterator<Thing> getPlayers();
-
-    FunctionalIterator<Thing> getPlayers(String[] roleTypes);
-
-    FunctionalIterator<Thing> getPlayers(RoleType[] roleTypes);
 
     Forwardable<Thing, Order.Asc> getPlayers(String roleType, String... roleTypes);
 

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -110,7 +110,10 @@ public class RelationImpl extends ThingImpl implements Relation {
 
     @Override
     public FunctionalIterator<Thing> getPlayers(String... roleTypes) {
-        return getPlayers(iterate(roleTypes).map(label -> getType().getRelates(label)).map(rt -> rt.vertex));
+        if (roleTypes.length == 0) return readableVertex().outs().edge(ROLEPLAYER).to().map(ThingImpl::of);
+        else {
+            return getPlayers(iterate(roleTypes).map(label -> getType().getRelates(label)).map(rt -> rt.vertex));
+        }
     }
 
     @Override

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -109,16 +109,8 @@ public class RelationImpl extends ThingImpl implements Relation {
     }
 
     @Override
-    public FunctionalIterator<Thing> getPlayers() {
-        return readableVertex().outs().edge(ROLEPLAYER).to().map(ThingImpl::of);
-    }
-
-    @Override
-    public Forwardable<Thing, Order.Asc> getPlayers(String roleType, String... roleTypes) {
-        return getPlayers(
-                getType().getRelates(roleType),
-                iterate(roleTypes).map(label -> getType().getRelates(label)).stream().toArray(RoleType[]::new)
-        );
+    public FunctionalIterator<Thing> getPlayers(String... roleTypes) {
+        return getPlayers(iterate(roleTypes).map(label -> getType().getRelates(label)).map(rt -> rt.vertex));
     }
 
     @Override

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -20,6 +20,8 @@ package com.vaticle.typedb.core.concept.thing.impl;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Forwardable;
+import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import com.vaticle.typedb.core.concept.thing.Relation;
 import com.vaticle.typedb.core.concept.thing.Thing;
 import com.vaticle.typedb.core.concept.type.RoleType;
@@ -39,8 +41,8 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.R
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.RELATION_ROLE_UNRELATED;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.THING_ROLE_UNPLAYED;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
-import static com.vaticle.typedb.core.common.iterator.Iterators.link;
 import static com.vaticle.typedb.core.common.iterator.Iterators.single;
+import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Thing.Base.PLAYING;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Thing.Base.RELATING;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Thing.Optimised.ROLEPLAYER;
@@ -107,29 +109,48 @@ public class RelationImpl extends ThingImpl implements Relation {
     }
 
     @Override
-    public FunctionalIterator<ThingImpl> getPlayers(String roleType, String... roleTypes) {
-        return getPlayers(link(single(roleType), iterate(roleTypes))
-                                  .map(label -> getType().getRelates(label))
-                                  .stream().toArray(RoleType[]::new));
+    public FunctionalIterator<Thing> getPlayers() {
+        return readableVertex().outs().edge(ROLEPLAYER).to().map(ThingImpl::of);
     }
 
     @Override
-    public FunctionalIterator<ThingImpl> getPlayers(RoleType... roleTypes) {
-        if (roleTypes.length == 0) {
-            return readableVertex().outs().edge(ROLEPLAYER).to().map(ThingImpl::of);
+    public FunctionalIterator<Thing> getPlayers(String[] roleTypes) {
+        if (roleTypes.length == 0) return getPlayers();
+        else return getPlayers(iterate(roleTypes).map(label -> getType().getRelates(label).vertex));
+    }
+
+    @Override
+    public FunctionalIterator<Thing> getPlayers(RoleType[] roleTypes) {
+        if (roleTypes.length == 0) return getPlayers();
+        else {
+            return getPlayers(iterate(roleTypes).flatMap(RoleType::getSubtypes).distinct().map(rt -> ((RoleTypeImpl) rt).vertex));
         }
-        return getPlayers(iterate(roleTypes).flatMap(RoleType::getSubtypes).distinct().map(rt -> ((RoleTypeImpl) rt).vertex));
-    }
-
-    private FunctionalIterator<ThingImpl> getPlayers(FunctionalIterator<TypeVertex> roleTypeVertices) {
-        return roleTypeVertices.flatMap(v -> readableVertex().outs().edge(ROLEPLAYER, v).to()).map(ThingImpl::of);
     }
 
     @Override
-    public Map<RoleTypeImpl, ? extends List<ThingImpl>> getPlayersByRoleType() {
-        Map<RoleTypeImpl, List<ThingImpl>> playersByRole = new HashMap<>();
+    public Forwardable<Thing, Order.Asc> getPlayers(String roleType, String... roleTypes) {
+        return getPlayers(
+                getType().getRelates(roleType),
+                iterate(roleTypes).map(label -> getType().getRelates(label)).stream().toArray(RoleType[]::new)
+        );
+    }
+
+    @Override
+    public Forwardable<Thing, Order.Asc> getPlayers(RoleType roleType, RoleType... roleTypes) {
+        return getPlayers(single(roleType).link(iterate(roleTypes)).flatMap(RoleType::getSubtypes).distinct().map(rt -> ((RoleTypeImpl) rt).vertex));
+    }
+
+    private Forwardable<Thing, Order.Asc> getPlayers(FunctionalIterator<TypeVertex> roleTypeVertices) {
+        assert roleTypeVertices.hasNext();
+        return roleTypeVertices.mergeMap(v -> readableVertex().outs().edge(ROLEPLAYER, v).to(), ASC)
+                .mapSorted(ThingImpl::of, thing -> ((ThingImpl) thing).readableVertex(), ASC);
+    }
+
+    @Override
+    public Map<RoleTypeImpl, List<Thing>> getPlayersByRoleType() {
+        Map<RoleTypeImpl, List<Thing>> playersByRole = new HashMap<>();
         getType().getRelates().forEachRemaining(rt -> {
-            List<ThingImpl> players = getPlayers(rt).toList();
+            List<Thing> players = getPlayers(rt).toList();
             if (!players.isEmpty()) playersByRole.put(rt, players);
         });
         return playersByRole;

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -114,20 +114,6 @@ public class RelationImpl extends ThingImpl implements Relation {
     }
 
     @Override
-    public FunctionalIterator<Thing> getPlayers(String[] roleTypes) {
-        if (roleTypes.length == 0) return getPlayers();
-        else return getPlayers(iterate(roleTypes).map(label -> getType().getRelates(label).vertex));
-    }
-
-    @Override
-    public FunctionalIterator<Thing> getPlayers(RoleType[] roleTypes) {
-        if (roleTypes.length == 0) return getPlayers();
-        else {
-            return getPlayers(iterate(roleTypes).flatMap(RoleType::getSubtypes).distinct().map(rt -> ((RoleTypeImpl) rt).vertex));
-        }
-    }
-
-    @Override
     public Forwardable<Thing, Order.Asc> getPlayers(String roleType, String... roleTypes) {
         return getPlayers(
                 getType().getRelates(roleType),

--- a/migrator/data/DataImporter.java
+++ b/migrator/data/DataImporter.java
@@ -245,7 +245,7 @@ public class DataImporter {
             transaction.commit();
             transaction.committedIIDs().forEachRemaining(pair -> {
                 String originalID = bufferedToOriginalIDs.get(pair.first());
-                conceptTracker.recordMapping(originalID, pair.second());
+                conceptTracker.recordMapped(originalID, pair.second());
                 if (incompleteIDs.contains(originalID)) conceptTracker.recordIncomplete(originalID);
             });
             bufferedToOriginalIDs.clear();
@@ -260,7 +260,7 @@ public class DataImporter {
         }
 
         protected void recordAttributeIDMapping(ByteArray IID, String originalID) {
-            conceptTracker.recordMapping(originalID, IID);
+            conceptTracker.recordMapped(originalID, IID);
         }
 
         void recordIncompleteID(String originalID) {
@@ -497,7 +497,7 @@ public class DataImporter {
                     if (relation != null) continue;
                     relation = transaction.concepts().getRelationType(item.getRelation().getLabel()).create();
                     status.relationCount.incrementAndGet();
-                    conceptTracker.recordMapping(item.getRelation().getId(), relation.getIID());
+                    conceptTracker.recordMapped(item.getRelation().getId(), relation.getIID());
                     conceptTracker.recordIncomplete(item.getRelation().getId());
                     for (DataProto.Item.OwnedAttribute ownership : item.getRelation().getAttributeList()) {
                         Thing attribute = transaction.concepts().getThing(conceptTracker.getMapped(ownership.getId()));
@@ -578,7 +578,7 @@ public class DataImporter {
             }
         }
 
-        public void recordMapping(String originalID, ByteArray newID) {
+        private void recordMapped(String originalID, ByteArray newID) {
             ByteArray originalIDEncoded = encodeOriginalID(originalID);
             ByteArray mappingKey = ByteArray.join(Prefix.ID_MAPPING.bytes, originalIDEncoded);
             try {
@@ -604,7 +604,7 @@ public class DataImporter {
             return getMapped(originalID) != null;
         }
 
-        public void recordIncomplete(String originalID) {
+        private void recordIncomplete(String originalID) {
             ByteArray key = ByteArray.join(Prefix.ID_INCOMPLETE.bytes, encodeOriginalID(originalID));
             try {
                 storage.put(key.getBytes(), new byte[0]);
@@ -630,7 +630,7 @@ public class DataImporter {
             return hasIncomplete;
         }
 
-        public void deleteIncomplete(String originalID) {
+        private void deleteIncomplete(String originalID) {
             ByteArray key = ByteArray.join(Prefix.ID_INCOMPLETE.bytes, encodeOriginalID(originalID));
             try {
                 storage.delete(key.getBytes());

--- a/migrator/data/DataImporter.java
+++ b/migrator/data/DataImporter.java
@@ -99,7 +99,7 @@ public class DataImporter {
         this.version = version;
         assert com.vaticle.typedb.core.concurrent.executor.Executors.isInitialised();
         this.parallelisation = com.vaticle.typedb.core.concurrent.executor.Executors.PARALLELISATION_FACTOR;
-        this.importExecutor = Executors.newFixedThreadPool(parallelisation);
+        this.importExecutor = Executors.newFixedThreadPool(parallelisation * 2);
         this.readerExecutor = Executors.newSingleThreadExecutor();
         this.conceptTracker = new ConceptTracker(database);
         this.skippedRelations = new AtomicBoolean(false);
@@ -685,13 +685,13 @@ public class DataImporter {
             this.roles = roles;
         }
 
-        public boolean verify(Status status) {
+        boolean verify(Status status) {
             return attributes == status.attributeCount.get() && entities == status.entityCount.get() &&
                     relations == status.relationCount.get() && ownerships == status.ownershipCount.get() &&
                     roles == status.roleCount.get();
         }
 
-        public String mismatch(Status status) {
+        String mismatch(Status status) {
             assert !verify(status);
             String mismatch = "";
             if (attributes != status.attributeCount.get()) {

--- a/server/concept/ThingService.java
+++ b/server/concept/ThingService.java
@@ -35,6 +35,7 @@ import com.vaticle.typedb.protocol.ConceptProto;
 import com.vaticle.typedb.protocol.TransactionProto.Transaction;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -180,7 +181,9 @@ public class ThingService {
 
     private void getPlayers(Relation relation, List<ConceptProto.Type> protoRoleTypes, UUID reqID) {
         RoleType[] roleTypes = protoRoleTypes.stream().map(type -> notNull(getRoleType(type))).toArray(RoleType[]::new);
-        FunctionalIterator<? extends Thing> players = relation.getPlayers(roleTypes);
+        FunctionalIterator<? extends Thing> players = roleTypes.length == 0 ?
+                relation.getPlayers() :
+                relation.getPlayers(roleTypes[0], Arrays.copyOfRange(roleTypes, 1, roleTypes.length));
         transactionSvc.stream(players, reqID, things -> getPlayersResPart(reqID, things));
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We make the built in TypeDB Importer (`typedb server import`) scale for a large number of relations by removing in-memory data structures used to track imported concepts. Instead, the data is persisted into the preexisting temporary RocksDB instance, ensuring the import will scale to a huge number of concepts to import. 

## What are the changes implemented in this PR?

* Fix import/export logging verbosity (!netty!)
* Fix import/export error propagation to the client side, which allows the user to see a useful error when the import fails for any reason
* No longer use in-memory data structures during relation import to track partial relations. Instead, we rely on the temporary RocksDB instance to mark partial relations. We then iteratively load the partial relations until they are completed.
* Introduce a very small encoding scheme used in the temporary rocksdb storage to be able to store completeness information along with ID mappings