### PR TITLE
Fix session idle timeouts to not occur after session close

### DIFF
--- a/server/SessionService.java
+++ b/server/SessionService.java
@@ -100,7 +100,7 @@ public class SessionService implements AutoCloseable {
     }
 
     private void mayStartIdleTimeout() {
-        if (transactionServices.isEmpty()) {
+        if (isOpen() && transactionServices.isEmpty()) {
             idleTimeoutTask = scheduled().schedule(this::idleTimeout, options.sessionIdleTimeoutMillis(), MILLISECONDS);
         }
     }

--- a/server/TypeDBServer.java
+++ b/server/TypeDBServer.java
@@ -270,10 +270,10 @@ public class TypeDBServer implements AutoCloseable {
         TypeDBServer server = new TypeDBServer(subcmdServer.config(), subcmdServer.isDebug());
         server.start();
         Instant end = Instant.now();
-        server.logger().info("- version: {}", Version.VERSION);
-        server.logger().info("- listening to address: {}:{}", server.address().getHostString(), server.address().getPort());
-        server.logger().info("- data directory configured to: {}", server.dataDir());
-        server.logger().info("- bootup completed in: {} ms", Duration.between(start, end).toMillis());
+        server.logger().info("version: {}", Version.VERSION);
+        server.logger().info("listening to address: {}:{}", server.address().getHostString(), server.address().getPort());
+        server.logger().info("data directory configured to: {}", server.dataDir());
+        server.logger().info("bootup completed in: {} ms", Duration.between(start, end).toMillis());
         server.logger().info("...");
         server.serve();
     }


### PR DESCRIPTION
## What is the goal of this PR?

We fix a bug which allowed session idle timeouts to occur after the session is closed, resulting in misleading logging.

## What are the changes implemented in this PR?

* Session idle timeouts used to be mistakenly scheduled after the session was closed. This happened because while closing a session, we close open transactions. Closing a transaction causes the session idle timeout to begin! So, closing the session re-schedules the session idle timeout to start, which should not happen at all.
* Change formatting of server bootup information logging