### PR TITLE
Remove partial support for write transaction inference

### DIFF
--- a/graph/ThingGraph.java
+++ b/graph/ThingGraph.java
@@ -309,7 +309,7 @@ public class ThingGraph {
                     return v;
                 }
         );
-        if (!isInferred && vertex.isInferred()) vertex.isInferred(false);
+        assert isInferred == vertex.isInferred();
         return vertex;
     }
 
@@ -327,7 +327,7 @@ public class ThingGraph {
                     return v;
                 }
         );
-        if (!isInferred && vertex.isInferred()) vertex.isInferred(false);
+        assert isInferred == vertex.isInferred();
         return vertex;
     }
 
@@ -345,7 +345,7 @@ public class ThingGraph {
                     return v;
                 }
         );
-        if (!isInferred && vertex.isInferred()) vertex.isInferred(false);
+        assert isInferred == vertex.isInferred();
         return vertex;
     }
 
@@ -374,7 +374,7 @@ public class ThingGraph {
                     return v;
                 }
         );
-        if (!isInferred && vertex.isInferred()) vertex.isInferred(false);
+        assert isInferred == vertex.isInferred();
         return vertex;
     }
 
@@ -392,7 +392,7 @@ public class ThingGraph {
                     return v;
                 }
         );
-        if (!isInferred && vertex.isInferred()) vertex.isInferred(false);
+        assert isInferred == vertex.isInferred();
         return vertex;
     }
 

--- a/graph/adjacency/impl/ThingAdjacencyImpl.java
+++ b/graph/adjacency/impl/ThingAdjacencyImpl.java
@@ -304,10 +304,10 @@ public abstract class ThingAdjacencyImpl<EDGE_VIEW extends ThingEdge.View<EDGE_V
                     if (existingEdge == null) {
                         if (isOut()) owner.graph().edgeCreated(edge); // only record creation in one direction
                         return edge;
-                    } else if (existingEdge.isInferred() && !edge.isInferred()) {
-                        existingEdge.isInferred(true);
+                    } else {
+                        assert existingEdge.isInferred() == edge.isInferred();
+                        return existingEdge;
                     }
-                    return existingEdge;
                 });
                 return bufferedEdges;
             });

--- a/graph/edge/ThingEdge.java
+++ b/graph/edge/ThingEdge.java
@@ -40,8 +40,6 @@ public interface ThingEdge extends Edge<Encoding.Edge.Thing, ThingVertex> {
 
     Optional<ThingVertex> optimised();
 
-    void isInferred(boolean isInferred);
-
     boolean isInferred();
 
     View.Forward forwardView();

--- a/graph/edge/impl/ThingEdgeImpl.java
+++ b/graph/edge/impl/ThingEdgeImpl.java
@@ -48,7 +48,7 @@ public abstract class ThingEdgeImpl implements ThingEdge {
     final View.Forward forward;
     final View.Backward backward;
     final AtomicBoolean deleted;
-    boolean isInferred;
+    final boolean isInferred;
 
     ThingEdgeImpl(ThingGraph graph, Encoding.Edge.Thing encoding, boolean isInferred) {
         this.graph = graph;
@@ -235,11 +235,6 @@ public abstract class ThingEdgeImpl implements ThingEdge {
             }
         }
 
-        @Override
-        public void isInferred(boolean isInferred) {
-            this.isInferred = isInferred;
-        }
-
         /**
          * Deletes this {@code Edge} from connecting between two {@code Vertex}.
          *
@@ -385,11 +380,6 @@ public abstract class ThingEdgeImpl implements ThingEdge {
         }
 
         @Override
-        public void isInferred(boolean isInferred) {
-            throw TypeDBException.of(ILLEGAL_OPERATION);
-        }
-
-        @Override
         public final boolean equals(Object object) {
             if (this == object) return true;
             if (object == null || getClass() != object.getClass()) return false;
@@ -502,11 +492,6 @@ public abstract class ThingEdgeImpl implements ThingEdge {
             } else {
                 return EdgeViewIID.Thing.of(toIID(), InfixIID.Thing.of(encoding().backward()), fromIID());
             }
-        }
-
-        @Override
-        public void isInferred(boolean isInferred) {
-            throw TypeDBException.of(ILLEGAL_OPERATION);
         }
 
         /**

--- a/graph/vertex/ThingVertex.java
+++ b/graph/vertex/ThingVertex.java
@@ -112,13 +112,6 @@ public interface ThingVertex extends Vertex<VertexIID.Thing, Encoding.Vertex.Thi
 
         void commit();
 
-        /**
-         * Sets a boolean flag to indicate whether this vertex was a result of inference.
-         *
-         * @param isInferred indicating whether this vertex was a result of inference
-         */
-        void isInferred(boolean isInferred);
-
         @Override
         AttributeVertex.Write<?> asAttribute();
 

--- a/graph/vertex/impl/AttributeVertexImpl.java
+++ b/graph/vertex/impl/AttributeVertexImpl.java
@@ -256,7 +256,7 @@ public abstract class AttributeVertexImpl {
     public static abstract class Write<VALUE> extends ThingVertexImpl.Write implements AttributeVertex.Write<VALUE> {
 
         private final VertexIID.Attribute<VALUE> attributeIID;
-        private boolean isInferred;
+        private final boolean isInferred;
         private java.lang.Boolean isPersisted;
 
         private Write(ThingGraph graph, VertexIID.Attribute<VALUE> iid, boolean isInferred) {
@@ -322,11 +322,6 @@ public abstract class AttributeVertexImpl {
                 // TODO: implement for ValueType.TEXT
                 return null;
             }
-        }
-
-        @Override
-        public void isInferred(boolean isInferred) {
-            this.isInferred = isInferred;
         }
 
         @Override

--- a/graph/vertex/impl/ThingVertexImpl.java
+++ b/graph/vertex/impl/ThingVertexImpl.java
@@ -189,11 +189,6 @@ public abstract class ThingVertexImpl extends VertexImpl<VertexIID.Thing> implem
             return ins;
         }
 
-        @Override
-        public void isInferred(boolean isInferred) {
-            throw TypeDBException.of(ILLEGAL_OPERATION);
-        }
-
         public boolean isModified() {
             return isModified;
         }
@@ -246,7 +241,7 @@ public abstract class ThingVertexImpl extends VertexImpl<VertexIID.Thing> implem
 
         public static class Buffered extends ThingVertexImpl.Write {
 
-            protected boolean isInferred;
+            private final boolean isInferred;
 
             public Buffered(ThingGraph graph, VertexIID.Thing iid, boolean isInferred) {
                 super(graph, iid);
@@ -267,11 +262,6 @@ public abstract class ThingVertexImpl extends VertexImpl<VertexIID.Thing> implem
             @Override
             public Encoding.Status status() {
                 return Encoding.Status.BUFFERED;
-            }
-
-            @Override
-            public void isInferred(boolean isInferred) {
-                this.isInferred = isInferred;
             }
 
             @Override


### PR DESCRIPTION
## What is the goal of this PR?

Simplify and remove internal APIs that were designed to support reasoning in write transactions. Reasoning in write transaction is not going to be supported for the foreseeable future, so continuing to support this logic incurs minor but avoidable overheads.

## What are the changes implemented in this PR?

* Remove setters for `isInferred` for both `ThingEdge` and `ThingVertex`
* Remove users of these setters, which were trying to implement "upgrading" an inferred vertex or edge to a user-inserted one in the middle of a write transaction