### PR TITLE
Synchronize session timeout setter

### DIFF
--- a/server/SessionService.java
+++ b/server/SessionService.java
@@ -99,7 +99,7 @@ public class SessionService implements AutoCloseable {
         idleTimeoutTask.cancel(false);
     }
 
-    private void mayStartIdleTimeout() {
+    private synchronized void mayStartIdleTimeout() {
         if (isOpen() && transactionServices.isEmpty()) {
             idleTimeoutTask = scheduled().schedule(this::idleTimeout, options.sessionIdleTimeoutMillis(), MILLISECONDS);
         }


### PR DESCRIPTION
## What is the goal of this PR?

TypeDB randomly shuts down sessions due to session timeouts, even under incorrect conditions. Via empirical testing this problem appears to be caused by a race condition between the setters/resetters of the idle timeout, which we make safer by synchronizing the starting of the idle timeout.

## What are the changes implemented in this PR?

* `synchronize` the idle timeout starting method which (empirically in tests) appears to prevent session timeouts from occuring.

Note: if the issue still occurs, we should consider changing the mechanism completely to something less error-prone.