### PR TITLE
Replace partition name with partition ID

### DIFF
--- a/database/CorePartitionManager.java
+++ b/database/CorePartitionManager.java
@@ -125,19 +125,19 @@ public abstract class CorePartitionManager {
                     configuration.defaultCFOptions()
             );
             descriptors[VARIABLE_START_EDGE_HANDLE_INDEX] = new ColumnFamilyDescriptor(
-                    VARIABLE_START_EDGE.encoding().partitionName().get().getBytes(),
+                    new byte[]{VARIABLE_START_EDGE.encoding().ID()},
                     configuration.variableStartEdgeCFOptions()
             );
             descriptors[FIXED_START_EDGE_HANDLE_INDEX] = new ColumnFamilyDescriptor(
-                    FIXED_START_EDGE.encoding().partitionName().get().getBytes(),
+                    new byte[]{FIXED_START_EDGE.encoding().ID()},
                     configuration.fixedStartEdgeCFOptions()
             );
             descriptors[OPTIMISATION_EDGE_HANDLE_INDEX] = new ColumnFamilyDescriptor(
-                    OPTIMISATION_EDGE.encoding().partitionName().get().getBytes(),
+                    new byte[]{OPTIMISATION_EDGE.encoding().ID()},
                     configuration.optimisationEdgeCFOptions()
             );
             descriptors[METADATA_HANDLE_INDEX] = new ColumnFamilyDescriptor(
-                    METADATA.encoding().partitionName().get().getBytes(),
+                    new byte[]{METADATA.encoding().ID()},
                     configuration.metadataCFOptions()
             );
             return Arrays.asList(descriptors);

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -20,6 +20,7 @@ package com.vaticle.typedb.core.graph.common;
 
 import com.vaticle.typedb.common.collection.Pair;
 import com.vaticle.typedb.core.common.collection.ByteArray;
+import com.vaticle.typedb.core.common.collection.Bytes;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typeql.lang.common.TypeQLArg;
@@ -55,27 +56,20 @@ public class Encoding {
     public static final int ENCODING_VERSION = 2;
 
     public enum Partition {
-        DEFAULT((short) 0, null),
-        VARIABLE_START_EDGE((short) 1, ByteArray.encodeString("VARIABLE_START_EDGE", STRING_ENCODING)),
-        FIXED_START_EDGE((short) 2, ByteArray.encodeString("FIXED_START_EDGE", STRING_ENCODING)),
-        OPTIMISATION_EDGE((short) 3, ByteArray.encodeString("OPTIMISATION_EDGE", STRING_ENCODING)),
-        METADATA((short) 4, ByteArray.encodeString("METADATA", STRING_ENCODING));
+        DEFAULT(0),
+        VARIABLE_START_EDGE(1),
+        FIXED_START_EDGE(2),
+        OPTIMISATION_EDGE(3),
+        METADATA(4);
 
-        private final short ID;
-        // TODO: Remove partition name (See issue #6526)
-        private final ByteArray partitionName;
+        private final byte ID;
 
-        Partition(short ID, @Nullable ByteArray partitionName) {
-            this.ID = ID;
-            this.partitionName = partitionName;
+        Partition(int ID) {
+            this.ID = Bytes.unsignedByte(ID);
         }
 
-        public short ID() {
+        public byte ID() {
             return ID;
-        }
-
-        public Optional<ByteArray> partitionName() {
-            return Optional.ofNullable(partitionName);
         }
     }
 

--- a/graph/common/Storage.java
+++ b/graph/common/Storage.java
@@ -110,7 +110,7 @@ public interface Storage {
             private final Encoding.Partition encoding;
             private final Integer fixedStartBytes;
 
-            public static Partition fromID(short ID) {
+            public static Partition fromID(byte ID) {
                 if (ID == Encoding.Partition.DEFAULT.ID()) {
                     return DEFAULT;
                 } else if (ID == Encoding.Partition.VARIABLE_START_EDGE.ID()) {


### PR DESCRIPTION
## What is the goal of this PR?

Introduce a canonical identifier for each Partition (RocksDB Column Families), replacing the separate IDs used by Cluster (a `short`) and Core (a `string`). 

Implements #6526.

## What are the changes implemented in this PR?

* Introduce a `byte` partition/colum family identifier, which replaces both previous identifiers of String and short type. This ID will be used in both Core and Cluster