### PR TITLE
Update reasoner soundness tests to correctly check cyclic explanations

### DIFF
--- a/test/behaviour/reasoner/verification/SoundnessVerifier.java
+++ b/test/behaviour/reasoner/verification/SoundnessVerifier.java
@@ -93,11 +93,9 @@ class SoundnessVerifier {
     }
 
     private boolean canExplanationBeVerified(Explanation explanation) {
-        boolean possible = true;
-        for (Concept c : explanation.conditionAnswer().concepts().values()) {
-            possible = possible && (!c.asThing().isInferred() || inferredConceptMapping.containsKey(c));
-        }
-        return possible;
+        return iterate(explanation.conditionAnswer().concepts().values())
+                .filter(c -> c.asThing().isInferred() && !inferredConceptMapping.containsKey(c))
+                .first().isEmpty();
     }
 
     private void verifyAnswerAndCollectExplanations(ConceptMap answer, Transaction tx) {


### PR DESCRIPTION
## Abandon
(I need to use the work-around through James' repo till I get grabl)

## What is the goal of this PR?
Behaviour tests for the soundness of the reasoner fail when they involve cyclic explanations. This was due to the incorrect mapping of inferred concepts between the reasoner's transaction and the oracle's transaction.

## What are the changes implemented in this PR?

The SoundnessVerifier can only correctly map an inferred concept 'C' when it processes an explanation where
1. All the concepts in the condition of the rule are mapped
2. C occurs in the conclusion of the rule3. 

This repeatedly processes the explanation set, processing only explanations which satisfy the above condition. 
Each iteration verifies some explanations, enabling others to be verified in the following iteration, until all explanations have been processed. If progress is not made, an exception is thrown.   
