### PR TITLE
Client transactions are closable when executing queries

### DIFF
--- a/server/TransactionService.java
+++ b/server/TransactionService.java
@@ -284,7 +284,7 @@ public class TransactionService implements StreamObserver<TransactionProto.Trans
     }
 
     @Override
-    public synchronized void close() {
+    public void close() {
         if (isRPCAlive.compareAndSet(true, false)) {
             if (isTransactionOpen.compareAndSet(true, false)) {
                 transaction.close();
@@ -295,7 +295,7 @@ public class TransactionService implements StreamObserver<TransactionProto.Trans
         }
     }
 
-    public synchronized void close(Throwable error) {
+    public void close(Throwable error) {
         if (isRPCAlive.compareAndSet(true, false)) {
             if (isTransactionOpen.compareAndSet(true, false)) {
                 transaction.close();


### PR DESCRIPTION
## What is the goal of this PR?

We allow transactions initiated by external RPC clients to be closed immediately, without waiting for the current query to finish running. This also allows server shutdown to proceed without blocking on running queries. Previously, a query that was taking too long could not be terminated at all: not by closing the trasaction from the client-side nor by shutting down the server!

## What are the changes implemented in this PR?

* Do not synchronize `TransactionService.close()` against `TransactionService.execute()`
  * This was preventing the server shutdown (since we first close all open transactions, before stopping the server). 
  * It was also preventing the clients from killing server transactions by closing sessions or transactions on the client side