### PR TITLE
Clone repository prior to executing 'Bazel install' in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,14 +65,16 @@ jobs:
 workflows:
   typedb:
     jobs:
-      - test-assembly-mac-zip:
-          filters:
-            branches:
-              only:
-                - master
-      - test-assembly-windows-zip:
-          filters:
-            branches:
-              only:
-                - master
+      - test-assembly-mac-zip
+      - test-assembly-windows-zip
+      # - test-assembly-mac-zip:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      # - test-assembly-windows-zip:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,16 +65,14 @@ jobs:
 workflows:
   typedb:
     jobs:
-      - test-assembly-mac-zip
-      - test-assembly-windows-zip
-      # - test-assembly-mac-zip:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      # - test-assembly-windows-zip:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
+      - test-assembly-mac-zip:
+          filters:
+            branches:
+              only:
+                - master
+      - test-assembly-windows-zip:
+          filters:
+            branches:
+              only:
+                - master
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ jobs:
       xcode: "12.4.0"
     working_directory: ~/typedb
     steps:
-      - install-bazel-mac
       - checkout
+      - install-bazel-mac
       - run-bazel:
           command: bazel test //test/assembly:assembly --test_output=errors
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "465e60776ca3055ce85d90e94624d37db3f7e790", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/lolski/dependencies",
+        commit = "41830d6c234030eb614fed37d90fd91d1c2d8fe6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql_lang_java():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/lolski/dependencies",
-        commit = "41830d6c234030eb614fed37d90fd91d1c2d8fe6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "465e60776ca3055ce85d90e94624d37db3f7e790", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql_lang_java():


### PR DESCRIPTION
## What is the goal of this PR?

The test assembly (Mac) CircleCI job clones the repository prior to executing the 'Bazel install script' (since the `.bazelversion` file must be present when the script is executed).

## What are the changes implemented in this PR?

1. Update `test-assembly-mac`: Run the `checkout` step prior to `install-bazel-mac`