### PR TITLE
Fix intermittent incomplete type matches

### DIFF
--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -362,7 +362,7 @@ public abstract class ProcedureEdge<
                     if (to.props().hasIID()) {
                         return to.iterateAndFilterFromIID(graphMgr, params).filter(vertex -> isaTypes.contains(vertex.type()));
                     } else {
-                        FunctionalIterator<TypeVertex> toTypes = iterate(isaTypes).filter(v -> to.props().types().contains(type.properLabel()));
+                        FunctionalIterator<TypeVertex> toTypes = iterate(isaTypes).filter(v -> to.props().types().contains(v.properLabel()));
                         if (!toTypes.hasNext()) return emptySorted();
                         else return to.iterateAndFilterFromTypes(graphMgr, params, toTypes);
                     }


### PR DESCRIPTION
## What is the goal of this PR?

Fix a bug that caused an `isa` query where the type is a variable to occasionally match fewer types than expected.

## What are the changes implemented in this PR?

A typo in ProcedureEdge caused the traversal to only consider direct types of a thing when traversing the `isa` edge when coming from the type. It appears that this is a rarely chosen direction of an `isa` edge in the planning (and, therefore, in the behaviour test suite), so an explicit test is added.
