### PR TITLE
Improve incompatible data version error message

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -154,8 +154,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
 
     public static class Database extends ErrorMessage {
         public static final Database INCOMPATIBLE_ENCODING =
-                new Database(1, "Database '%s' has incompatible data version '%d' - this server supports " +
-                        "version '%d'. (Did you copy a database across incompatible server versions?)");
+                new Database(1, "Database '%s' (located at: %s) has incompatible data version '%d' - this server supports " +
+                        "version '%d'. Please reload or migrate your data.");
         public static final Database DATABASE_MANAGER_CLOSED =
                 new Database(2, "Attempted to use database manager when it has been closed.");
         public static final Database DATABASE_EXISTS =

--- a/database/CoreDatabase.java
+++ b/database/CoreDatabase.java
@@ -291,7 +291,7 @@ public class CoreDatabase implements TypeDB.Database {
             );
             int encoding = encodingBytes == null || encodingBytes.length == 0 ? 0 : ByteArray.of(encodingBytes).decodeInt();
             if (encoding != ENCODING_VERSION) {
-                throw TypeDBException.of(INCOMPATIBLE_ENCODING, name(), encoding, ENCODING_VERSION);
+                throw TypeDBException.of(INCOMPATIBLE_ENCODING,  name(), directory().toAbsolutePath(), encoding, ENCODING_VERSION);
             }
         } catch (RocksDBException e) {
             throw TypeDBException.of(e);

--- a/test/integration/database/DatabaseTest.java
+++ b/test/integration/database/DatabaseTest.java
@@ -54,7 +54,7 @@ public class DatabaseTest {
                 .storageIndexCacheSize(MB).storageDataCacheSize(MB);
         assertThrowsWithMessage(
                 () -> factory.databaseManager(options),
-                INCOMPATIBLE_ENCODING.message("test", 0, Encoding.ENCODING_VERSION)
+                INCOMPATIBLE_ENCODING.message("test", dataDir.resolve("test").toAbsolutePath(), 0, Encoding.ENCODING_VERSION)
         );
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

We improve the error message reported when booting a server with an incompatible data version. This was outlined in #6568.

## What are the changes implemented in this PR?

* Include the database data directory path in the error message
* Improve the wording of the error message to ask the user to migrate data.