### PR TITLE
Allow edges with multiple adjacency in a procedure

### DIFF
--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -81,13 +81,11 @@ public abstract class ProcedureEdge<
 
     private final int order;
     private final Encoding.Direction.Edge direction;
-    private final int hash;
 
     private ProcedureEdge(VERTEX_FROM from, VERTEX_TO to, int order, Encoding.Direction.Edge direction, String symbol) {
         super(from, to, symbol);
         this.order = order;
         this.direction = direction;
-        this.hash = Objects.hash(from(), to(), order, direction);
     }
 
     public static ProcedureEdge<?, ?> of(ProcedureVertex<?, ?> from, ProcedureVertex<?, ?> to,
@@ -155,19 +153,6 @@ public abstract class ProcedureEdge<
 
     public Native.Thing.RolePlayer asRolePlayer() {
         throw TypeDBException.of(ILLEGAL_CAST, className(getClass()), className(Native.Thing.RolePlayer.class));
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ProcedureEdge<?, ?> that = (ProcedureEdge<?, ?>) o;
-        return from().equals(that.from()) && to().equals(that.to()) && direction == that.direction;
-    }
-
-    @Override
-    public int hashCode() {
-        return hash;
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

Fix a bug that caused a match query to ignore multiple connections of the same kind (e.g. `($x, $x) isa relation`).

## What are the changes implemented in this PR?

We rely on the built-in hash & equality comparison. This can be optimised in the future, but the existing shortcuts simply don't cut it. The issue is difficult to reproduce, so it's not codified in a test.