### PR TITLE
Update @vaticle_dependencies to include RocksDB 6.26.1

### DIFF
--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -151,9 +151,9 @@
 @maven//:org_objenesis_objenesis
 @maven//:org_objenesis_objenesis_2_5
 @maven//:org_rocksdb_rocksdbjni
-@maven//:org_rocksdb_rocksdbjni_6_20_3
+@maven//:org_rocksdb_rocksdbjni_6_26_1
 @maven//:org_rocksdb_rocksdbjni_dev_mac
-@maven//:org_rocksdb_rocksdbjni_dev_mac_6_20_3
+@maven//:org_rocksdb_rocksdbjni_dev_mac_6_26_1
 @maven//:org_slf4j_slf4j_api
 @maven//:org_slf4j_slf4j_api_1_7_32
 @maven//:org_yaml_snakeyaml

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "465e60776ca3055ce85d90e94624d37db3f7e790", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "5ad52b762cb178339bcdcf26bd1db7afa503a777", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql_lang_java():


### PR DESCRIPTION
## What is the goal of this PR?

TypeDB uses RocksDB 6.26.1. The upgrade was made possible due to the new mechanism used by statistics corrector.

## What are the changes implemented in this PR?

- Upgrade `@vaticle_dependencies` to the newest version which has an upgraded RocksDB 6.26.1