### PR TITLE
Update query planner to allow multiple starting points

### DIFF
--- a/common/optimiser/Optimiser.java
+++ b/common/optimiser/Optimiser.java
@@ -58,7 +58,7 @@ public class Optimiser {
 
     public synchronized Status optimise(long timeLimitMillis) {
         if (hasSolver && constraintsChanged()) {
-            constraints.forEach(constraint -> constraint.initialise(solver));
+            constraints.forEach(OptimiserConstraint::updateCoefficients);
             status = Status.NOT_SOLVED;
         }
         if (isOptimal()) return status;
@@ -88,7 +88,7 @@ public class Optimiser {
     }
 
     private boolean constraintsChanged() {
-        return iterate(constraints).anyMatch(c -> !c.isInitialised);
+        return iterate(constraints).anyMatch(c -> !c.isUpToDate);
     }
 
     private void initialiseSolver() {
@@ -98,7 +98,7 @@ public class Optimiser {
         parameters.setIntegerParam(PRESOLVE, PRESOLVE_ON.swigValue());
         parameters.setIntegerParam(INCREMENTALITY, INCREMENTALITY_ON.swigValue());
         variables.forEach(var -> var.initialise(solver));
-        constraints.forEach(constraint -> constraint.initialise(solver));
+        constraints.forEach(constraint -> { constraint.initialise(solver); constraint.updateCoefficients(); });
         applyObjective();
         applyInitialisation();
         hasSolver = true;

--- a/common/optimiser/Optimiser.java
+++ b/common/optimiser/Optimiser.java
@@ -59,14 +59,14 @@ public class Optimiser {
     public synchronized Status optimise(long timeLimitMillis) {
         if (hasSolver && constraintsChanged()) {
             constraints.forEach(constraint -> constraint.initialise(solver));
-            status = Status.FEASIBLE;
+            status = Status.NOT_SOLVED;
         }
         if (isOptimal()) return status;
         else if (!hasSolver) initialiseSolver();
         solver.setTimeLimit(timeLimitMillis);
         status = Status.of(solver.solve(parameters));
-        variables.forEach(OptimiserVariable::recordValue);
-        clearInitialisation();
+        if (status != Status.NOT_SOLVED && status != Status.ERROR)
+            variables.forEach(OptimiserVariable::recordValue);
         if (isOptimal()) releaseSolver();
         return status;
     }

--- a/common/optimiser/Optimiser.java
+++ b/common/optimiser/Optimiser.java
@@ -88,7 +88,7 @@ public class Optimiser {
     }
 
     private boolean constraintsChanged() {
-        return constraints.stream().anyMatch(c -> !c.isInitialised);
+        return iterate(constraints).anyMatch(c -> !c.isInitialised);
     }
 
     private void initialiseSolver() {

--- a/common/optimiser/Optimiser.java
+++ b/common/optimiser/Optimiser.java
@@ -131,10 +131,6 @@ public class Optimiser {
         solver.setHint(mpVariables, initialisations);
     }
 
-    private void clearInitialisation() {
-        solver.setHint(new MPVariable[0], new double[0]);
-    }
-
     public void setObjectiveCoefficient(OptimiserVariable<?> var, double coeff) {
         objectiveCoefficients.put(var, coeff);
         if (hasSolver) solver.objective().setCoefficient(var.mpVariable(), coeff);

--- a/common/optimiser/OptimiserConstraint.java
+++ b/common/optimiser/OptimiserConstraint.java
@@ -42,12 +42,13 @@ public class OptimiserConstraint {
     }
 
     public void setCoefficient(OptimiserVariable<?> variable, double coeff) {
-        if (isInitialised)
+        if (isInitialised) {
             if (coefficients.containsKey(variable)) {
                 isInitialised = coefficients.get(variable) == coeff;
             } else {
                 isInitialised = false;
             }
+        }
         coefficients.put(variable, coeff);
     }
 

--- a/common/optimiser/OptimiserVariable.java
+++ b/common/optimiser/OptimiserVariable.java
@@ -54,10 +54,6 @@ public abstract class OptimiserVariable<T> {
         this.initial = initial;
     }
 
-    public void clearInitial() {
-        initial = null;
-    }
-
     public boolean hasInitial() {
         return initial != null;
     }

--- a/common/optimiser/OptimiserVariable.java
+++ b/common/optimiser/OptimiserVariable.java
@@ -26,27 +26,60 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNE
 
 public abstract class OptimiserVariable<T> {
 
+    protected T initial;
+    protected T solution;
+    protected MPVariable mpVariable;
+
     final String name;
 
     OptimiserVariable(String name) {
         this.name = name;
     }
 
-    public abstract T solutionValue();
+    public T value() {
+        if (hasSolutionValue()) return solutionValue();
+        else return initial();
+    }
 
-    abstract MPVariable mpVariable();
+    public boolean hasSolutionValue() {
+        return solution != null;
+    }
+
+    public T solutionValue() {
+        assert hasSolutionValue();
+        return solution;
+    }
+
+    public void setInitial(T initial) {
+        this.initial = initial;
+    }
+
+    public void clearInitial() {
+        initial = null;
+    }
+
+    public boolean hasInitial() {
+        return initial != null;
+    }
+
+    public T initial() {
+        assert hasInitial();
+        return initial;
+    }
+
+    public abstract double hint();
+
+    MPVariable mpVariable() {
+        return mpVariable;
+    }
 
     abstract void recordValue();
 
-    public abstract void clearInitial();
-
-    abstract boolean hasInitial();
-
-    public abstract double getInitial();
-
     abstract void initialise(MPSolver solver);
 
-    abstract void release();
+    synchronized void release() {
+        this.mpVariable.delete();
+    }
 
     @Override
     public String toString() {
@@ -55,23 +88,8 @@ public abstract class OptimiserVariable<T> {
 
     public static class Boolean extends OptimiserVariable<java.lang.Boolean> {
 
-        private java.lang.Boolean initial;
-        private java.lang.Boolean solution;
-        private MPVariable mpVariable;
-
         public Boolean(String name) {
             super(name);
-        }
-
-        @Override
-        public java.lang.Boolean solutionValue() {
-            assert solution != null;
-            return solution;
-        }
-
-        @Override
-        MPVariable mpVariable() {
-            return mpVariable;
         }
 
         @Override
@@ -87,26 +105,7 @@ public abstract class OptimiserVariable<T> {
         }
 
         @Override
-        synchronized void release() {
-            this.mpVariable.delete();
-        }
-
-        public void setInitial(boolean initial) {
-            this.initial = initial;
-        }
-
-        @Override
-        boolean hasInitial() {
-            return initial != null;
-        }
-
-        @Override
-        public void clearInitial() {
-            initial = null;
-        }
-
-        @Override
-        public double getInitial() {
+        public double hint() {
             assert hasInitial();
             if (initial) return 1.0;
             else return 0.0;
@@ -117,25 +116,11 @@ public abstract class OptimiserVariable<T> {
 
         private final double lowerBound;
         private final double upperBound;
-        private java.lang.Integer initial;
-        private java.lang.Integer solution;
-        private MPVariable mpVariable;
 
         public Integer(double lowerBound, double upperBound, String name) {
             super(name);
             this.lowerBound = lowerBound;
             this.upperBound = upperBound;
-        }
-
-        @Override
-        public java.lang.Integer solutionValue() {
-            assert solution != null;
-            return solution;
-        }
-
-        @Override
-        MPVariable mpVariable() {
-            return mpVariable;
         }
 
         @Override
@@ -149,26 +134,7 @@ public abstract class OptimiserVariable<T> {
         }
 
         @Override
-        synchronized void release() {
-            this.mpVariable.delete();
-        }
-
-        @Override
-        boolean hasInitial() {
-            return initial != null;
-        }
-
-        public void setInitial(int initial) {
-            this.initial = initial;
-        }
-
-        @Override
-        public void clearInitial() {
-            initial = null;
-        }
-
-        @Override
-        public double getInitial() {
+        public double hint() {
             assert hasInitial();
             return initial;
         }

--- a/traversal/common/Identifier.java
+++ b/traversal/common/Identifier.java
@@ -115,7 +115,7 @@ public abstract class Identifier {
             else if (o == null || getClass() != o.getClass()) return false;
 
             Scoped that = (Scoped) o;
-            return this.relation.equals(that.relation) && (Objects.equals(this.roleType, that.roleType))
+            return this.relation.equals(that.relation) && Objects.equals(this.roleType, that.roleType)
                     && this.player.equals(that.player) && this.repetition == that.repetition;
         }
 

--- a/traversal/common/Identifier.java
+++ b/traversal/common/Identifier.java
@@ -115,7 +115,8 @@ public abstract class Identifier {
             else if (o == null || getClass() != o.getClass()) return false;
 
             Scoped that = (Scoped) o;
-            return this.relation.equals(that.relation) && this.repetition == that.repetition;
+            return this.relation.equals(that.relation) && (Objects.equals(this.roleType, that.roleType))
+                    && this.player.equals(that.player) && this.repetition == that.repetition;
         }
 
         @Override

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -251,7 +251,7 @@ public class GraphPlanner implements Planner {
 
     @SuppressWarnings("NonAtomicOperationOnVolatileField")
     private void optimise(GraphManager graphMgr, boolean singleUse) {
-        computeTraversalCosts(graphMgr);
+        updateTraversalCosts(graphMgr);
         if (isUpToDate() && isOptimal()) {
             if (LOG.isDebugEnabled()) LOG.debug("GraphPlanner still optimal and up-to-date");
             return;
@@ -286,7 +286,7 @@ public class GraphPlanner implements Planner {
         if (LOG.isTraceEnabled()) LOG.trace(optimiser.toString());
     }
 
-    private void computeTraversalCosts(GraphManager graphMgr) {
+    private void updateTraversalCosts(GraphManager graphMgr) {
         if (snapshot < graphMgr.data().stats().snapshot()) {
             // TODO: we should not include the graph's uncommitted writes, but only the persisted counts in the costs
             snapshot = graphMgr.data().stats().snapshot();

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -160,16 +160,16 @@ public class GraphPlanner implements Planner {
     }
 
     private void initialise() {
-        initialiseVariables();
-        initialiseConstraints();
+        createVariables();
+        createConstraints();
     }
 
-    private void initialiseVariables() {
-        vertices.values().forEach(PlannerVertex::initialiseVariables);
-        edges.forEach(PlannerEdge::initialiseVariables);
+    private void createVariables() {
+        vertices.values().forEach(PlannerVertex::createVariables);
+        edges.forEach(PlannerEdge::createVariables);
     }
 
-    private void initialiseConstraints() {
+    private void createConstraints() {
         String conPrefix = "planner_con_";
         for (int i = 0; i < vertices.size(); i++) {
             OptimiserConstraint conOneVertexAtOrderI = optimiser.constraint(1, 1, conPrefix + "one_vertex_at_order_" + i);
@@ -177,8 +177,8 @@ public class GraphPlanner implements Planner {
                 conOneVertexAtOrderI.setCoefficient(vertex.varOrderAssignment[i], 1);
             }
         }
-        vertices.values().forEach(PlannerVertex::initialiseConstraints);
-        edges.forEach(PlannerEdge::initialiseConstraints);
+        vertices.values().forEach(PlannerVertex::createConstraints);
+        edges.forEach(PlannerEdge::createConstraints);
     }
 
     @Override
@@ -398,8 +398,7 @@ public class GraphPlanner implements Planner {
         }
         assert vertexOrder == vertices.size();
 
-        vertices.values().forEach(PlannerVertex::inferInitialStartingVertexFromOrder);
-        vertices.values().forEach(PlannerVertex::setOutgoingEdgesInitialValues);
-        edges.forEach(PlannerEdge::setInitialMinimal);
+        vertices.values().forEach(PlannerVertex::initialise);
+        edges.forEach(PlannerEdge::initialise);
     }
 }

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -387,8 +387,6 @@ public class GraphPlanner implements Planner {
     }
 
     private void setInitialValues() {
-        resetInitialValues();
-
         PlannerVertex<?> start = vertices.values().stream().min(comparing(PlannerVertex::cost)).get();
         Set<PlannerVertex<?>> closedSet = new HashSet<>();
         PriorityQueue<PlannerVertex<?>> open = new PriorityQueue<>(comparing(
@@ -411,10 +409,5 @@ public class GraphPlanner implements Planner {
         vertices.values().forEach(PlannerVertex::inferStartingVertexFromOrder);
         vertices.values().forEach(PlannerVertex::setOutgoingEdgesInitialValues);
         edges.forEach(PlannerEdge::initialiseMinimal);
-    }
-
-    private void resetInitialValues() {
-        vertices.values().forEach(PlannerVertex::resetInitialValues);
-        edges.forEach(PlannerEdge::resetInitialValues);
     }
 }

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -73,8 +73,8 @@ public class GraphPlanner implements Planner {
     private volatile long totalDuration;
     private volatile long snapshot;
 
-    volatile double recordedTotalCost;
-    double totalCost;
+    private volatile double recordedTotalCost;
+    private double totalCost;
 
     private GraphPlanner() {
         optimiser = new Optimiser();
@@ -207,7 +207,7 @@ public class GraphPlanner implements Planner {
     }
 
     void setOutOfDate() {
-        this.isUpToDate = false;
+        isUpToDate = false;
     }
 
     private boolean isUpToDate() {
@@ -316,19 +316,19 @@ public class GraphPlanner implements Planner {
         if (totalCostChangeSignificant()) setOutOfDate();
     }
 
-    boolean costChangeSignificant(PlannerVertex<?> vertex) {
+    private boolean costChangeSignificant(PlannerVertex<?> vertex) {
         return costChangeSignificant(vertex.recordedCost, vertex.cost());
     }
 
-    boolean costChangeSignificant(PlannerEdge<?, ?> edge) {
+    private boolean costChangeSignificant(PlannerEdge<?, ?> edge) {
         return costChangeSignificant(edge.forward) || costChangeSignificant(edge.backward);
     }
 
-    boolean costChangeSignificant(PlannerEdge.Directional<?, ?> edge) {
+    private boolean costChangeSignificant(PlannerEdge.Directional<?, ?> edge) {
         return costChangeSignificant(edge.recordedCost, edge.cost());
     }
 
-    boolean costChangeSignificant(double costPrevious, double costNext) {
+    private boolean costChangeSignificant(double costPrevious, double costNext) {
         assert recordedTotalCost > 0;
         assert costPrevious > 0;
         assert costNext > 0;
@@ -338,7 +338,7 @@ public class GraphPlanner implements Planner {
                 abs(costNext - costPrevious) / recordedTotalCost >= OBJECTIVE_VARIABLE_TO_PLANNER_COST_MIN_CHANGE;
     }
 
-    boolean totalCostChangeSignificant() {
+    private boolean totalCostChangeSignificant() {
         assert recordedTotalCost > 0;
         return abs((totalCost / recordedTotalCost) - 1) >= OBJECTIVE_PLANNER_COST_MAX_CHANGE;
     }

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -95,7 +95,7 @@ public class GraphPlanner implements Planner {
         Set<StructureEdge<?, ?>> registeredEdges = new HashSet<>();
         structure.vertices().forEach(vertex -> planner.registerVertex(vertex, registeredVertices, registeredEdges));
         assert planner.vertices().size() > 1 && !planner.edges().isEmpty();
-        planner.initialise();
+        planner.initialiseOptimiserModel();
         return planner;
     }
 
@@ -159,17 +159,17 @@ public class GraphPlanner implements Planner {
         ).asType();
     }
 
-    private void initialise() {
-        createVariables();
-        createConstraints();
+    private void initialiseOptimiserModel() {
+        createOptimiserVariables();
+        createOptimiserConstraints();
     }
 
-    private void createVariables() {
-        vertices.values().forEach(PlannerVertex::createVariables);
-        edges.forEach(PlannerEdge::createVariables);
+    private void createOptimiserVariables() {
+        vertices.values().forEach(PlannerVertex::createOptimiserVariables);
+        edges.forEach(PlannerEdge::createOptimiserVariables);
     }
 
-    private void createConstraints() {
+    private void createOptimiserConstraints() {
         String conPrefix = "planner_con_";
         for (int i = 0; i < vertices.size(); i++) {
             OptimiserConstraint conOneVertexAtOrderI = optimiser.constraint(1, 1, conPrefix + "one_vertex_at_order_" + i);
@@ -177,8 +177,8 @@ public class GraphPlanner implements Planner {
                 conOneVertexAtOrderI.setCoefficient(vertex.varOrderAssignment[i], 1);
             }
         }
-        vertices.values().forEach(PlannerVertex::createConstraints);
-        edges.forEach(PlannerEdge::createConstraints);
+        vertices.values().forEach(PlannerVertex::createOptimiserConstraints);
+        edges.forEach(PlannerEdge::createOptimiserConstraints);
     }
 
     @Override
@@ -257,7 +257,7 @@ public class GraphPlanner implements Planner {
         }
         updateOptimiserCoefficients();
 
-        if (!isPlanned()) setInitialValues();
+        if (!isPlanned()) initialiseOptimiserValues();
 
         // TODO: we should have a more clever logic to allocate extra time
         long allocatedDuration = singleUse ? HIGHER_TIME_LIMIT_MILLIS : DEFAULT_TIME_LIMIT_MILLIS;
@@ -385,7 +385,7 @@ public class GraphPlanner implements Planner {
         return str.toString();
     }
 
-    private void setInitialValues() {
+    private void initialiseOptimiserValues() {
         Set<PlannerVertex<?>> unorderedVertices = new HashSet<>(vertices.values());
         int vertexOrder = 0;
         while (!unorderedVertices.isEmpty()) {
@@ -398,7 +398,7 @@ public class GraphPlanner implements Planner {
         }
         assert vertexOrder == vertices.size();
 
-        vertices.values().forEach(PlannerVertex::initialise);
-        edges.forEach(PlannerEdge::initialise);
+        vertices.values().forEach(PlannerVertex::initialiseOptimiserValues);
+        edges.forEach(PlannerEdge::initialiseOptimiserValues);
     }
 }

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -309,14 +309,14 @@ public class GraphPlanner implements Planner {
             if (costChangeSignificant(e)) setOutOfDate();
         });
 
-        double vertexCost = iterate(vertices.values()).map(PlannerVertex::cost).reduce(0.0, Double::sum);
-        double edgeCost = iterate(edges).map(e -> e.forward.cost() + e.backward.cost()).reduce(0.0, Double::sum);
+        double vertexCost = iterate(vertices.values()).map(PlannerVertex::safeCost).reduce(0.0, Double::sum);
+        double edgeCost = iterate(edges).map(e -> e.forward.safeCost() + e.backward.safeCost()).reduce(0.0, Double::sum);
         totalCost = vertexCost + edgeCost;
         if (totalCostChangeSignificant()) setOutOfDate();
     }
 
     private boolean costChangeSignificant(PlannerVertex<?> vertex) {
-        return costChangeSignificant(vertex.costLastRecorded, vertex.cost());
+        return costChangeSignificant(vertex.costLastRecorded, vertex.safeCost());
     }
 
     private boolean costChangeSignificant(PlannerEdge<?, ?> edge) {
@@ -324,7 +324,7 @@ public class GraphPlanner implements Planner {
     }
 
     private boolean costChangeSignificant(PlannerEdge.Directional<?, ?> edge) {
-        return costChangeSignificant(edge.costLastRecorded, edge.cost());
+        return costChangeSignificant(edge.costLastRecorded, edge.safeCost());
     }
 
     private boolean costChangeSignificant(double costPrevious, double costNext) {
@@ -391,7 +391,7 @@ public class GraphPlanner implements Planner {
         while (!unorderedVertices.isEmpty()) {
             PlannerVertex<?> vertex = unorderedVertices.stream().min(comparing(
                     v -> v.ins().stream().filter(e -> !unorderedVertices.contains(e.from()))
-                            .mapToDouble(PlannerEdge.Directional::cost).min().orElse(v.cost())
+                            .mapToDouble(PlannerEdge.Directional::safeCost).min().orElse(v.safeCost())
             )).get();
             unorderedVertices.remove(vertex);
             vertex.setOrderInitial(vertexOrder++);

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -39,7 +39,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -399,8 +398,8 @@ public class GraphPlanner implements Planner {
         }
         assert vertexOrder == vertices.size();
 
-        vertices.values().forEach(PlannerVertex::inferStartingVertexFromOrder);
+        vertices.values().forEach(PlannerVertex::inferInitialStartingVertexFromOrder);
         vertices.values().forEach(PlannerVertex::setOutgoingEdgesInitialValues);
-        edges.forEach(PlannerEdge::initialiseMinimal);
+        edges.forEach(PlannerEdge::setInitialMinimal);
     }
 }

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -310,8 +310,8 @@ public class GraphPlanner implements Planner {
             if (costChangeSignificant(e)) setOutOfDate();
         });
 
-        double vertexCost = vertices.values().stream().mapToDouble(PlannerVertex::cost).sum();
-        double edgeCost = edges.stream().mapToDouble(PlannerEdge::cost).sum();
+        double vertexCost = iterate(vertices.values()).map(PlannerVertex::cost).reduce(0.0, Double::sum);
+        double edgeCost = iterate(edges).map(e -> e.forward.cost() + e.backward.cost()).reduce(0.0, Double::sum);
         totalCost = vertexCost + edgeCost;
         if (totalCostChangeSignificant()) setOutOfDate();
     }

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -32,6 +32,7 @@ import com.vaticle.typeql.lang.common.TypeQLToken;
 
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 import static com.vaticle.typedb.common.util.Objects.className;
@@ -147,8 +148,8 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         private boolean didInitialiseConstraints;
         private boolean hasInitialValues;
 
-        private final int tieBreaker;
-        private static int nextTieBreaker = 0;
+        private final long tieBreaker;
+        private static final AtomicLong nextTieBreaker = new AtomicLong(0);
 
         double cost;
         double recordedCost;
@@ -167,7 +168,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
 
             this.varPrefix = "edge_var_" + this.toString() + "_";
             this.conPrefix = "edge_con_" + this.toString() + "_";
-            this.tieBreaker = nextTieBreaker++;
+            this.tieBreaker = nextTieBreaker.getAndIncrement();
         }
 
         public boolean isSelected() {

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -248,7 +248,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             assert varIsSelected.hasInitial();
             varIsMinimal.setInitial(
                     varIsSelected.initial() &&
-                            to().ins().stream().
+                            iterate(to().ins()).
                                     filter(e -> !this.equals(e)).
                                     filter(e -> e.varIsSelected.initial()).
                                     noneMatch(e -> e.cheaperThan(this))

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -91,14 +91,14 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         return backward;
     }
 
-    void initialiseVariables() {
-        forward.initialiseVariables();
-        backward.initialiseVariables();
+    void createVariables() {
+        forward.createVariables();
+        backward.createVariables();
     }
 
-    void initialiseConstraints() {
-        forward.initialiseConstraints();
-        backward.initialiseConstraints();
+    void createConstraints() {
+        forward.createConstraints();
+        backward.createConstraints();
     }
 
     void computeCost(GraphManager graphMgr) {
@@ -116,9 +116,9 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         backward.recordCost();
     }
 
-    public void setInitialMinimal() {
-        forward.setInitialMinimal();
-        backward.setInitialMinimal();
+    public void initialise() {
+        forward.initialise();
+        backward.initialise();
     }
 
     @Override
@@ -171,12 +171,12 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             return isInitialised;
         }
 
-        void initialiseVariables() {
+        void createVariables() {
             varIsSelected = planner.optimiser().booleanVar(varPrefix + "is_selected");
             varIsMinimal = planner.optimiser().booleanVar(varPrefix + "is_minimal");
         }
 
-        void initialiseConstraints() {
+        void createConstraints() {
             int numVertices = planner.vertices().size();
 
             OptimiserConstraint conIsSelected = planner.optimiser().constraint(1, numVertices, conPrefix + "is_selected");
@@ -235,8 +235,14 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             initialiseMinimalEdgeConstraint();
         }
 
-        public void setInitialSelected(boolean selected) {
-            varIsSelected.setInitial(selected);
+        public void initialise() {
+            setInitialSelected();
+            setInitialMinimal();
+            isInitialised = true;
+        }
+
+        public void setInitialSelected() {
+            varIsSelected.setInitial(from().varOrderNumber.initial() < to().varOrderNumber.initial());
         }
 
         public void setInitialMinimal() {
@@ -248,7 +254,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                                     filter(e -> e.varIsSelected.initial()).
                                     noneMatch(e -> e.cheaperThan(this))
             );
-            isInitialised = true;
         }
 
         public boolean isEqual() {

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -52,6 +52,8 @@ import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.PLAYS;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.RELATES;
 import static com.vaticle.typedb.core.graph.common.Encoding.Edge.Type.SUB;
 import static com.vaticle.typedb.core.traversal.planner.GraphPlanner.INIT_ZERO;
+import static java.lang.Math.log;
+import static java.lang.Math.max;
 
 public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_TO extends PlannerVertex<?>>
         extends TraversalEdge<VERTEX_FROM, VERTEX_TO> {
@@ -96,18 +98,22 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
     }
 
     void initialiseConstraints() {
-        String conPrefix = "edge_con_" + this.toString() + "_";
-        OptimiserConstraint conOneDirection = planner.optimiser().constraint(1, 1, conPrefix + "one_direction");
-        conOneDirection.setCoefficient(forward.varIsSelected, 1);
-        conOneDirection.setCoefficient(backward.varIsSelected, 1);
-
         forward.initialiseConstraints();
         backward.initialiseConstraints();
     }
 
-    void updateObjective(GraphManager graphMgr) {
-        forward.updateObjective(graphMgr);
-        backward.updateObjective(graphMgr);
+    double getCost() {
+        return forward.getCost() + backward.getCost();
+    }
+
+    void computeCost(GraphManager graphMgr) {
+        forward.computeCost(graphMgr);
+        backward.computeCost(graphMgr);
+    }
+
+    void updateOptimiserCoefficients() {
+        forward.updateOptimiserCoefficients();
+        backward.updateOptimiserCoefficients();
     }
 
     void recordCost() {
@@ -115,9 +121,14 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         backward.recordCost();
     }
 
-    void resetInitialValue() {
+    void resetInitialValues() {
         forward.resetInitialValue();
         backward.resetInitialValue();
+    }
+
+    public void initialiseMinimal() {
+        forward.setInitialMinimal();
+        backward.setInitialMinimal();
     }
 
     @Override
@@ -129,17 +140,23 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             extends TraversalEdge<VERTEX_DIR_FROM, VERTEX_DIR_TO> {
 
         OptimiserVariable.Boolean varIsSelected;
-        OptimiserVariable.Boolean[] varOrderAssignment;
-        private OptimiserVariable.Integer varOrderNumber;
+        OptimiserVariable.Boolean varIsMinimal;
+        OptimiserConstraint conIsMinimal;
+
         private final String varPrefix;
         private final String conPrefix;
         private final GraphPlanner planner;
         private final Encoding.Direction.Edge direction;
-        private boolean hasInitialValue;
-        private boolean isInitialisedVariables;
-        private boolean isInitialisedConstraints;
-        private double costNext;
-        double costLastRecorded;
+
+        private boolean didInitialiseVariables;
+        private boolean didInitialiseConstraints;
+        private boolean hasInitialValues;
+
+        private final int tieBreaker;
+        private static int nextTieBreaker = 0;
+
+        double cost;
+        double recordedCost;
 
         private Directional<VERTEX_DIR_TO, VERTEX_DIR_FROM> opposite;
 
@@ -147,29 +164,35 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             super(from, to, symbol);
             this.planner = from.planner;
             this.direction = direction;
-            this.costLastRecorded = 0.01; // non-zero value for safe division
-            this.isInitialisedVariables = false;
-            this.isInitialisedConstraints = false;
+            this.recordedCost = INIT_ZERO;
+
+            this.didInitialiseVariables = false;
+            this.didInitialiseConstraints = false;
+            this.hasInitialValues = false;
+
             this.varPrefix = "edge_var_" + this.toString() + "_";
             this.conPrefix = "edge_con_" + this.toString() + "_";
+            this.tieBreaker = nextTieBreaker++;
         }
-
-        abstract void updateObjective(GraphManager graphMgr);
 
         public boolean isSelected() {
-            return varIsSelected.solutionValue();
-        }
-
-        public int orderNumber() {
-            return varOrderNumber.solutionValue();
+            return varIsSelected.value();
         }
 
         public Encoding.Direction.Edge direction() {
             return direction;
         }
 
-        public boolean isInitialisedVariables() {
-            return isInitialisedVariables;
+        public boolean didInitialiseVariables() {
+            return didInitialiseVariables;
+        }
+
+        public boolean didInitialiseConstraints() {
+            return didInitialiseConstraints;
+        }
+
+        public boolean hasInitialValues() {
+            return hasInitialValues;
         }
 
         void opposite(Directional<VERTEX_DIR_TO, VERTEX_DIR_FROM> opposite) {
@@ -178,45 +201,48 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
 
         void initialiseVariables() {
             varIsSelected = planner.optimiser().booleanVar(varPrefix + "is_selected");
-            varOrderNumber = planner.optimiser().intVar(0, planner.edges().size(), varPrefix + "order_number");
-            varOrderAssignment = new OptimiserVariable.Boolean[planner.edges().size()];
-            for (int i = 0; i < planner.edges().size(); i++) {
-                varOrderAssignment[i] = planner.optimiser().booleanVar(varPrefix + "order_assignment[" + i + "]");
-            }
-            isInitialisedVariables = true;
+            varIsMinimal = planner.optimiser().booleanVar(varPrefix + "is_minimal");
+            didInitialiseVariables = true;
         }
 
         void initialiseConstraints() {
-            assert from.isInitialisedVariables();
-            assert to.isInitialisedVariables();
-            initialiseConstraintsForOrderNumber();
-            initialiseConstraintsForOrderSequence();
-            isInitialisedConstraints = true;
+            assert from.didInitialiseVariables();
+            assert to.didInitialiseVariables();
+
+            int numVertices = planner.vertices().size();
+
+            OptimiserConstraint conIsSelected = planner.optimiser().constraint(1, numVertices, conPrefix + "is_selected");
+            conIsSelected.setCoefficient(varIsSelected, numVertices);
+            conIsSelected.setCoefficient(from.varOrderNumber, 1);
+            conIsSelected.setCoefficient(to.varOrderNumber, -1);
+
+            int numAdjacent = to.ins().size();
+            conIsMinimal = planner.optimiser().constraint(0, numAdjacent, conPrefix + "is_minimal");
+            conIsMinimal.setCoefficient(varIsMinimal, numAdjacent + 1);
+            conIsMinimal.setCoefficient(varIsSelected, -1);
+            setMinimalEdgeConstraint();
+
+            didInitialiseConstraints = true;
         }
 
-        private void initialiseConstraintsForOrderNumber() {
-            OptimiserConstraint conOrderIfSelected = planner.optimiser().constraint(0, 0, conPrefix + "order_if_selected");
-            conOrderIfSelected.setCoefficient(varIsSelected, -1);
-
-            OptimiserConstraint conAssignOrderNumber = planner.optimiser().constraint(0, 0, conPrefix + "assign_order_number");
-            conAssignOrderNumber.setCoefficient(varOrderNumber, -1);
-
-            for (int i = 0; i < planner.edges().size(); i++) {
-                conOrderIfSelected.setCoefficient(varOrderAssignment[i], 1);
-                conAssignOrderNumber.setCoefficient(varOrderAssignment[i], i + 1);
+        private void setMinimalEdgeConstraint() {  // FIXME rename
+            for (PlannerEdge.Directional<?, ?> adjacent: to.ins()) {
+                if (!this.equals(adjacent))
+                    if (cheaperThan(adjacent))
+                        conIsMinimal.setCoefficient(adjacent.varIsSelected, 0);
+                    else
+                        conIsMinimal.setCoefficient(adjacent.varIsSelected, 1);
             }
         }
 
-        private void initialiseConstraintsForOrderSequence() {
-            Set<Directional<?, ?>> previousEdges = iterate(from.ins()).filter(edge -> !edge.equals(this.opposite)).toSet();
-            int i = 0;
-            for (Directional<?, ?> previousEdge : previousEdges) {
-                String name = conPrefix + "order_sequence_" + i++;
-                OptimiserConstraint conOrderSequence = planner.optimiser().constraint(0, planner.edges().size() + 1, name);
-                conOrderSequence.setCoefficient(this.varOrderNumber, 1);
-                conOrderSequence.setCoefficient(this.opposite.varIsSelected, planner.edges().size() + 1);
-                conOrderSequence.setCoefficient(previousEdge.varOrderNumber, -1);
-                conOrderSequence.setCoefficient(previousEdge.varIsSelected, -1);
+        private boolean cheaperThan(PlannerEdge.Directional<?, ?> other) {
+            assert !this.equals(other);
+            if (recordedCost < other.recordedCost) {
+                return true;
+            } else if (recordedCost == other.recordedCost) {
+                return tieBreaker < other.tieBreaker;
+            } else {
+                return false;
             }
         }
 
@@ -227,51 +253,43 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             return from.equals(to);
         }
 
-        protected void setObjectiveCoefficient(double cost) {
-            assert !Double.isNaN(cost);
-            if (cost < INIT_ZERO) cost = INIT_ZERO;
-            int expMultiplier = planner.edges().size() - 1;
-            for (int i = 0; i < planner.edges().size(); i++) {
-                double exp = 1 + (expMultiplier-- * planner.costExponentUnit);
-                double coeff = cost * Math.pow(planner.branchingFactor, exp);
-                planner.optimiser().setObjectiveCoefficient(varOrderAssignment[i], coeff);
-            }
-            costNext = cost;
-            planner.updateCostNext(costLastRecorded, costNext);
+        abstract void computeCost(GraphManager graphMgr);
+
+        public double getCost() {
+            return cost;
         }
 
         private void recordCost() {
-            costLastRecorded = costNext;
+            recordedCost = max(cost, INIT_ZERO);
+        }
+
+        protected void updateOptimiserCoefficients() {
+            assert !Double.isNaN(recordedCost);
+            assert recordedCost >= INIT_ZERO;
+            planner.optimiser().setObjectiveCoefficient(varIsMinimal, log(1 + recordedCost));
+            setMinimalEdgeConstraint();
         }
 
         private void resetInitialValue() {
             varIsSelected.clearInitial();
-            varOrderNumber.clearInitial();
-            iterate(varOrderAssignment).forEachRemaining(OptimiserVariable.Boolean::clearInitial);
-            hasInitialValue = false;
+            varIsMinimal.clearInitial();
+            hasInitialValues = false;
         }
 
-        void setInitialValue(int order) {
-            assert order > 0;
-            varOrderNumber.setInitial(order);
-            varIsSelected.setInitial(true);
-            for (int i = 0; i < varOrderAssignment.length; i++) {
-                if (i == order - 1) varOrderAssignment[i].setInitial(true);
-                else varOrderAssignment[i].setInitial(false);
-            }
-            hasInitialValue = true;
-            opposite.setInitialUnselected();
+        public void setInitialSelected(boolean selected) {
+            varIsSelected.setInitial(selected);
         }
 
-        public void setInitialUnselected() {
-            varIsSelected.setInitial(false);
-            varOrderNumber.setInitial(0); // irrelevant
-            iterate(varOrderAssignment).forEachRemaining(var -> var.setInitial(false));
-            hasInitialValue = true;
-        }
-
-        boolean hasInitialValue() {
-            return hasInitialValue;
+        public void setInitialMinimal() {  // FIXME rename
+            assert varIsSelected.hasInitial();
+            varIsMinimal.setInitial(
+                varIsSelected.initial() &&
+                to().ins().stream().
+                    filter(e -> !this.equals(e)).
+                    filter(e -> e.varIsSelected.initial()).
+                    noneMatch(e -> e.cheaperThan(this))
+            );
+            hasInitialValues = true;
         }
 
         public boolean isEqual() {
@@ -325,8 +343,8 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             }
 
             @Override
-            void updateObjective(GraphManager graphMgr) {
-                setObjectiveCoefficient(0);
+            void computeCost(GraphManager graphMgr) {
+                cost = INIT_ZERO;
             }
 
             @Override
@@ -383,8 +401,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             }
 
             @Override
-            void updateObjective(GraphManager graphMgr) {
-                long cost;
+            void computeCost(GraphManager graphMgr) {
                 if (isLoop() || to().props().hasIID()) {
                     cost = 1;
                 } else if (predicate.operator().equals(PredicateOperator.Equality.EQ)) {
@@ -393,7 +410,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     cost = graphMgr.data().stats().thingVertexSum(to.props().types());
                 }
                 assert !Double.isNaN(cost);
-                setObjectiveCoefficient(cost);
             }
         }
     }
@@ -507,12 +523,10 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                 }
 
                 @Override
-                void updateObjective(GraphManager graphMgr) {
-                    long cost;
+                void computeCost(GraphManager graphMgr) {
                     if (!isTransitive) cost = 1;
                     else cost = graphMgr.schema().stats().subTypesDepth(to.props().labels());
                     assert !Double.isNaN(cost);
-                    setObjectiveCoefficient(cost);
                 }
             }
 
@@ -523,8 +537,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                 }
 
                 @Override
-                void updateObjective(GraphManager graphMgr) {
-                    long cost;
+                void computeCost(GraphManager graphMgr) {
                     if (to().props().hasIID()) {
                         cost = 1;
                     } else {
@@ -534,7 +547,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                         else cost = graphMgr.data().stats().thingVertexTransitiveMax(toTypes);
                     }
                     assert !Double.isNaN(cost);
-                    setObjectiveCoefficient(cost);
                 }
             }
         }
@@ -660,8 +672,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
-                        long cost;
+                    void computeCost(GraphManager graphMgr) {
                         if (isLoop() || !isTransitive) {
                             cost = 1;
                         } else if (!to.props().labels().isEmpty()) {
@@ -670,7 +681,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                             cost = graphMgr.schema().stats().subTypesDepth(graphMgr.schema().rootThingType());
                         }
                         assert !Double.isNaN(cost);
-                        setObjectiveCoefficient(cost);
                     }
                 }
 
@@ -681,8 +691,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
-                        double cost;
+                    void computeCost(GraphManager graphMgr) {
                         if (isLoop()) {
                             cost = 1;
                         } else if (!to.props().labels().isEmpty()) {
@@ -693,7 +702,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                             cost = graphMgr.schema().stats().subTypesMean(graphMgr.schema().thingTypes().stream(), isTransitive);
                         }
                         assert !Double.isNaN(cost);
-                        setObjectiveCoefficient(cost);
                     }
                 }
             }
@@ -745,8 +753,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
-                        double cost;
+                    void computeCost(GraphManager graphMgr) {
                         if (isLoop()) {
                             cost = 1;
                         } else if (!to.props().labels().isEmpty()) {
@@ -758,7 +765,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                             cost = graphMgr.schema().stats().outOwnsMean(graphMgr.schema().entityTypes().stream(), isKey);
                         }
                         assert !Double.isNaN(cost);
-                        setObjectiveCoefficient(cost);
                     }
                 }
 
@@ -769,9 +775,8 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
+                    void computeCost(GraphManager graphMgr) {
                         // TODO: We can refine the branching factor by not strictly considering entity types only
-                        double cost;
                         if (isLoop()) {
                             cost = 1;
                         } else if (!to.props().labels().isEmpty()) {
@@ -784,7 +789,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                                     graphMgr.schema().stats().subTypesMean(graphMgr.schema().entityTypes().stream(), true);
                         }
                         assert !Double.isNaN(cost);
-                        setObjectiveCoefficient(cost);
                     }
                 }
             }
@@ -825,8 +829,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
-                        double cost;
+                    void computeCost(GraphManager graphMgr) {
                         if (!to.props().labels().isEmpty()) {
                             cost = to.props().labels().size();
                         } else if (!from.props().labels().isEmpty()) {
@@ -836,7 +839,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                             cost = graphMgr.schema().stats().outPlaysMean(graphMgr.schema().entityTypes().stream());
                         }
                         assert !Double.isNaN(cost);
-                        setObjectiveCoefficient(cost);
                     }
                 }
 
@@ -847,9 +849,8 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
+                    void computeCost(GraphManager graphMgr) {
                         // TODO: We can refine the branching factor by not strictly considering entity types only
-                        double cost;
                         if (!to.props().labels().isEmpty()) {
                             cost = graphMgr.schema().stats().subTypesSum(to.props().labels(), true);
                         } else if (!from.props().labels().isEmpty()) {
@@ -860,7 +861,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                                     graphMgr.schema().stats().subTypesMean(graphMgr.schema().entityTypes().stream(), true);
                         }
                         assert !Double.isNaN(cost);
-                        setObjectiveCoefficient(cost);
                     }
                 }
             }
@@ -901,8 +901,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
-                        double cost;
+                    void computeCost(GraphManager graphMgr) {
                         if (!to.props().labels().isEmpty()) {
                             cost = to.props().labels().size();
                         } else if (!from.props().labels().isEmpty()) {
@@ -911,7 +910,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                             cost = graphMgr.schema().stats().outRelates(graphMgr.schema().relationTypes().stream());
                         }
                         assert !Double.isNaN(cost);
-                        setObjectiveCoefficient(cost);
                     }
                 }
 
@@ -922,8 +920,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
-                        double cost;
+                    void computeCost(GraphManager graphMgr) {
                         if (!to.props().labels().isEmpty()) {
                             cost = graphMgr.schema().stats().subTypesMean(to.props().labels(), true);
                         } else if (!from.props().labels().isEmpty()) {
@@ -936,7 +933,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                             cost = graphMgr.schema().stats().subTypesMean(graphMgr.schema().relationTypes().stream(), true);
                         }
                         assert !Double.isNaN(cost);
-                        setObjectiveCoefficient(cost);
                     }
                 }
             }
@@ -1053,26 +1049,24 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
+                    void computeCost(GraphManager graphMgr) {
                         if (isLoop() || to().props().hasIID()) {
-                            setObjectiveCoefficient(1);
-                            return;
-                        }
+                            cost = 1;
+                        } else {
+                            Set<TypeVertex> ownerTypes = iterate(from.props().types()).map(l -> graphMgr.schema().getType(l)).toSet();
+                            Set<TypeVertex> attTypes = iterate(to.props().types()).map(l -> graphMgr.schema().getType(l)).toSet();
 
-                        Set<TypeVertex> ownerTypes = iterate(from.props().types()).map(l -> graphMgr.schema().getType(l)).toSet();
-                        Set<TypeVertex> attTypes = iterate(to.props().types()).map(l -> graphMgr.schema().getType(l)).toSet();
-
-                        double cost = 0.0;
-                        for (TypeVertex owner : ownerTypes) {
-                            double div = graphMgr.data().stats().thingVertexCount(owner);
-                            if (div > 0) {
-                                cost += graphMgr.data().stats().hasEdgeSum(owner, attTypes) / div;
+                            cost = 0;
+                            for (TypeVertex owner : ownerTypes) {
+                                double div = graphMgr.data().stats().thingVertexCount(owner);
+                                if (div > 0) {
+                                    cost += graphMgr.data().stats().hasEdgeSum(owner, attTypes) / div;
+                                }
                             }
+                            assert !ownerTypes.isEmpty();
+                            cost /= ownerTypes.size();
+                            assert !Double.isNaN(cost);
                         }
-                        assert !ownerTypes.isEmpty();
-                        cost /= ownerTypes.size();
-                        assert !Double.isNaN(cost);
-                        setObjectiveCoefficient(cost);
                     }
                 }
 
@@ -1083,26 +1077,24 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
+                    void computeCost(GraphManager graphMgr) {
                         if (isLoop() || to().props().hasIID()) {
-                            setObjectiveCoefficient(1);
-                            return;
-                        }
+                            cost = 1;
+                        } else {
+                            Set<TypeVertex> attTypes = iterate(from.props().types()).map(l -> graphMgr.schema().getType(l)).toSet();
+                            Set<TypeVertex> ownerTypes = iterate(to.props().types()).map(l -> graphMgr.schema().getType(l)).toSet();
 
-                        Set<TypeVertex> attTypes = iterate(from.props().types()).map(l -> graphMgr.schema().getType(l)).toSet();
-                        Set<TypeVertex> ownerTypes = iterate(to.props().types()).map(l -> graphMgr.schema().getType(l)).toSet();
-
-                        double cost = 0.0;
-                        for (TypeVertex attr : attTypes) {
-                            double div = graphMgr.data().stats().thingVertexCount(attr);
-                            if (div > 0) {
-                                cost += graphMgr.data().stats().hasEdgeSum(ownerTypes, attr) / div;
+                            cost = 0;
+                            for (TypeVertex attr : attTypes) {
+                                double div = graphMgr.data().stats().thingVertexCount(attr);
+                                if (div > 0) {
+                                    cost += graphMgr.data().stats().hasEdgeSum(ownerTypes, attr) / div;
+                                }
                             }
+                            assert !attTypes.isEmpty();
+                            cost /= attTypes.size();
+                            assert !Double.isNaN(cost);
                         }
-                        assert !attTypes.isEmpty();
-                        cost /= attTypes.size();
-                        assert !Double.isNaN(cost);
-                        setObjectiveCoefficient(cost);
                     }
                 }
             }
@@ -1143,13 +1135,12 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
+                    void computeCost(GraphManager graphMgr) {
                         assert !to.props().hasIID();
-                        double cost = 0.0;
+                        cost = INIT_ZERO;
                         double div = graphMgr.data().stats().thingVertexSum(from.props().types());
                         if (div > 0) cost = graphMgr.data().stats().thingVertexSum(to.props().types()) / div;
                         assert !Double.isNaN(cost);
-                        setObjectiveCoefficient(cost);
                     }
                 }
 
@@ -1160,8 +1151,8 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
-                        setObjectiveCoefficient(1);
+                    void computeCost(GraphManager graphMgr) {
+                        cost = 1;
                     }
                 }
             }
@@ -1202,9 +1193,9 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
+                    void computeCost(GraphManager graphMgr) {
                         assert !to.props().hasIID();
-                        double cost = 0;
+                        cost = 0;
                         for (Label roleType : to.props().types()) {
                             assert roleType.scope().isPresent();
                             double div = graphMgr.data().stats().thingVertexTransitiveCount(Label.of(roleType.scope().get()));
@@ -1213,7 +1204,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                         assert !to.props().types().isEmpty();
                         cost /= to.props().types().size();
                         assert !Double.isNaN(cost);
-                        setObjectiveCoefficient(cost);
                     }
                 }
 
@@ -1224,8 +1214,8 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
-                        setObjectiveCoefficient(1);
+                    void computeCost(GraphManager graphMgr) {
+                        cost = 1;
                     }
                 }
             }
@@ -1274,13 +1264,13 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
+                    void computeCost(GraphManager graphMgr) {
                         if (isLoop() || to.props().hasIID()) {
-                            setObjectiveCoefficient(1);
-                            return;
+                            cost = 1;
                         }
 
-                        double cost = 0;
+                        cost = 0;
+
                         Set<TypeVertex> roleTypeVertices = iterate(this.roleTypes()).map(graphMgr.schema()::getType).toSet();
                         for (TypeVertex roleType : roleTypeVertices) {
                             assert roleType.isRoleType() && roleType.properLabel().scope().isPresent();
@@ -1290,7 +1280,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                         assert !roleTypeVertices.isEmpty();
                         cost = cost / roleTypeVertices.size();
                         assert !Double.isNaN(cost);
-                        setObjectiveCoefficient(cost);
                     }
                 }
 
@@ -1301,17 +1290,15 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     }
 
                     @Override
-                    void updateObjective(GraphManager graphMgr) {
+                    void computeCost(GraphManager graphMgr) {
                         if (isLoop() || to.props().hasIID()) {
-                            setObjectiveCoefficient(1);
-                            return;
+                            cost = 1;
                         }
 
-                        double cost = 0;
+                        cost = 0;
                         double div = graphMgr.data().stats().thingVertexSum(from.props().types());
                         if (div > 0) cost = graphMgr.data().stats().thingVertexSum(roleTypes) / div;
                         assert !Double.isNaN(cost);
-                        setObjectiveCoefficient(cost);
                     }
                 }
             }

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -226,7 +226,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         }
 
         private void initialiseMinimalEdgeConstraint() {
-            for (PlannerEdge.Directional<?, ?> adjacent: to.ins()) {
+            for (PlannerEdge.Directional<?, ?> adjacent : to.ins()) {
                 if (!this.equals(adjacent))
                     if (cheaperThan(adjacent))
                         conIsMinimal.setCoefficient(adjacent.varIsSelected, 0);
@@ -282,11 +282,11 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         public void setInitialMinimal() {
             assert varIsSelected.hasInitial();
             varIsMinimal.setInitial(
-                varIsSelected.initial() &&
-                to().ins().stream().
-                    filter(e -> !this.equals(e)).
-                    filter(e -> e.varIsSelected.initial()).
-                    noneMatch(e -> e.cheaperThan(this))
+                    varIsSelected.initial() &&
+                            to().ins().stream().
+                                    filter(e -> !this.equals(e)).
+                                    filter(e -> e.varIsSelected.initial()).
+                                    noneMatch(e -> e.cheaperThan(this))
             );
             hasInitialValues = true;
         }

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -121,11 +121,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         backward.recordCost();
     }
 
-    void resetInitialValues() {
-        forward.resetInitialValues();
-        backward.resetInitialValues();
-    }
-
     public void initialiseMinimal() {
         forward.setInitialMinimal();
         backward.setInitialMinimal();
@@ -267,12 +262,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             assert recordedCost >= INIT_ZERO;
             planner.optimiser().setObjectiveCoefficient(varIsMinimal, log(1 + recordedCost));
             initialiseMinimalEdgeConstraint();
-        }
-
-        private void resetInitialValues() {
-            varIsSelected.clearInitial();
-            varIsMinimal.clearInitial();
-            hasInitialValues = false;
         }
 
         public void setInitialSelected(boolean selected) {

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -144,13 +144,13 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         private static final AtomicLong nextTieBreaker = new AtomicLong(0);
 
         double cost;
-        double recordedCost;
+        double costLastRecorded;
 
         Directional(VERTEX_DIR_FROM from, VERTEX_DIR_TO to, Encoding.Direction.Edge direction, String symbol) {
             super(from, to, symbol);
             this.planner = from.planner;
             this.direction = direction;
-            this.recordedCost = INIT_ZERO;
+            this.costLastRecorded = INIT_ZERO;
 
             this.isInitialised = false;
 
@@ -202,7 +202,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
 
         private boolean cheaperThan(PlannerEdge.Directional<?, ?> that) {
             assert !this.equals(that);
-            assert recordedCost == cost();
+            assert costLastRecorded == cost();
             if (cost() < that.cost()) {
                 return true;
             } else if (cost() == that.cost()) {
@@ -226,11 +226,11 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         }
 
         private void recordCost() {
-            recordedCost = cost();
+            costLastRecorded = cost();
         }
 
         protected void updateOptimiserCoefficients() {
-            assert recordedCost == cost();
+            assert costLastRecorded == cost();
             planner.optimiser().setObjectiveCoefficient(varIsMinimal, log(1 + cost()));
             initialiseMinimalEdgeConstraint();
         }

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -144,9 +144,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         private final GraphPlanner planner;
         private final Encoding.Direction.Edge direction;
 
-        private boolean didInitialiseVariables;
-        private boolean didInitialiseConstraints;
-        private boolean hasInitialValues;
+        private boolean isInitialised;
 
         private final long tieBreaker;
         private static final AtomicLong nextTieBreaker = new AtomicLong(0);
@@ -162,9 +160,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             this.direction = direction;
             this.recordedCost = INIT_ZERO;
 
-            this.didInitialiseVariables = false;
-            this.didInitialiseConstraints = false;
-            this.hasInitialValues = false;
+            this.isInitialised = false;
 
             this.varPrefix = "edge_var_" + this.toString() + "_";
             this.conPrefix = "edge_con_" + this.toString() + "_";
@@ -179,17 +175,10 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             return direction;
         }
 
-        public boolean didInitialiseVariables() {
-            return didInitialiseVariables;
+        public boolean isInitialised() {
+            return isInitialised;
         }
 
-        public boolean didInitialiseConstraints() {
-            return didInitialiseConstraints;
-        }
-
-        public boolean hasInitialValues() {
-            return hasInitialValues;
-        }
 
         void opposite(Directional<VERTEX_DIR_TO, VERTEX_DIR_FROM> opposite) {
             this.opposite = opposite;
@@ -198,13 +187,9 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         void initialiseVariables() {
             varIsSelected = planner.optimiser().booleanVar(varPrefix + "is_selected");
             varIsMinimal = planner.optimiser().booleanVar(varPrefix + "is_minimal");
-            didInitialiseVariables = true;
         }
 
         void initialiseConstraints() {
-            assert from.didInitialiseVariables();
-            assert to.didInitialiseVariables();
-
             int numVertices = planner.vertices().size();
 
             OptimiserConstraint conIsSelected = planner.optimiser().constraint(1, numVertices, conPrefix + "is_selected");
@@ -217,8 +202,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             conIsMinimal.setCoefficient(varIsMinimal, numAdjacent + 1);
             conIsMinimal.setCoefficient(varIsSelected, -1);
             initialiseMinimalEdgeConstraint();
-
-            didInitialiseConstraints = true;
         }
 
         private void initialiseMinimalEdgeConstraint() {
@@ -278,7 +261,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                                     filter(e -> e.varIsSelected.initial()).
                                     noneMatch(e -> e.cheaperThan(this))
             );
-            hasInitialValues = true;
+            isInitialised = true;
         }
 
         public boolean isEqual() {

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -251,7 +251,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                     varIsSelected.initial() &&
                             iterate(to().ins()).
                                     filter(e -> !this.equals(e)).
-                                    filter(e -> e.varIsSelected.initial()).
+                                    filter(e -> e.from().varOrderNumber.initial() < e.to().varOrderNumber.initial()).
                                     noneMatch(e -> e.cheaperThan(this))
             );
         }

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -116,7 +116,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         backward.recordCost();
     }
 
-    public void initialiseMinimal() {
+    public void setInitialMinimal() {
         forward.setInitialMinimal();
         backward.setInitialMinimal();
     }
@@ -188,7 +188,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             conIsMinimal = planner.optimiser().constraint(0, numAdjacent, conPrefix + "is_minimal");
             conIsMinimal.setCoefficient(varIsMinimal, numAdjacent + 1);
             conIsMinimal.setCoefficient(varIsSelected, -1);
-            initialiseMinimalEdgeConstraint();
         }
 
         private void initialiseMinimalEdgeConstraint() {

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -92,8 +92,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
     }
 
     void initialiseVariables() {
-        forward.opposite(backward);
-        backward.opposite(forward);
         forward.initialiseVariables();
         backward.initialiseVariables();
     }
@@ -152,8 +150,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         double cost;
         double recordedCost;
 
-        private Directional<VERTEX_DIR_TO, VERTEX_DIR_FROM> opposite;
-
         Directional(VERTEX_DIR_FROM from, VERTEX_DIR_TO to, Encoding.Direction.Edge direction, String symbol) {
             super(from, to, symbol);
             this.planner = from.planner;
@@ -177,11 +173,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
 
         public boolean isInitialised() {
             return isInitialised;
-        }
-
-
-        void opposite(Directional<VERTEX_DIR_TO, VERTEX_DIR_FROM> opposite) {
-            this.opposite = opposite;
         }
 
         void initialiseVariables() {

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -216,9 +216,10 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
 
         private boolean cheaperThan(PlannerEdge.Directional<?, ?> that) {
             assert !this.equals(that);
-            if (recordedCost < that.recordedCost) {
+            assert recordedCost == cost();
+            if (cost() < that.cost()) {
                 return true;
-            } else if (recordedCost == that.recordedCost) {
+            } else if (cost() == that.cost()) {
                 return tieBreaker < that.tieBreaker;
             } else {
                 return false;
@@ -243,8 +244,8 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         }
 
         protected void updateOptimiserCoefficients() {
-            assert recordedCost >= INIT_ZERO;
-            planner.optimiser().setObjectiveCoefficient(varIsMinimal, log(1 + recordedCost));
+            assert recordedCost == cost();
+            planner.optimiser().setObjectiveCoefficient(varIsMinimal, log(1 + cost()));
             initialiseMinimalEdgeConstraint();
         }
 

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -101,10 +101,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         backward.initialiseConstraints();
     }
 
-    double cost() {
-        return forward.cost() + backward.cost();
-    }
-
     void computeCost(GraphManager graphMgr) {
         forward.computeCost(graphMgr);
         backward.computeCost(graphMgr);
@@ -158,8 +154,8 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
 
             this.isInitialised = false;
 
-            this.varPrefix = "edge_var_" + this.toString() + "_";
-            this.conPrefix = "edge_con_" + this.toString() + "_";
+            this.varPrefix = "edge_var_" + this + "_";
+            this.conPrefix = "edge_con_" + this + "_";
             this.tieBreaker = nextTieBreaker.getAndIncrement();
         }
 

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -202,10 +202,10 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
 
         private boolean cheaperThan(PlannerEdge.Directional<?, ?> that) {
             assert !this.equals(that);
-            assert costLastRecorded == cost();
-            if (cost() < that.cost()) {
+            assert costLastRecorded == safeCost();
+            if (safeCost() < that.safeCost()) {
                 return true;
-            } else if (cost() == that.cost()) {
+            } else if (safeCost() == that.safeCost()) {
                 return tieBreaker < that.tieBreaker;
             } else {
                 return false;
@@ -221,17 +221,17 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
 
         abstract void computeCost(GraphManager graphMgr);
 
-        public double cost() {
+        public double safeCost() {
             return max(cost, INIT_ZERO);
         }
 
         private void recordCost() {
-            costLastRecorded = cost();
+            costLastRecorded = safeCost();
         }
 
         protected void updateOptimiserCoefficients() {
-            assert costLastRecorded == cost();
-            planner.optimiser().setObjectiveCoefficient(varIsMinimal, log(1 + cost()));
+            assert costLastRecorded == safeCost();
+            planner.optimiser().setObjectiveCoefficient(varIsMinimal, log(1 + safeCost()));
             initialiseMinimalEdgeConstraint();
         }
 

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -91,14 +91,14 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         return backward;
     }
 
-    void createVariables() {
-        forward.createVariables();
-        backward.createVariables();
+    void createOptimiserVariables() {
+        forward.createOptimiserVariables();
+        backward.createOptimiserVariables();
     }
 
-    void createConstraints() {
-        forward.createConstraints();
-        backward.createConstraints();
+    void createOptimiserConstraints() {
+        forward.createOptimiserConstraints();
+        backward.createOptimiserConstraints();
     }
 
     void computeCost(GraphManager graphMgr) {
@@ -116,9 +116,9 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         backward.recordCost();
     }
 
-    public void initialise() {
-        forward.initialise();
-        backward.initialise();
+    public void initialiseOptimiserValues() {
+        forward.initialiseOptimiserValues();
+        backward.initialiseOptimiserValues();
     }
 
     @Override
@@ -171,12 +171,12 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             return isInitialised;
         }
 
-        void createVariables() {
+        void createOptimiserVariables() {
             varIsSelected = planner.optimiser().booleanVar(varPrefix + "is_selected");
             varIsMinimal = planner.optimiser().booleanVar(varPrefix + "is_minimal");
         }
 
-        void createConstraints() {
+        void createOptimiserConstraints() {
             int numVertices = planner.vertices().size();
 
             OptimiserConstraint conIsSelected = planner.optimiser().constraint(1, numVertices, conPrefix + "is_selected");
@@ -235,7 +235,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             initialiseMinimalEdgeConstraint();
         }
 
-        public void initialise() {
+        public void initialiseOptimiserValues() {
             setInitialSelected();
             setInitialMinimal();
             isInitialised = true;

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -46,7 +46,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
     private boolean isInitialised;
 
     double cost;
-    double recordedCost;
+    double costLastRecorded;
 
     OptimiserVariable.Boolean varIsStartingVertex;
     OptimiserVariable.Boolean[] varOrderAssignment;
@@ -56,7 +56,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
         super(identifier);
         this.planner = planner;
         isInitialised = false;
-        recordedCost = INIT_ZERO;
+        costLastRecorded = INIT_ZERO;
     }
 
     abstract void computeCost(GraphManager graphMgr);
@@ -136,12 +136,12 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
     }
 
     protected void updateOptimiserCoefficients() {
-        assert recordedCost == cost();
+        assert costLastRecorded == cost();
         planner.optimiser().setObjectiveCoefficient(varIsStartingVertex, log(1 + cost()));
     }
 
     void recordCost() {
-        recordedCost = cost();
+        costLastRecorded = cost();
     }
 
     boolean validResults() {

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -154,7 +154,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
         for (int i = 0; i < planner.vertices().size(); i++) varOrderAssignment[i].setInitial(order == i);
     }
 
-    void inferStartingVertexFromOrder() {
+    void inferInitialStartingVertexFromOrder() {
         assert varOrderNumber.hasInitial();
         double initialOrder = varOrderNumber.initial();
         varIsStartingVertex.setInitial(iterate(outs()).allMatch(e -> e.to().varOrderNumber.initial() > initialOrder));

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -168,12 +168,6 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
                 && (isEndingVertex() ^ hasOutgoingEdges());
     }
 
-    void resetInitialValues() {
-        varIsStartingVertex.clearInitial();
-        varOrderNumber.clearInitial();
-        for (OptimiserVariable.Boolean b : varOrderAssignment) b.clearInitial();
-    }
-
     void setOrderInitial(int order) {
         varOrderNumber.setInitial(order);
         for (int i = 0; i < planner.vertices().size(); i++) varOrderAssignment[i].setInitial(order == i);

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -65,8 +65,8 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
 
     abstract void computeCost(GraphManager graphMgr);
 
-    public double getCost() {
-        return cost;
+    public double cost() {
+        return max(cost, INIT_ZERO);
     }
 
     public boolean isStartingVertex() {
@@ -162,7 +162,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
     }
 
     void recordCost() {
-        recordedCost = cost;
+        recordedCost = cost();
     }
 
     boolean validResults() {
@@ -239,7 +239,6 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
                     cost = graphMgr.data().stats().thingVertexSum(props().types());
                 }
             }
-            cost = max(cost, INIT_ZERO);
         }
 
         @Override
@@ -280,7 +279,6 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
             } else {
                 cost = graphMgr.schema().stats().typeCount();
             }
-            cost = max(cost, INIT_ZERO);
         }
 
         @Override

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -110,7 +110,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
         loop(edge.backward());
     }
 
-    void createVariables() {
+    void createOptimiserVariables() {
         assert planner != null;
         varIsStartingVertex = planner.optimiser().booleanVar(varPrefix + "is_starting_vertex");
         varOrderNumber = planner.optimiser().intVar(0, planner.vertices().size() - 1, varPrefix + "order_number");
@@ -120,7 +120,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
         }
     }
 
-    void createConstraints() {
+    void createOptimiserConstraints() {
         OptimiserConstraint conIsOrdered = planner.optimiser().constraint(1, 1, conPrefix + "ordered");
         OptimiserConstraint conAssignOrderNumber = planner.optimiser().constraint(0, 0, conPrefix + "assign_order_number");
         conAssignOrderNumber.setCoefficient(varOrderNumber, -1);
@@ -154,7 +154,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
         for (int i = 0; i < planner.vertices().size(); i++) varOrderAssignment[i].setInitial(order == i);
     }
 
-    void initialise() {
+    void initialiseOptimiserValues() {
         assert varOrderNumber.hasInitial();
         double initialOrder = varOrderNumber.initial();
         varIsStartingVertex.setInitial(iterate(outs()).allMatch(e -> e.to().varOrderNumber.initial() > initialOrder));

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -110,7 +110,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
         loop(edge.backward());
     }
 
-    void initialiseVariables() {
+    void createVariables() {
         assert planner != null;
         varIsStartingVertex = planner.optimiser().booleanVar(varPrefix + "is_starting_vertex");
         varOrderNumber = planner.optimiser().intVar(0, planner.vertices().size() - 1, varPrefix + "order_number");
@@ -120,7 +120,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
         }
     }
 
-    void initialiseConstraints() {
+    void createConstraints() {
         OptimiserConstraint conIsOrdered = planner.optimiser().constraint(1, 1, conPrefix + "ordered");
         OptimiserConstraint conAssignOrderNumber = planner.optimiser().constraint(0, 0, conPrefix + "assign_order_number");
         conAssignOrderNumber.setCoefficient(varOrderNumber, -1);
@@ -154,16 +154,11 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
         for (int i = 0; i < planner.vertices().size(); i++) varOrderAssignment[i].setInitial(order == i);
     }
 
-    void inferInitialStartingVertexFromOrder() {
+    void initialise() {
         assert varOrderNumber.hasInitial();
         double initialOrder = varOrderNumber.initial();
         varIsStartingVertex.setInitial(iterate(outs()).allMatch(e -> e.to().varOrderNumber.initial() > initialOrder));
         isInitialised = true;
-    }
-
-    void setOutgoingEdgesInitialValues() {
-        double initialOrder = varOrderNumber.initial();
-        outs().forEach(e -> e.setInitialSelected(e.to().varOrderNumber.initial() > initialOrder));
     }
 
     public PlannerVertex.Thing asThing() {

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -56,7 +56,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
         super(identifier);
         this.planner = planner;
         isInitialised = false;
-        recordedCost = 0.01; // non-zero value for safe division
+        recordedCost = INIT_ZERO;
     }
 
     abstract void computeCost(GraphManager graphMgr);
@@ -136,8 +136,8 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
     }
 
     protected void updateOptimiserCoefficients() {
-        assert !Double.isNaN(recordedCost);
-        planner.optimiser().setObjectiveCoefficient(varIsStartingVertex, log(1 + recordedCost));
+        assert recordedCost == cost();
+        planner.optimiser().setObjectiveCoefficient(varIsStartingVertex, log(1 + cost()));
     }
 
     void recordCost() {

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -149,9 +149,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
         int numIns = ins().size();
         OptimiserConstraint conIsStartingVertex = planner.optimiser().constraint(1, numIns, conPrefix + "is_starting_vertex");
         conIsStartingVertex.setCoefficient(varIsStartingVertex, numIns);
-        for (PlannerEdge.Directional<?, ?> edge: ins()) {
-            conIsStartingVertex.setCoefficient(edge.varIsSelected, 1);
-        }
+        for (PlannerEdge.Directional<?, ?> edge : ins()) conIsStartingVertex.setCoefficient(edge.varIsSelected, 1);
 
         didInitialiseConstraints = true;
     }
@@ -173,13 +171,12 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
     void resetInitialValues() {
         varIsStartingVertex.clearInitial();
         varOrderNumber.clearInitial();
-        for (OptimiserVariable.Boolean b: varOrderAssignment) b.clearInitial();
+        for (OptimiserVariable.Boolean b : varOrderAssignment) b.clearInitial();
     }
 
     void setOrderInitial(int order) {
         varOrderNumber.setInitial(order);
-        for (int i = 0; i < planner.vertices().size(); i++)
-            varOrderAssignment[i].setInitial(order == i);
+        for (int i = 0; i < planner.vertices().size(); i++) varOrderAssignment[i].setInitial(order == i);
     }
 
     void inferStartingVertexFromOrder() {

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -33,6 +33,8 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILL
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.traversal.planner.GraphPlanner.INIT_ZERO;
 import static com.vaticle.typedb.core.traversal.predicate.PredicateOperator.Equality.EQ;
+import static java.lang.Math.log;
+import static java.lang.Math.max;
 
 public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Properties>
         extends TraversalVertex<PlannerEdge.Directional<?, ?>, PROPERTIES> {
@@ -41,43 +43,62 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
 
     private final String varPrefix = "vertex_var_" + id() + "_";
     private final String conPrefix = "vertex_con_" + id() + "_";
-    private boolean isInitialisedVariables;
-    private boolean isInitialisedConstraints;
-    private double costNext;
-    double costLastRecorded;
+    private boolean didInitialiseVariables;
+    private boolean didInitialiseConstraints;
+    private boolean didInitialiseValues;
+
+    double cost;
+    double recordedCost;
+
     OptimiserVariable.Boolean varIsStartingVertex;
-    OptimiserVariable.Boolean varIsEndingVertex;
-    OptimiserVariable.Boolean varHasIncomingEdges;
-    OptimiserVariable.Boolean varHasOutgoingEdges;
+    OptimiserVariable.Boolean[] varOrderAssignment;
+    OptimiserVariable.Integer varOrderNumber;
 
     PlannerVertex(Identifier identifier, @Nullable GraphPlanner planner) {
         super(identifier);
         this.planner = planner;
-        isInitialisedVariables = false;
-        isInitialisedConstraints = false;
-        costLastRecorded = 0.01; // non-zero value for safe division
+        didInitialiseVariables = false;
+        didInitialiseConstraints = false;
+        didInitialiseValues = false;
+        recordedCost = 0.01; // non-zero value for safe division
     }
 
-    abstract void updateObjective(GraphManager graph);
+    abstract void computeCost(GraphManager graphMgr);
+
+    public double getCost() {
+        return cost;
+    }
 
     public boolean isStartingVertex() {
-        return varIsStartingVertex.solutionValue();
+        return varIsStartingVertex.value();
     }
 
     public boolean isEndingVertex() {
-        return varIsEndingVertex.solutionValue();
+        return !hasOutgoingEdges();
     }
 
     public boolean hasIncomingEdges() {
-        return varHasIncomingEdges.solutionValue();
+        return !isStartingVertex();
     }
 
     public boolean hasOutgoingEdges() {
-        return varHasOutgoingEdges.solutionValue();
+        return iterate(outs()).anyMatch(PlannerEdge.Directional::isSelected);
     }
 
-    public boolean isInitialisedVariables() {
-        return isInitialisedVariables;
+    public int getOrder() {
+        return varOrderNumber.value();
+    }
+
+    public boolean didInitialiseVariables() {
+        return didInitialiseVariables;
+    }
+
+    public boolean didInitialiseConstraints() {
+        return didInitialiseConstraints;
+    }
+
+    public boolean didInitialiseValues() {
+        return didInitialiseValues;
     }
 
     void out(PlannerEdge<?, ?> edge) {
@@ -104,58 +125,44 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
     void initialiseVariables() {
         assert planner != null;
         varIsStartingVertex = planner.optimiser().booleanVar(varPrefix + "is_starting_vertex");
-        varIsEndingVertex = planner.optimiser().booleanVar(varPrefix + "is_ending_vertex");
-        varHasIncomingEdges = planner.optimiser().booleanVar(varPrefix + "has_incoming_edges");
-        varHasOutgoingEdges = planner.optimiser().booleanVar(varPrefix + "has_outgoing_edges");
-        isInitialisedVariables = true;
+        varOrderNumber = planner.optimiser().intVar(0, planner.vertices().size() - 1, varPrefix + "order_number");
+        varOrderAssignment = new OptimiserVariable.Boolean[planner.vertices().size()];
+        for (int i = 0; i < planner.vertices().size(); i++) {
+            varOrderAssignment[i] = planner.optimiser().booleanVar(varPrefix + "order_assignment[" + i + "]");
+        }
+        didInitialiseVariables = true;
     }
 
     void initialiseConstraints() {
-        assert ins().stream().allMatch(PlannerEdge.Directional::isInitialisedVariables);
-        assert outs().stream().allMatch(PlannerEdge.Directional::isInitialisedVariables);
-        assert loops().stream().allMatch(PlannerEdge.Directional::isInitialisedVariables);
-        initialiseConstraintsForIncomingEdges();
-        initialiseConstraintsForOutgoingEdges();
-        initialiseConstraintsForVertexFlow();
-        isInitialisedConstraints = true;
+        assert ins().stream().allMatch(PlannerEdge.Directional::didInitialiseVariables);
+        assert outs().stream().allMatch(PlannerEdge.Directional::didInitialiseVariables);
+        assert loops().stream().allMatch(PlannerEdge.Directional::didInitialiseVariables);
+
+        OptimiserConstraint conIsOrdered = planner.optimiser().constraint(1, 1, conPrefix + "ordered");
+        OptimiserConstraint conAssignOrderNumber = planner.optimiser().constraint(0, 0, conPrefix + "assign_order_number");
+        conAssignOrderNumber.setCoefficient(varOrderNumber, -1);
+        for (int i = 0; i < planner.vertices().size(); i++) {
+            conIsOrdered.setCoefficient(varOrderAssignment[i], 1);
+            conAssignOrderNumber.setCoefficient(varOrderAssignment[i], i);
+        }
+
+        int numIns = ins().size();
+        OptimiserConstraint conIsStartingVertex = planner.optimiser().constraint(1, numIns, conPrefix + "is_starting_vertex");
+        conIsStartingVertex.setCoefficient(varIsStartingVertex, numIns);
+        for (PlannerEdge.Directional<?, ?> edge: ins()) {
+            conIsStartingVertex.setCoefficient(edge.varIsSelected, 1);
+        }
+
+        didInitialiseConstraints = true;
     }
 
-    private void initialiseConstraintsForIncomingEdges() {
-        assert !ins().isEmpty();
-        OptimiserConstraint conHasIncomingEdges = planner.optimiser().constraint(0, ins().size() - 1, conPrefix + "has_incoming_edges");
-        conHasIncomingEdges.setCoefficient(varHasIncomingEdges, ins().size());
-        ins().forEach(edge -> conHasIncomingEdges.setCoefficient(edge.varIsSelected, -1));
-    }
-
-    private void initialiseConstraintsForOutgoingEdges() {
-        assert !outs().isEmpty();
-        OptimiserConstraint conHasOutgoingEdges = planner.optimiser().constraint(0, outs().size() - 1, conPrefix + "has_outgoing_edges");
-        conHasOutgoingEdges.setCoefficient(varHasOutgoingEdges, outs().size());
-        outs().forEach(edge -> conHasOutgoingEdges.setCoefficient(edge.varIsSelected, -1));
-    }
-
-    private void initialiseConstraintsForVertexFlow() {
-        OptimiserConstraint conStartOrIncoming = planner.optimiser().constraint(1, 1, conPrefix + "starting_or_incoming");
-        conStartOrIncoming.setCoefficient(varIsStartingVertex, 1);
-        conStartOrIncoming.setCoefficient(varHasIncomingEdges, 1);
-
-        OptimiserConstraint conEndingOrOutgoing = planner.optimiser().constraint(1, 1, conPrefix + "ending_or_outgoing");
-        conEndingOrOutgoing.setCoefficient(varIsEndingVertex, 1);
-        conEndingOrOutgoing.setCoefficient(varHasOutgoingEdges, 1);
-    }
-
-    protected void setObjectiveCoefficient(double cost) {
-        assert !Double.isNaN(cost);
-        if (cost < INIT_ZERO) cost = INIT_ZERO;
-        double exp = planner.edges().size() * planner.costExponentUnit;
-        double coeff = cost * Math.pow(planner.branchingFactor, exp);
-        planner.optimiser().setObjectiveCoefficient(varIsStartingVertex, coeff);
-        costNext = cost;
-        planner.updateCostNext(costLastRecorded, costNext);
+    protected void updateOptimiserCoefficients() {
+        assert !Double.isNaN(recordedCost);
+        planner.optimiser().setObjectiveCoefficient(varIsStartingVertex, log(1 + recordedCost));
     }
 
     void recordCost() {
-        costLastRecorded = costNext;
+        recordedCost = cost;
     }
 
     boolean validResults() {
@@ -163,34 +170,28 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
                 && (isEndingVertex() ^ hasOutgoingEdges());
     }
 
-    void resetInitialValue() {
+    void resetInitialValues() {
         varIsStartingVertex.clearInitial();
-        varIsEndingVertex.clearInitial();
-        varHasIncomingEdges.clearInitial();
-        varHasOutgoingEdges.clearInitial();
+        varOrderNumber.clearInitial();
+        for (OptimiserVariable.Boolean b: varOrderAssignment) b.clearInitial();
     }
 
-    void setStartingVertexInitial() {
-        varIsStartingVertex.setInitial(true);
-        varIsEndingVertex.setInitial(false);
-        varHasIncomingEdges.setInitial(false);
+    void setOrderInitial(int order) {
+        varOrderNumber.setInitial(order);
+        for (int i = 0; i < planner.vertices().size(); i++)
+            varOrderAssignment[i].setInitial(order == i);
     }
 
-    void setEndingVertexInitial() {
-        varIsEndingVertex.setInitial(true);
-        varIsStartingVertex.setInitial(false);
-        varHasOutgoingEdges.setInitial(false);
-        assert varHasIncomingEdges.getInitial() == 1;
+    void inferStartingVertexFromOrder() {
+        assert varOrderNumber.hasInitial();
+        double initialOrder = varOrderNumber.initial();
+        varIsStartingVertex.setInitial(outs().stream().allMatch(e -> e.to().varOrderNumber.initial() > initialOrder));
+        didInitialiseValues = true;
     }
 
-    void setHasOutgoingEdgesInitial() {
-        varHasOutgoingEdges.setInitial(true);
-        varIsEndingVertex.setInitial(false);
-    }
-
-    void setHasIncomingEdgesInitial() {
-        varHasIncomingEdges.setInitial(true);
-        varIsStartingVertex.setInitial(false);
+    void setOutgoingEdgesInitialValues() {
+        double initialOrder = varOrderNumber.initial();
+        outs().forEach(e -> e.setInitialSelected(e.to().varOrderNumber.initial() > initialOrder));
     }
 
     public PlannerVertex.Thing asThing() {
@@ -204,8 +205,10 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
     @Override
     public String toString() {
         String string = super.toString();
-        if (isStartingVertex()) string += " (start)";
-        else if (isEndingVertex()) string += " (end)";
+        if (didInitialiseValues) {
+            if (isStartingVertex()) string += " (start)";
+            else if (isEndingVertex()) string += " (end)";
+        }
         return string;
     }
 
@@ -225,17 +228,18 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
         }
 
         @Override
-        void updateObjective(GraphManager graph) {
+        void computeCost(GraphManager graphMgr) {
             if (props().hasIID()) {
-                setObjectiveCoefficient(1);
+                cost = 1;
             } else {
                 assert !props().types().isEmpty();
                 if (iterate(props().predicates()).anyMatch(p -> p.operator().equals(EQ))) {
-                    setObjectiveCoefficient(props().types().size());
+                    cost = props().types().size();
                 } else {
-                    setObjectiveCoefficient(graph.data().stats().thingVertexSum(props().types()));
+                    cost = graphMgr.data().stats().thingVertexSum(props().types());
                 }
             }
+            cost = max(cost, INIT_ZERO);
         }
 
         @Override
@@ -260,22 +264,23 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
         }
 
         @Override
-        void updateObjective(GraphManager graph) {
+        void computeCost(GraphManager graphMgr) {
             if (!props().labels().isEmpty()) {
-                setObjectiveCoefficient(props().labels().size());
+                cost = props().labels().size();
             } else if (props().isAbstract()) {
-                setObjectiveCoefficient(graph.schema().stats().abstractTypeCount());
+                cost = graphMgr.schema().stats().abstractTypeCount();
             } else if (!props().valueTypes().isEmpty()) {
                 int count = 0;
                 for (Encoding.ValueType valueType : props().valueTypes()) {
-                    count += graph.schema().stats().attTypesWithValueType(valueType);
+                    count += graphMgr.schema().stats().attTypesWithValueType(valueType);
                 }
-                setObjectiveCoefficient(count);
+                cost = count;
             } else if (props().regex().isPresent()) {
-                setObjectiveCoefficient(1);
+                cost = 1;
             } else {
-                setObjectiveCoefficient(graph.schema().stats().typeCount());
+                cost = graphMgr.schema().stats().typeCount();
             }
+            cost = max(cost, INIT_ZERO);
         }
 
         @Override

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -61,7 +61,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
 
     abstract void computeCost(GraphManager graphMgr);
 
-    public double cost() {
+    public double safeCost() {
         return max(cost, INIT_ZERO);
     }
 
@@ -136,12 +136,12 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
     }
 
     protected void updateOptimiserCoefficients() {
-        assert costLastRecorded == cost();
-        planner.optimiser().setObjectiveCoefficient(varIsStartingVertex, log(1 + cost()));
+        assert costLastRecorded == safeCost();
+        planner.optimiser().setObjectiveCoefficient(varIsStartingVertex, log(1 + safeCost()));
     }
 
     void recordCost() {
-        costLastRecorded = cost();
+        costLastRecorded = safeCost();
     }
 
     boolean validResults() {

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -157,7 +157,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
     void inferStartingVertexFromOrder() {
         assert varOrderNumber.hasInitial();
         double initialOrder = varOrderNumber.initial();
-        varIsStartingVertex.setInitial(outs().stream().allMatch(e -> e.to().varOrderNumber.initial() > initialOrder));
+        varIsStartingVertex.setInitial(iterate(outs()).allMatch(e -> e.to().varOrderNumber.initial() > initialOrder));
         isInitialised = true;
     }
 

--- a/traversal/procedure/CombinationProcedure.java
+++ b/traversal/procedure/CombinationProcedure.java
@@ -161,7 +161,7 @@ public class CombinationProcedure {
 
     private ProcedureEdge<?, ?> createOut(ProcedureVertex.Type from, ProcedureVertex.Type to,
                                           StructureEdge<?, ?> structureEdge) {
-        ProcedureEdge<?, ?> edge = ProcedureEdge.of(from, to, structureEdge, -1, true);
+        ProcedureEdge<?, ?> edge = ProcedureEdge.of(from, to, structureEdge, true);
         edge.from().out(edge);
         edge.to().in(edge);
         return edge;
@@ -169,14 +169,14 @@ public class CombinationProcedure {
 
     private ProcedureEdge<?, ?> createIn(ProcedureVertex.Type from, ProcedureVertex.Type to,
                                          StructureEdge<?, ?> structureEdge) {
-        ProcedureEdge<?, ?> edge = ProcedureEdge.of(from, to, structureEdge, -1, false);
+        ProcedureEdge<?, ?> edge = ProcedureEdge.of(from, to, structureEdge, false);
         edge.from().out(edge);
         edge.to().in(edge);
         return edge;
     }
 
     private ProcedureEdge<?, ?> createLoop(ProcedureVertex.Type from, StructureEdge<?, ?> structureEdge) {
-        ProcedureEdge<?, ?> edge = ProcedureEdge.of(from, from, structureEdge, -1, true);
+        ProcedureEdge<?, ?> edge = ProcedureEdge.of(from, from, structureEdge, true);
         edge.from().loop(edge);
         return edge;
     }

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -66,7 +66,6 @@ public class GraphProcedure implements PermutationProcedure {
         Set<PlannerVertex<?>> registeredVertices = new HashSet<>();
         Set<PlannerEdge.Directional<?, ?>> registeredEdges = new HashSet<>();
         planner.vertices().forEach(vertex -> builder.registerVertex(vertex, registeredVertices, registeredEdges));
-        builder.streamlineVertices();
         return builder.build();
     }
 
@@ -187,23 +186,6 @@ public class GraphProcedure implements PermutationProcedure {
         public GraphProcedure build() {
             return new GraphProcedure(vertices.values().stream().sorted(comparing(ProcedureVertex::order))
                     .toArray(ProcedureVertex[]::new));
-        }
-
-        private void streamlineVertices() {
-            Stack<ProcedureVertex<?, ?>> open = new Stack<>();
-            vertices.values().stream().filter(ProcedureVertex::isStartingVertex).forEach(open::add);
-            Set<ProcedureVertex<?, ?>> closed = new HashSet<>();
-
-            int vertexOrder = 0;
-            while (!open.empty()) {
-                ProcedureVertex<?, ?> vertex = open.pop();
-                vertex.setOrder(vertexOrder++);
-                closed.add(vertex);
-                vertex.outs().stream().map(ProcedureEdge::to).distinct().sorted(comparing(v -> -v.ins().size())).filter(
-                        v -> v.ins().stream().map(ProcedureEdge::from).allMatch(closed::contains)
-                ).forEach(open::add);
-            }
-            assert vertexOrder == vertices.size();
         }
 
         private void registerVertex(PlannerVertex<?> plannerVertex, Set<PlannerVertex<?>> registeredVertices,

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -43,7 +43,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.concurrent.producer.Producers.async;

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -18,7 +18,6 @@
 
 package com.vaticle.typedb.core.traversal.procedure;
 
-import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.concurrent.producer.FunctionalProducer;
@@ -39,23 +38,23 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Stack;
 
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.concurrent.producer.Producers.async;
+import static java.util.Comparator.comparing;
 
 public class GraphProcedure implements PermutationProcedure {
 
     private static final Logger LOG = LoggerFactory.getLogger(GraphProcedure.class);
 
     private final ProcedureVertex<?, ?>[] vertices;
-    private ProcedureVertex<?, ?> startVertex;
+    private Set<ProcedureVertex<?, ?>> startVertices;
     private Set<ProcedureVertex<?, ?>> endVertices;
 
     private GraphProcedure(ProcedureVertex<?, ?>[] vertices) {
@@ -67,19 +66,23 @@ public class GraphProcedure implements PermutationProcedure {
         Set<PlannerVertex<?>> registeredVertices = new HashSet<>();
         Set<PlannerEdge.Directional<?, ?>> registeredEdges = new HashSet<>();
         planner.vertices().forEach(vertex -> builder.registerVertex(vertex, registeredVertices, registeredEdges));
-        return builder.orderAndbuild();
+        builder.streamlineVertices();
+        return builder.build();
     }
 
     public ProcedureVertex<?, ?>[] vertices() {
         return vertices;
     }
 
-    public ProcedureVertex<?, ?> startVertex() {
-        if (startVertex == null) {
-            startVertex = iterate(vertices()).filter(ProcedureVertex::isStartingVertex)
-                    .first().orElseThrow(() -> TypeDBException.of(ILLEGAL_STATE));
+    public ProcedureVertex<?, ?> initialVertex() {
+        return vertices[0];
+    }
+
+    public Set<ProcedureVertex<?, ?>> startVertices() {
+        if (startVertices == null) {
+            startVertices = iterate(vertices()).filter(ProcedureVertex::isStartingVertex).toSet();
         }
-        return startVertex;
+        return startVertices;
     }
 
     public Set<ProcedureVertex<?, ?>> endVertices() {
@@ -112,13 +115,13 @@ public class GraphProcedure implements PermutationProcedure {
             LOG.trace(this.toString());
         }
         assertWithinFilterBounds(filter);
-        if (startVertex().id().isRetrievable() && filter.contains(startVertex().id().asVariable().asRetrievable())) {
-            return async(startVertex().iterator(graphMgr, params).map(v ->
+        if (initialVertex().id().isRetrievable() && filter.contains(initialVertex().id().asVariable().asRetrievable())) {
+            return async(initialVertex().iterator(graphMgr, params).map(v ->
                     new GraphIterator(graphMgr, v, this, params, filter).distinct()
             ), parallelisation);
         } else {
             // TODO we can reduce the size of the distinct() set if the traversal engine doesn't overgenerate as much
-            return async(startVertex().iterator(graphMgr, params).map(v ->
+            return async(initialVertex().iterator(graphMgr, params).map(v ->
                     new GraphIterator(graphMgr, v, this, params, filter)
             ), parallelisation).distinct();
         }
@@ -132,14 +135,14 @@ public class GraphProcedure implements PermutationProcedure {
             LOG.trace(this.toString());
         }
         assertWithinFilterBounds(filter);
-        if (startVertex().id().isRetrievable() && filter.contains(startVertex().id().asVariable().asRetrievable())) {
-            return startVertex().iterator(graphMgr, params).flatMap(
+        if (initialVertex().id().isRetrievable() && filter.contains(initialVertex().id().asVariable().asRetrievable())) {
+            return initialVertex().iterator(graphMgr, params).flatMap(
                     // TODO we can reduce the size of the distinct() set if the traversal engine doesn't overgenerate as much
                     sv -> new GraphIterator(graphMgr, sv, this, params, filter).distinct()
             );
         } else {
             // TODO we can reduce the size of the distinct() set if the traversal engine doesn't overgenerate as much
-            return startVertex().iterator(graphMgr, params).flatMap(
+            return initialVertex().iterator(graphMgr, params).flatMap(
                     sv -> new GraphIterator(graphMgr, sv, this, params, filter)
             ).distinct();
         }
@@ -181,29 +184,26 @@ public class GraphProcedure implements PermutationProcedure {
             this.vertices = new HashMap<>();
         }
 
-        // TODO: remove when the query planner orders vertices natively
-        public GraphProcedure orderAndbuild() {
-            return new GraphProcedure(orderedVertices());
-        }
-
         public GraphProcedure build() {
-            return new GraphProcedure(vertices.values().stream().sorted(Comparator.comparing(ProcedureVertex::order))
+            return new GraphProcedure(vertices.values().stream().sorted(comparing(ProcedureVertex::order))
                     .toArray(ProcedureVertex[]::new));
         }
 
-        /**
-         * TODO: this is a compatibility layer to translate edge-ordered procedures into vertex-ordered procedures
-         * we need to remove it once the query planner natively orders vertices instead of edges
-         */
-        private ProcedureVertex<?, ?>[] orderedVertices() {
-            ProcedureVertex<?, ?>[] orderedVertices = new ProcedureVertex[vertices.size()];
-            List<ProcedureVertex<?, ?>> vertexList = iterate(vertices.values()).toList();
-            vertexList.sort(Comparator.comparing(v -> v.lastInEdge() == null ? 0 : v.lastInEdge().order()));
-            for (int i = 0; i < vertexList.size(); i++) {
-                orderedVertices[i] = vertexList.get(i);
-                orderedVertices[i].setOrder(i);
+        private void streamlineVertices() {
+            Stack<ProcedureVertex<?, ?>> open = new Stack<>();
+            vertices.values().stream().filter(ProcedureVertex::isStartingVertex).forEach(open::add);
+            Set<ProcedureVertex<?, ?>> closed = new HashSet<>();
+
+            int vertexOrder = 0;
+            while (!open.empty()) {
+                ProcedureVertex<?, ?> vertex = open.pop();
+                vertex.setOrder(vertexOrder++);
+                closed.add(vertex);
+                vertex.outs().stream().map(ProcedureEdge::to).distinct().sorted(comparing(v -> -v.ins().size())).filter(
+                        v -> v.ins().stream().map(ProcedureEdge::from).allMatch(closed::contains)
+                ).forEach(open::add);
             }
-            return orderedVertices;
+            assert vertexOrder == vertices.size();
         }
 
         private void registerVertex(PlannerVertex<?> plannerVertex, Set<PlannerVertex<?>> registeredVertices,
@@ -211,9 +211,12 @@ public class GraphProcedure implements PermutationProcedure {
             if (registeredVertices.contains(plannerVertex)) return;
             registeredVertices.add(plannerVertex);
             List<PlannerVertex<?>> adjacents = new ArrayList<>();
+
             ProcedureVertex<?, ?> vertex = vertex(plannerVertex);
             if (vertex.isThing()) vertex.asThing().props(plannerVertex.asThing().props());
             else vertex.asType().props(plannerVertex.asType().props());
+            vertex.setOrder(plannerVertex.getOrder());
+
             plannerVertex.outs().forEach(plannerEdge -> {
                 if (!registeredEdges.contains(plannerEdge) && plannerEdge.isSelected()) {
                     registeredEdges.add(plannerEdge);
@@ -324,7 +327,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Type.Sub.Forward forwardSub(
                 ProcedureVertex.Type child, ProcedureVertex.Type parent, boolean isTransitive) {
             ProcedureEdge.Native.Type.Sub.Forward edge =
-                    new ProcedureEdge.Native.Type.Sub.Forward(child, parent, -1, isTransitive);
+                    new ProcedureEdge.Native.Type.Sub.Forward(child, parent, isTransitive);
             registerEdge(edge);
             return edge;
         }
@@ -332,7 +335,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Type.Sub.Backward backwardSub(
                 ProcedureVertex.Type parent, ProcedureVertex.Type child, boolean isTransitive) {
             ProcedureEdge.Native.Type.Sub.Backward edge =
-                    new ProcedureEdge.Native.Type.Sub.Backward(parent, child, -1, isTransitive);
+                    new ProcedureEdge.Native.Type.Sub.Backward(parent, child, isTransitive);
             registerEdge(edge);
             return edge;
         }
@@ -340,7 +343,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Type.Plays.Forward forwardPlays(
                 ProcedureVertex.Type player, ProcedureVertex.Type roleType) {
             ProcedureEdge.Native.Type.Plays.Forward edge =
-                    new ProcedureEdge.Native.Type.Plays.Forward(player, roleType, -1);
+                    new ProcedureEdge.Native.Type.Plays.Forward(player, roleType);
             registerEdge(edge);
             return edge;
         }
@@ -348,7 +351,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Type.Plays.Backward backwardPlays(
                 ProcedureVertex.Type roleType, ProcedureVertex.Type player) {
             ProcedureEdge.Native.Type.Plays.Backward edge =
-                    new ProcedureEdge.Native.Type.Plays.Backward(roleType, player, -1);
+                    new ProcedureEdge.Native.Type.Plays.Backward(roleType, player);
             registerEdge(edge);
             return edge;
         }
@@ -356,7 +359,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Type.Owns.Forward forwardOwns(
                 ProcedureVertex.Type owner, ProcedureVertex.Type att, boolean isKey) {
             ProcedureEdge.Native.Type.Owns.Forward edge =
-                    new ProcedureEdge.Native.Type.Owns.Forward(owner, att, -1, isKey);
+                    new ProcedureEdge.Native.Type.Owns.Forward(owner, att, isKey);
             registerEdge(edge);
             return edge;
         }
@@ -364,31 +367,31 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Type.Owns.Backward backwardOwns(
                 ProcedureVertex.Type att, ProcedureVertex.Type owner, boolean isKey) {
             ProcedureEdge.Native.Type.Owns.Backward edge =
-                    new ProcedureEdge.Native.Type.Owns.Backward(att, owner, -1, isKey);
+                    new ProcedureEdge.Native.Type.Owns.Backward(att, owner, isKey);
             registerEdge(edge);
             return edge;
         }
 
         public ProcedureEdge.Equal forwardEqual(ProcedureVertex.Type from, ProcedureVertex.Type to) {
-            ProcedureEdge.Equal edge = new ProcedureEdge.Equal(from, to, -1, Encoding.Direction.Edge.FORWARD);
+            ProcedureEdge.Equal edge = new ProcedureEdge.Equal(from, to, Encoding.Direction.Edge.FORWARD);
             registerEdge(edge);
             return edge;
         }
 
         public ProcedureEdge.Equal backwardEqual(ProcedureVertex.Type from, ProcedureVertex.Type to) {
-            ProcedureEdge.Equal edge = new ProcedureEdge.Equal(from, to, -1, Encoding.Direction.Edge.BACKWARD);
+            ProcedureEdge.Equal edge = new ProcedureEdge.Equal(from, to, Encoding.Direction.Edge.BACKWARD);
             registerEdge(edge);
             return edge;
         }
 
         public ProcedureEdge.Predicate forwardPredicate(ProcedureVertex.Thing from, ProcedureVertex.Thing to, Predicate.Variable predicate) {
-            ProcedureEdge.Predicate edge = new ProcedureEdge.Predicate(from, to, -1, Encoding.Direction.Edge.FORWARD, predicate);
+            ProcedureEdge.Predicate edge = new ProcedureEdge.Predicate(from, to, Encoding.Direction.Edge.FORWARD, predicate);
             registerEdge(edge);
             return edge;
         }
 
         public ProcedureEdge.Predicate backwardPredicate(ProcedureVertex.Thing from, ProcedureVertex.Thing to, Predicate.Variable predicate) {
-            ProcedureEdge.Predicate edge = new ProcedureEdge.Predicate(from, to, -1, Encoding.Direction.Edge.BACKWARD, predicate);
+            ProcedureEdge.Predicate edge = new ProcedureEdge.Predicate(from, to, Encoding.Direction.Edge.BACKWARD, predicate);
             registerEdge(edge);
             return edge;
         }
@@ -396,7 +399,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Isa.Forward forwardIsa(
                 ProcedureVertex.Thing thing, ProcedureVertex.Type type, boolean isTransitive) {
             ProcedureEdge.Native.Isa.Forward edge =
-                    new ProcedureEdge.Native.Isa.Forward(thing, type, -1, isTransitive);
+                    new ProcedureEdge.Native.Isa.Forward(thing, type, isTransitive);
             registerEdge(edge);
             return edge;
         }
@@ -404,7 +407,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Isa.Backward backwardIsa(
                 ProcedureVertex.Type type, ProcedureVertex.Thing thing, boolean isTransitive) {
             ProcedureEdge.Native.Isa.Backward edge =
-                    new ProcedureEdge.Native.Isa.Backward(type, thing, -1, isTransitive);
+                    new ProcedureEdge.Native.Isa.Backward(type, thing, isTransitive);
             registerEdge(edge);
             return edge;
         }
@@ -412,7 +415,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Type.Relates.Forward forwardRelates(
                 ProcedureVertex.Type relationType, ProcedureVertex.Type roleType) {
             ProcedureEdge.Native.Type.Relates.Forward edge =
-                    new ProcedureEdge.Native.Type.Relates.Forward(relationType, roleType, -1);
+                    new ProcedureEdge.Native.Type.Relates.Forward(relationType, roleType);
             registerEdge(edge);
             return edge;
         }
@@ -420,7 +423,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Type.Relates.Backward backwardRelates(
                 ProcedureVertex.Type roleType, ProcedureVertex.Type relationType) {
             ProcedureEdge.Native.Type.Relates.Backward edge =
-                    new ProcedureEdge.Native.Type.Relates.Backward(roleType, relationType, -1);
+                    new ProcedureEdge.Native.Type.Relates.Backward(roleType, relationType);
             registerEdge(edge);
             return edge;
         }
@@ -428,7 +431,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Thing.Has.Forward forwardHas(
                 ProcedureVertex.Thing owner, ProcedureVertex.Thing attribute) {
             ProcedureEdge.Native.Thing.Has.Forward edge =
-                    new ProcedureEdge.Native.Thing.Has.Forward(owner, attribute, -1);
+                    new ProcedureEdge.Native.Thing.Has.Forward(owner, attribute);
             registerEdge(edge);
             return edge;
         }
@@ -436,7 +439,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Thing.Has.Backward backwardHas(
                 ProcedureVertex.Thing attribute, ProcedureVertex.Thing owner) {
             ProcedureEdge.Native.Thing.Has.Backward edge =
-                    new ProcedureEdge.Native.Thing.Has.Backward(attribute, owner, -1);
+                    new ProcedureEdge.Native.Thing.Has.Backward(attribute, owner);
             registerEdge(edge);
             return edge;
         }
@@ -444,7 +447,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Thing.Relating.Forward forwardRelating(
                 ProcedureVertex.Thing relation, ProcedureVertex.Thing role) {
             ProcedureEdge.Native.Thing.Relating.Forward edge =
-                    new ProcedureEdge.Native.Thing.Relating.Forward(relation, role, -1);
+                    new ProcedureEdge.Native.Thing.Relating.Forward(relation, role);
             registerEdge(edge);
             return edge;
         }
@@ -452,7 +455,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Thing.Relating.Backward backwardRelating(
                 ProcedureVertex.Thing role, ProcedureVertex.Thing relation) {
             ProcedureEdge.Native.Thing.Relating.Backward edge =
-                    new ProcedureEdge.Native.Thing.Relating.Backward(role, relation, -1);
+                    new ProcedureEdge.Native.Thing.Relating.Backward(role, relation);
             registerEdge(edge);
             return edge;
         }
@@ -460,7 +463,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Thing.Playing.Forward forwardPlaying(
                 ProcedureVertex.Thing player, ProcedureVertex.Thing role) {
             ProcedureEdge.Native.Thing.Playing.Forward edge =
-                    new ProcedureEdge.Native.Thing.Playing.Forward(player, role, -1);
+                    new ProcedureEdge.Native.Thing.Playing.Forward(player, role);
             registerEdge(edge);
             return edge;
         }
@@ -468,7 +471,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Thing.Playing.Backward backwardPlaying(
                 ProcedureVertex.Thing role, ProcedureVertex.Thing player) {
             ProcedureEdge.Native.Thing.Playing.Backward edge =
-                    new ProcedureEdge.Native.Thing.Playing.Backward(role, player, -1);
+                    new ProcedureEdge.Native.Thing.Playing.Backward(role, player);
             registerEdge(edge);
             return edge;
         }
@@ -476,7 +479,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Thing.RolePlayer.Forward forwardRolePlayer(
                 ProcedureVertex.Thing relation, ProcedureVertex.Thing player, Set<Label> roleTypes) {
             ProcedureEdge.Native.Thing.RolePlayer.Forward edge =
-                    new ProcedureEdge.Native.Thing.RolePlayer.Forward(relation, player, -1, roleTypes);
+                    new ProcedureEdge.Native.Thing.RolePlayer.Forward(relation, player, roleTypes);
             registerEdge(edge);
             return edge;
         }
@@ -484,7 +487,7 @@ public class GraphProcedure implements PermutationProcedure {
         public ProcedureEdge.Native.Thing.RolePlayer.Backward backwardRolePlayer(
                 ProcedureVertex.Thing player, ProcedureVertex.Thing relation, Set<Label> roleTypes) {
             ProcedureEdge.Native.Thing.RolePlayer.Backward edge =
-                    new ProcedureEdge.Native.Thing.RolePlayer.Backward(player, relation, -1, roleTypes);
+                    new ProcedureEdge.Native.Thing.RolePlayer.Backward(player, relation, roleTypes);
             registerEdge(edge);
             return edge;
         }

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -221,11 +221,7 @@ public abstract class ProcedureEdge<
 
         @Override
         public boolean equals(Object o) {
-            if (super.equals(o)) {
-                ProcedureEdge.Predicate that = (ProcedureEdge.Predicate) o;
-                return predicate.equals(that.predicate);
-            }
-            return false;
+            return super.equals(o) && ((Predicate) o).predicate.equals(predicate);
         }
 
         @Override
@@ -456,11 +452,7 @@ public abstract class ProcedureEdge<
 
                 @Override
                 public boolean equals(Object o) {
-                    if (super.equals(o)) {
-                        ProcedureEdge.Native.Type.Sub that = (ProcedureEdge.Native.Type.Sub) o;
-                        return isTransitive == that.isTransitive;
-                    }
-                    return false;
+                    return super.equals(o) && ((Sub) o).isTransitive == isTransitive;
                 }
 
                 @Override
@@ -535,11 +527,7 @@ public abstract class ProcedureEdge<
 
                 @Override
                 public boolean equals(Object o) {
-                    if (super.equals(o)) {
-                        ProcedureEdge.Native.Type.Owns that = (ProcedureEdge.Native.Type.Owns) o;
-                        return isKey == that.isKey;
-                    }
-                    return false;
+                    return super.equals(o) && ((Owns) o).isKey == isKey;
                 }
 
                 @Override
@@ -1133,7 +1121,7 @@ public abstract class ProcedureEdge<
 
                 @Override
                 public boolean equals(Object o) {
-                    return super.equals(o) && ((ProcedureEdge.Native.Thing.RolePlayer) o).roleTypes.equals(roleTypes);
+                    return super.equals(o) && ((RolePlayer) o).roleTypes.equals(roleTypes);
                 }
 
                 @Override

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -79,25 +79,22 @@ public abstract class ProcedureEdge<
         VERTEX_FROM extends ProcedureVertex<?, ?>, VERTEX_TO extends ProcedureVertex<?, ?>
         > extends TraversalEdge<VERTEX_FROM, VERTEX_TO> {
 
-    private final int order;
     private final Encoding.Direction.Edge direction;
-    private final int hash;
+    protected int hash;
 
-    private ProcedureEdge(VERTEX_FROM from, VERTEX_TO to, int order, Encoding.Direction.Edge direction, String symbol) {
+    private ProcedureEdge(VERTEX_FROM from, VERTEX_TO to, Encoding.Direction.Edge direction, String symbol) {
         super(from, to, symbol);
-        this.order = order;
         this.direction = direction;
-        this.hash = Objects.hash(from(), to(), order, direction);
+        this.hash = Objects.hash(from(), to(), direction, symbol);
     }
 
     public static ProcedureEdge<?, ?> of(ProcedureVertex<?, ?> from, ProcedureVertex<?, ?> to,
                                          PlannerEdge.Directional<?, ?> plannerEdge) {
-        int order = plannerEdge.orderNumber();
         Encoding.Direction.Edge dir = plannerEdge.direction();
         if (plannerEdge.isEqual()) {
-            return new Equal(from, to, order, dir);
+            return new Equal(from, to, dir);
         } else if (plannerEdge.isPredicate()) {
-            return new Predicate(from.asThing(), to.asThing(), order, dir, plannerEdge.asPredicate().predicate());
+            return new Predicate(from.asThing(), to.asThing(), dir, plannerEdge.asPredicate().predicate());
         } else if (plannerEdge.isNative()) {
             return Native.of(from, to, plannerEdge.asNative());
         } else {
@@ -106,14 +103,14 @@ public abstract class ProcedureEdge<
     }
 
     public static ProcedureEdge<?, ?> of(ProcedureVertex<?, ?> from, ProcedureVertex<?, ?> to,
-                                         StructureEdge<?, ?> structureEdge, int order, boolean isForward) {
+                                         StructureEdge<?, ?> structureEdge, boolean isForward) {
         Encoding.Direction.Edge dir = isForward ? FORWARD : BACKWARD;
         if (structureEdge.isEqual()) {
-            return new Equal(from, to, order, dir);
+            return new Equal(from, to, dir);
         } else if (structureEdge.isPredicate()) {
-            return new Predicate(from.asThing(), to.asThing(), order, dir, structureEdge.asPredicate().predicate());
+            return new Predicate(from.asThing(), to.asThing(), dir, structureEdge.asPredicate().predicate());
         } else if (structureEdge.isNative()) {
-            return Native.of(from, to, structureEdge.asNative(), order, isForward);
+            return Native.of(from, to, structureEdge.asNative(), isForward);
         } else {
             throw TypeDBException.of(UNRECOGNISED_VALUE);
         }
@@ -124,10 +121,6 @@ public abstract class ProcedureEdge<
 
     public abstract boolean isClosure(GraphManager graphMgr, Vertex<?, ?> fromVertex, Vertex<?, ?> toVertex,
                                       Traversal.Parameters params);
-
-    public int order() {
-        return order;
-    }
 
     public Encoding.Direction.Edge direction() {
         return direction;
@@ -162,7 +155,7 @@ public abstract class ProcedureEdge<
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ProcedureEdge<?, ?> that = (ProcedureEdge<?, ?>) o;
-        return from().equals(that.from()) && to().equals(that.to()) && direction == that.direction;
+        return from().equals(that.from()) && to().equals(that.to()) && direction == that.direction && symbol.equals(that.symbol);
     }
 
     @Override
@@ -184,8 +177,8 @@ public abstract class ProcedureEdge<
     public static class Equal extends ProcedureEdge<ProcedureVertex<?, ?>, ProcedureVertex<?, ?>> {
 
         Equal(ProcedureVertex<?, ?> from, ProcedureVertex<?, ?> to,
-              int order, Encoding.Direction.Edge direction) {
-            super(from, to, order, direction, TypeQLToken.Predicate.Equality.EQ.toString());
+              Encoding.Direction.Edge direction) {
+            super(from, to, direction, TypeQLToken.Predicate.Equality.EQ.toString());
         }
 
         @Override
@@ -212,7 +205,7 @@ public abstract class ProcedureEdge<
         @Override
         public ProcedureEdge<?, ?> reverse() {
             Encoding.Direction.Edge reverseDirection = direction().isForward() ? BACKWARD : FORWARD;
-            return new Equal(to, from, order(), reverseDirection);
+            return new Equal(to, from, reverseDirection);
         }
     }
 
@@ -220,9 +213,9 @@ public abstract class ProcedureEdge<
 
         private final com.vaticle.typedb.core.traversal.predicate.Predicate.Variable predicate;
 
-        Predicate(ProcedureVertex.Thing from, ProcedureVertex.Thing to, int order,
+        Predicate(ProcedureVertex.Thing from, ProcedureVertex.Thing to,
                   Encoding.Direction.Edge direction, com.vaticle.typedb.core.traversal.predicate.Predicate.Variable predicate) {
-            super(from, to, order, direction, predicate.toString());
+            super(from, to, direction, predicate.toString());
             this.predicate = predicate;
         }
 
@@ -257,18 +250,17 @@ public abstract class ProcedureEdge<
             > extends ProcedureEdge<VERTEX_NATIVE_FROM, VERTEX_NATIVE_TO> {
 
         private Native(VERTEX_NATIVE_FROM from, VERTEX_NATIVE_TO to,
-                       int order, Encoding.Direction.Edge direction, Encoding.Edge encoding) {
-            super(from, to, order, direction, encoding.name());
+                       Encoding.Direction.Edge direction, Encoding.Edge encoding) {
+            super(from, to, direction, encoding.name());
         }
 
         static Native<?, ?> of(ProcedureVertex<?, ?> from, ProcedureVertex<?, ?> to,
                                PlannerEdge.Native.Directional<?, ?> edge) {
             boolean isForward = edge.direction().isForward();
             if (edge.isIsa()) {
-                int orderNumber = edge.orderNumber();
                 boolean isTransitive = edge.asIsa().isTransitive();
-                if (isForward) return new Isa.Forward(from.asThing(), to.asType(), orderNumber, isTransitive);
-                else return new Isa.Backward(from.asType(), to.asThing(), orderNumber, isTransitive);
+                if (isForward) return new Isa.Forward(from.asThing(), to.asType(), isTransitive);
+                else return new Isa.Backward(from.asType(), to.asThing(), isTransitive);
             } else if (edge.isType()) {
                 return Native.Type.of(from.asType(), to.asType(), edge.asType());
             } else if (edge.isThing()) {
@@ -279,15 +271,15 @@ public abstract class ProcedureEdge<
         }
 
         public static ProcedureEdge<?, ?> of(ProcedureVertex<?, ?> from, ProcedureVertex<?, ?> to,
-                                             StructureEdge.Native<?, ?> edge, int order, boolean isForward) {
+                                             StructureEdge.Native<?, ?> edge, boolean isForward) {
             if (edge.encoding().equals(ISA)) {
                 boolean isTransitive = edge.isTransitive();
-                if (isForward) return new Isa.Forward(from.asThing(), to.asType(), order, isTransitive);
-                else return new Isa.Backward(from.asType(), to.asThing(), order, isTransitive);
+                if (isForward) return new Isa.Forward(from.asThing(), to.asType(), isTransitive);
+                else return new Isa.Backward(from.asType(), to.asThing(), isTransitive);
             } else if (edge.encoding().isType()) {
-                return Native.Type.of(from.asType(), to.asType(), edge, order, isForward);
+                return Native.Type.of(from.asType(), to.asType(), edge, isForward);
             } else if (edge.encoding().isThing()) {
-                return Native.Thing.of(from.asThing(), to.asThing(), edge, order, isForward);
+                return Native.Thing.of(from.asThing(), to.asThing(), edge, isForward);
             } else {
                 throw TypeDBException.of(UNRECOGNISED_VALUE);
             }
@@ -299,9 +291,9 @@ public abstract class ProcedureEdge<
 
             final boolean isTransitive;
 
-            private Isa(VERTEX_ISA_FROM from, VERTEX_ISA_TO to, int order,
+            private Isa(VERTEX_ISA_FROM from, VERTEX_ISA_TO to,
                         Encoding.Direction.Edge direction, boolean isTransitive) {
-                super(from, to, order, direction, ISA);
+                super(from, to, direction, ISA);
                 this.isTransitive = isTransitive;
             }
 
@@ -321,8 +313,8 @@ public abstract class ProcedureEdge<
 
             static class Forward extends Isa<ProcedureVertex.Thing, ProcedureVertex.Type> {
 
-                Forward(ProcedureVertex.Thing thing, ProcedureVertex.Type type, int order, boolean isTransitive) {
-                    super(thing, type, order, FORWARD, isTransitive);
+                Forward(ProcedureVertex.Thing thing, ProcedureVertex.Type type, boolean isTransitive) {
+                    super(thing, type, FORWARD, isTransitive);
                 }
 
                 @Override
@@ -343,14 +335,14 @@ public abstract class ProcedureEdge<
 
                 @Override
                 public ProcedureEdge<?, ?> reverse() {
-                    return new Backward(to(), from(), order(), isTransitive);
+                    return new Backward(to(), from(), isTransitive);
                 }
             }
 
             static class Backward extends Isa<ProcedureVertex.Type, ProcedureVertex.Thing> {
 
-                Backward(ProcedureVertex.Type type, ProcedureVertex.Thing thing, int order, boolean isTransitive) {
-                    super(type, thing, order, BACKWARD, isTransitive);
+                Backward(ProcedureVertex.Type type, ProcedureVertex.Thing thing, boolean isTransitive) {
+                    super(type, thing, BACKWARD, isTransitive);
                 }
 
                 @Override
@@ -377,59 +369,58 @@ public abstract class ProcedureEdge<
 
                 @Override
                 public ProcedureEdge<?, ?> reverse() {
-                    return new Forward(to(), from(), order(), isTransitive);
+                    return new Forward(to(), from(), isTransitive);
                 }
             }
         }
 
         public static abstract class Type extends Native<ProcedureVertex.Type, ProcedureVertex.Type> {
 
-            private Type(ProcedureVertex.Type from, ProcedureVertex.Type to, int order,
+            private Type(ProcedureVertex.Type from, ProcedureVertex.Type to,
                          Encoding.Direction.Edge direction, Encoding.Edge encoding) {
-                super(from, to, order, direction, encoding);
+                super(from, to, direction, encoding);
             }
 
             static Native.Type of(ProcedureVertex.Type from, ProcedureVertex.Type to,
                                   PlannerEdge.Native.Type.Directional edge) {
                 boolean isForward = edge.direction().isForward();
                 boolean isTransitive = edge.isTransitive();
-                int orderNumber = edge.orderNumber();
 
                 if (edge.isSub()) {
-                    if (isForward) return new Sub.Forward(from, to, orderNumber, isTransitive);
-                    else return new Sub.Backward(from, to, orderNumber, isTransitive);
+                    if (isForward) return new Sub.Forward(from, to, isTransitive);
+                    else return new Sub.Backward(from, to, isTransitive);
                 } else if (edge.isOwns()) {
-                    if (isForward) return new Owns.Forward(from, to, orderNumber, edge.asOwns().isKey());
-                    else return new Owns.Backward(from, to, orderNumber, edge.asOwns().isKey());
+                    if (isForward) return new Owns.Forward(from, to, edge.asOwns().isKey());
+                    else return new Owns.Backward(from, to, edge.asOwns().isKey());
                 } else if (edge.isPlays()) {
-                    if (isForward) return new Plays.Forward(from, to, orderNumber);
-                    else return new Plays.Backward(from, to, orderNumber);
+                    if (isForward) return new Plays.Forward(from, to);
+                    else return new Plays.Backward(from, to);
                 } else if (edge.isRelates()) {
-                    if (isForward) return new Relates.Forward(from, to, orderNumber);
-                    else return new Relates.Backward(from, to, orderNumber);
+                    if (isForward) return new Relates.Forward(from, to);
+                    else return new Relates.Backward(from, to);
                 } else {
                     throw TypeDBException.of(UNRECOGNISED_VALUE);
                 }
             }
 
             static ProcedureEdge<?, ?> of(ProcedureVertex.Type from, ProcedureVertex.Type to,
-                                          StructureEdge.Native<?, ?> edge, int order, boolean isForward) {
+                                          StructureEdge.Native<?, ?> edge, boolean isForward) {
                 switch (edge.encoding().asType()) {
                     case SUB:
-                        if (isForward) return new Sub.Forward(from, to, order, edge.isTransitive());
-                        else return new Sub.Backward(from, to, order, edge.isTransitive());
+                        if (isForward) return new Sub.Forward(from, to, edge.isTransitive());
+                        else return new Sub.Backward(from, to, edge.isTransitive());
                     case OWNS:
-                        if (isForward) return new Owns.Forward(from, to, order, false);
-                        else return new Owns.Backward(from, to, order, false);
+                        if (isForward) return new Owns.Forward(from, to, false);
+                        else return new Owns.Backward(from, to, false);
                     case OWNS_KEY:
-                        if (isForward) return new Owns.Forward(from, to, order, true);
-                        else return new Owns.Backward(from, to, order, true);
+                        if (isForward) return new Owns.Forward(from, to, true);
+                        else return new Owns.Backward(from, to, true);
                     case PLAYS:
-                        if (isForward) return new Plays.Forward(from, to, order);
-                        else return new Plays.Backward(from, to, order);
+                        if (isForward) return new Plays.Forward(from, to);
+                        else return new Plays.Backward(from, to);
                     case RELATES:
-                        if (isForward) return new Relates.Forward(from, to, order);
-                        else return new Relates.Backward(from, to, order);
+                        if (isForward) return new Relates.Forward(from, to);
+                        else return new Relates.Backward(from, to);
                     default:
                         throw TypeDBException.of(UNRECOGNISED_VALUE);
                 }
@@ -439,9 +430,9 @@ public abstract class ProcedureEdge<
 
                 final boolean isTransitive;
 
-                private Sub(ProcedureVertex.Type from, ProcedureVertex.Type to, int order,
+                private Sub(ProcedureVertex.Type from, ProcedureVertex.Type to,
                             Encoding.Direction.Edge direction, boolean isTransitive) {
-                    super(from, to, order, direction, SUB);
+                    super(from, to, direction, SUB);
                     this.isTransitive = isTransitive;
                 }
 
@@ -455,14 +446,23 @@ public abstract class ProcedureEdge<
                 }
 
                 @Override
+                public boolean equals(Object o) {
+                    if (super.equals(o)) {
+                        ProcedureEdge.Native.Type.Sub that = (ProcedureEdge.Native.Type.Sub) o;
+                        return isTransitive == that.isTransitive;
+                    }
+                    return false;
+                }
+
+                @Override
                 public String toString() {
                     return super.toString() + String.format(" { isTransitive: %s }", isTransitive);
                 }
 
                 static class Forward extends Sub {
 
-                    Forward(ProcedureVertex.Type from, ProcedureVertex.Type to, int order, boolean isTransitive) {
-                        super(from, to, order, FORWARD, isTransitive);
+                    Forward(ProcedureVertex.Type from, ProcedureVertex.Type to, boolean isTransitive) {
+                        super(from, to, FORWARD, isTransitive);
                     }
 
                     @Override
@@ -480,14 +480,14 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Sub.Backward(to, from, order(), isTransitive);
+                        return new Sub.Backward(to, from, isTransitive);
                     }
                 }
 
                 static class Backward extends Sub {
 
-                    Backward(ProcedureVertex.Type from, ProcedureVertex.Type to, int order, boolean isTransitive) {
-                        super(from, to, order, BACKWARD, isTransitive);
+                    Backward(ProcedureVertex.Type from, ProcedureVertex.Type to, boolean isTransitive) {
+                        super(from, to, BACKWARD, isTransitive);
                     }
 
                     @Override
@@ -509,7 +509,7 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Sub.Forward(to, from, order(), isTransitive);
+                        return new Sub.Forward(to, from, isTransitive);
                     }
                 }
             }
@@ -518,10 +518,19 @@ public abstract class ProcedureEdge<
 
                 final boolean isKey;
 
-                private Owns(ProcedureVertex.Type from, ProcedureVertex.Type to, int order,
+                private Owns(ProcedureVertex.Type from, ProcedureVertex.Type to,
                              Encoding.Direction.Edge direction, boolean isKey) {
-                    super(from, to, order, direction, OWNS);
+                    super(from, to, direction, OWNS);
                     this.isKey = isKey;
+                }
+
+                @Override
+                public boolean equals(Object o) {
+                    if (super.equals(o)) {
+                        ProcedureEdge.Native.Type.Owns that = (ProcedureEdge.Native.Type.Owns) o;
+                        return isKey == that.isKey;
+                    }
+                    return false;
                 }
 
                 @Override
@@ -531,8 +540,8 @@ public abstract class ProcedureEdge<
 
                 static class Forward extends Owns {
 
-                    Forward(ProcedureVertex.Type from, ProcedureVertex.Type to, int order, boolean isKey) {
-                        super(from, to, order, FORWARD, isKey);
+                    Forward(ProcedureVertex.Type from, ProcedureVertex.Type to, boolean isKey) {
+                        super(from, to, FORWARD, isKey);
                     }
 
                     @Override
@@ -562,14 +571,14 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Owns.Backward(to, from, order(), isKey);
+                        return new Owns.Backward(to, from, isKey);
                     }
                 }
 
                 static class Backward extends Owns {
 
-                    Backward(ProcedureVertex.Type from, ProcedureVertex.Type to, int order, boolean isKey) {
-                        super(from, to, order, BACKWARD, isKey);
+                    Backward(ProcedureVertex.Type from, ProcedureVertex.Type to, boolean isKey) {
+                        super(from, to, BACKWARD, isKey);
                     }
 
                     @Override
@@ -599,22 +608,22 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Owns.Forward(to, from, order(), isKey);
+                        return new Owns.Forward(to, from, isKey);
                     }
                 }
             }
 
             static abstract class Plays extends Type {
 
-                private Plays(ProcedureVertex.Type from, ProcedureVertex.Type to, int order,
+                private Plays(ProcedureVertex.Type from, ProcedureVertex.Type to,
                               Encoding.Direction.Edge direction) {
-                    super(from, to, order, direction, PLAYS);
+                    super(from, to, direction, PLAYS);
                 }
 
                 static class Forward extends Plays {
 
-                    Forward(ProcedureVertex.Type from, ProcedureVertex.Type to, int order) {
-                        super(from, to, order, FORWARD);
+                    Forward(ProcedureVertex.Type from, ProcedureVertex.Type to) {
+                        super(from, to, FORWARD);
                     }
 
                     @Override
@@ -638,14 +647,14 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Plays.Backward(to, from, order());
+                        return new Plays.Backward(to, from);
                     }
                 }
 
                 static class Backward extends Plays {
 
-                    Backward(ProcedureVertex.Type from, ProcedureVertex.Type to, int order) {
-                        super(from, to, order, BACKWARD);
+                    Backward(ProcedureVertex.Type from, ProcedureVertex.Type to) {
+                        super(from, to, BACKWARD);
                     }
 
                     @Override
@@ -669,22 +678,22 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Plays.Forward(to, from, order());
+                        return new Plays.Forward(to, from);
                     }
                 }
             }
 
             static abstract class Relates extends Type {
 
-                private Relates(ProcedureVertex.Type from, ProcedureVertex.Type to, int order,
+                private Relates(ProcedureVertex.Type from, ProcedureVertex.Type to,
                                 Encoding.Direction.Edge direction) {
-                    super(from, to, order, direction, RELATES);
+                    super(from, to, direction, RELATES);
                 }
 
                 static class Forward extends Relates {
 
-                    Forward(ProcedureVertex.Type from, ProcedureVertex.Type to, int order) {
-                        super(from, to, order, FORWARD);
+                    Forward(ProcedureVertex.Type from, ProcedureVertex.Type to) {
+                        super(from, to, FORWARD);
                     }
 
                     @Override
@@ -707,14 +716,14 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Relates.Backward(to, from, order());
+                        return new Relates.Backward(to, from);
                     }
                 }
 
                 static class Backward extends Relates {
 
-                    Backward(ProcedureVertex.Type from, ProcedureVertex.Type to, int order) {
-                        super(from, to, order, BACKWARD);
+                    Backward(ProcedureVertex.Type from, ProcedureVertex.Type to) {
+                        super(from, to, BACKWARD);
                     }
 
                     @Override
@@ -738,7 +747,7 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Relates.Forward(to, from, order());
+                        return new Relates.Forward(to, from);
                     }
                 }
             }
@@ -746,49 +755,48 @@ public abstract class ProcedureEdge<
 
         static abstract class Thing extends Native<ProcedureVertex.Thing, ProcedureVertex.Thing> {
 
-            private Thing(ProcedureVertex.Thing from, ProcedureVertex.Thing to, int order,
+            private Thing(ProcedureVertex.Thing from, ProcedureVertex.Thing to,
                           Encoding.Direction.Edge direction, Encoding.Edge encoding) {
-                super(from, to, order, direction, encoding);
+                super(from, to, direction, encoding);
             }
 
             static Thing of(ProcedureVertex.Thing from, ProcedureVertex.Thing to,
                             PlannerEdge.Native.Thing.Directional edge) {
                 boolean isForward = edge.direction().isForward();
-                int orderNumber = edge.orderNumber();
 
                 if (edge.isHas()) {
-                    if (isForward) return new Has.Forward(from, to, orderNumber);
-                    else return new Has.Backward(from, to, orderNumber);
+                    if (isForward) return new Has.Forward(from, to);
+                    else return new Has.Backward(from, to);
                 } else if (edge.isPlaying()) {
-                    if (isForward) return new Playing.Forward(from, to, orderNumber);
-                    else return new Playing.Backward(from, to, orderNumber);
+                    if (isForward) return new Playing.Forward(from, to);
+                    else return new Playing.Backward(from, to);
                 } else if (edge.isRelating()) {
-                    if (isForward) return new Relating.Forward(from, to, orderNumber);
-                    else return new Relating.Backward(from, to, orderNumber);
+                    if (isForward) return new Relating.Forward(from, to);
+                    else return new Relating.Backward(from, to);
                 } else if (edge.isRolePlayer()) {
                     PlannerEdge.Native.Thing.RolePlayer.Directional rp = edge.asRolePlayer();
-                    if (isForward) return new RolePlayer.Forward(from, to, orderNumber, rp.roleTypes());
-                    else return new RolePlayer.Backward(from, to, orderNumber, rp.roleTypes());
+                    if (isForward) return new RolePlayer.Forward(from, to, rp.roleTypes());
+                    else return new RolePlayer.Backward(from, to, rp.roleTypes());
                 } else {
                     throw TypeDBException.of(UNRECOGNISED_VALUE);
                 }
             }
 
             static ProcedureEdge<ProcedureVertex.Thing, ProcedureVertex.Thing> of(ProcedureVertex.Thing from, ProcedureVertex.Thing to,
-                                                                                  StructureEdge.Native<?, ?> edge, int order, boolean isForward) {
+                                                                                  StructureEdge.Native<?, ?> edge, boolean isForward) {
                 Encoding.Edge.Thing encoding = edge.encoding().asThing();
                 if (encoding == HAS) {
-                    if (isForward) return new Has.Forward(from, to, order);
-                    else return new Has.Backward(from, to, order);
+                    if (isForward) return new Has.Forward(from, to);
+                    else return new Has.Backward(from, to);
                 } else if (encoding == RELATING) {
-                    if (isForward) return new Relating.Forward(from, to, order);
-                    else return new Relating.Backward(from, to, order);
+                    if (isForward) return new Relating.Forward(from, to);
+                    else return new Relating.Backward(from, to);
                 } else if (encoding == PLAYING) {
-                    if (isForward) return new Playing.Forward(from, to, order);
-                    else return new Playing.Backward(from, to, order);
+                    if (isForward) return new Playing.Forward(from, to);
+                    else return new Playing.Backward(from, to);
                 } else if (encoding == ROLEPLAYER) {
-                    if (isForward) return new RolePlayer.Forward(from, to, order, edge.asRolePlayer().types());
-                    else return new RolePlayer.Backward(from, to, order, edge.asRolePlayer().types());
+                    if (isForward) return new RolePlayer.Forward(from, to, edge.asRolePlayer().types());
+                    else return new RolePlayer.Backward(from, to, edge.asRolePlayer().types());
                 } else {
                     throw TypeDBException.of(UNRECOGNISED_VALUE);
                 }
@@ -823,15 +831,15 @@ public abstract class ProcedureEdge<
 
             static abstract class Has extends Thing {
 
-                private Has(ProcedureVertex.Thing from, ProcedureVertex.Thing to, int order,
+                private Has(ProcedureVertex.Thing from, ProcedureVertex.Thing to,
                             Encoding.Direction.Edge direction) {
-                    super(from, to, order, direction, HAS);
+                    super(from, to, direction, HAS);
                 }
 
                 static class Forward extends Has {
 
-                    Forward(ProcedureVertex.Thing from, ProcedureVertex.Thing to, int order) {
-                        super(from, to, order, FORWARD);
+                    Forward(ProcedureVertex.Thing from, ProcedureVertex.Thing to) {
+                        super(from, to, FORWARD);
                     }
 
                     @Override
@@ -880,14 +888,14 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Backward(to, from, order());
+                        return new Backward(to, from);
                     }
                 }
 
                 static class Backward extends Has {
 
-                    Backward(ProcedureVertex.Thing from, ProcedureVertex.Thing to, int order) {
-                        super(from, to, order, BACKWARD);
+                    Backward(ProcedureVertex.Thing from, ProcedureVertex.Thing to) {
+                        super(from, to, BACKWARD);
                     }
 
                     @Override
@@ -918,22 +926,22 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Forward(to, from, order());
+                        return new Forward(to, from);
                     }
                 }
             }
 
             static abstract class Playing extends Thing {
 
-                private Playing(ProcedureVertex.Thing from, ProcedureVertex.Thing to, int order,
+                private Playing(ProcedureVertex.Thing from, ProcedureVertex.Thing to,
                                 Encoding.Direction.Edge direction) {
-                    super(from, to, order, direction, PLAYING);
+                    super(from, to, direction, PLAYING);
                 }
 
                 static class Forward extends Playing {
 
-                    Forward(ProcedureVertex.Thing from, ProcedureVertex.Thing to, int order) {
-                        super(from, to, order, FORWARD);
+                    Forward(ProcedureVertex.Thing from, ProcedureVertex.Thing to) {
+                        super(from, to, FORWARD);
                     }
 
                     @Override
@@ -951,14 +959,14 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Backward(to, from, order());
+                        return new Backward(to, from);
                     }
                 }
 
                 static class Backward extends Playing {
 
-                    Backward(ProcedureVertex.Thing from, ProcedureVertex.Thing to, int order) {
-                        super(from, to, order, BACKWARD);
+                    Backward(ProcedureVertex.Thing from, ProcedureVertex.Thing to) {
+                        super(from, to, BACKWARD);
                     }
 
                     @Override
@@ -991,22 +999,22 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Forward(to, from, order());
+                        return new Forward(to, from);
                     }
                 }
             }
 
             static abstract class Relating extends Thing {
 
-                private Relating(ProcedureVertex.Thing from, ProcedureVertex.Thing to, int order,
+                private Relating(ProcedureVertex.Thing from, ProcedureVertex.Thing to,
                                  Encoding.Direction.Edge direction) {
-                    super(from, to, order, direction, RELATING);
+                    super(from, to, direction, RELATING);
                 }
 
                 static class Forward extends Relating {
 
-                    Forward(ProcedureVertex.Thing from, ProcedureVertex.Thing to, int order) {
-                        super(from, to, order, FORWARD);
+                    Forward(ProcedureVertex.Thing from, ProcedureVertex.Thing to) {
+                        super(from, to, FORWARD);
                     }
 
                     @Override
@@ -1024,14 +1032,14 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Backward(to, from, order());
+                        return new Backward(to, from);
                     }
                 }
 
                 static class Backward extends Relating {
 
-                    Backward(ProcedureVertex.Thing from, ProcedureVertex.Thing to, int order) {
-                        super(from, to, order, BACKWARD);
+                    Backward(ProcedureVertex.Thing from, ProcedureVertex.Thing to) {
+                        super(from, to, BACKWARD);
                     }
 
                     @Override
@@ -1062,7 +1070,7 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Forward(to, from, order());
+                        return new Forward(to, from);
                     }
 
                 }
@@ -1072,9 +1080,9 @@ public abstract class ProcedureEdge<
 
                 final Set<Label> roleTypes;
 
-                private RolePlayer(ProcedureVertex.Thing from, ProcedureVertex.Thing to, int order,
+                private RolePlayer(ProcedureVertex.Thing from, ProcedureVertex.Thing to,
                                    Encoding.Direction.Edge direction, Set<Label> roleTypes) {
-                    super(from, to, order, direction, ROLEPLAYER);
+                    super(from, to, direction, ROLEPLAYER);
                     this.roleTypes = roleTypes;
                 }
 
@@ -1115,14 +1123,23 @@ public abstract class ProcedureEdge<
                 }
 
                 @Override
+                public boolean equals(Object o) {
+                    if (super.equals(o)) {
+                        ProcedureEdge.Native.Thing.RolePlayer that = (ProcedureEdge.Native.Thing.RolePlayer) o;
+                        return roleTypes.equals(that.roleTypes);
+                    }
+                    return false;
+                }
+
+                @Override
                 public String toString() {
                     return super.toString() + String.format(" { roleTypes: %s }", roleTypes);
                 }
 
                 static class Forward extends RolePlayer {
 
-                    Forward(ProcedureVertex.Thing from, ProcedureVertex.Thing to, int order, Set<Label> roleTypes) {
-                        super(from, to, order, FORWARD, roleTypes);
+                    Forward(ProcedureVertex.Thing from, ProcedureVertex.Thing to, Set<Label> roleTypes) {
+                        super(from, to, FORWARD, roleTypes);
                     }
 
                     @Override
@@ -1190,14 +1207,14 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Backward(to, from, order(), roleTypes);
+                        return new Backward(to, from, roleTypes);
                     }
                 }
 
                 static class Backward extends RolePlayer {
 
-                    Backward(ProcedureVertex.Thing from, ProcedureVertex.Thing to, int order, Set<Label> roleTypes) {
-                        super(from, to, order, BACKWARD, roleTypes);
+                    Backward(ProcedureVertex.Thing from, ProcedureVertex.Thing to, Set<Label> roleTypes) {
+                        super(from, to, BACKWARD, roleTypes);
                     }
 
                     @Override
@@ -1259,7 +1276,7 @@ public abstract class ProcedureEdge<
 
                     @Override
                     public ProcedureEdge<?, ?> reverse() {
-                        return new Forward(to, from, order(), roleTypes);
+                        return new Forward(to, from, roleTypes);
                     }
                 }
             }

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -80,7 +80,7 @@ public abstract class ProcedureEdge<
         > extends TraversalEdge<VERTEX_FROM, VERTEX_TO> {
 
     private final Encoding.Direction.Edge direction;
-    protected int hash;
+    private final int hash;
 
     private ProcedureEdge(VERTEX_FROM from, VERTEX_TO to, Encoding.Direction.Edge direction, String symbol) {
         super(from, to, symbol);
@@ -217,6 +217,15 @@ public abstract class ProcedureEdge<
                   Encoding.Direction.Edge direction, com.vaticle.typedb.core.traversal.predicate.Predicate.Variable predicate) {
             super(from, to, direction, predicate.toString());
             this.predicate = predicate;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (super.equals(o)) {
+                ProcedureEdge.Predicate that = (ProcedureEdge.Predicate) o;
+                return predicate.equals(that.predicate);
+            }
+            return false;
         }
 
         @Override

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -85,7 +85,7 @@ public abstract class ProcedureEdge<
     private ProcedureEdge(VERTEX_FROM from, VERTEX_TO to, Encoding.Direction.Edge direction, String symbol) {
         super(from, to, symbol);
         this.direction = direction;
-        this.hash = Objects.hash(from(), to(), direction, symbol);
+        this.hash = Objects.hash(from(), to(), direction);
     }
 
     public static ProcedureEdge<?, ?> of(ProcedureVertex<?, ?> from, ProcedureVertex<?, ?> to,
@@ -213,8 +213,8 @@ public abstract class ProcedureEdge<
 
         private final com.vaticle.typedb.core.traversal.predicate.Predicate.Variable predicate;
 
-        Predicate(ProcedureVertex.Thing from, ProcedureVertex.Thing to,
-                  Encoding.Direction.Edge direction, com.vaticle.typedb.core.traversal.predicate.Predicate.Variable predicate) {
+        Predicate(ProcedureVertex.Thing from, ProcedureVertex.Thing to, Encoding.Direction.Edge direction,
+                  com.vaticle.typedb.core.traversal.predicate.Predicate.Variable predicate) {
             super(from, to, direction, predicate.toString());
             this.predicate = predicate;
         }
@@ -1133,11 +1133,7 @@ public abstract class ProcedureEdge<
 
                 @Override
                 public boolean equals(Object o) {
-                    if (super.equals(o)) {
-                        ProcedureEdge.Native.Thing.RolePlayer that = (ProcedureEdge.Native.Thing.RolePlayer) o;
-                        return roleTypes.equals(that.roleTypes);
-                    }
-                    return false;
+                    return super.equals(o) && ((ProcedureEdge.Native.Thing.RolePlayer) o).roleTypes.equals(roleTypes);
                 }
 
                 @Override

--- a/traversal/procedure/ProcedureVertex.java
+++ b/traversal/procedure/ProcedureVertex.java
@@ -151,7 +151,6 @@ public abstract class ProcedureVertex<
 
         @Override
         public Forwardable<? extends ThingVertex, Order.Asc> iterator(GraphManager graphMgr, Traversal.Parameters parameters) {
-//            assert isStartingVertex();
             if (props().hasIID()) return iterateAndFilterFromIID(graphMgr, parameters);
             else return iterateAndFilterFromTypes(graphMgr, parameters);
         }

--- a/traversal/procedure/ProcedureVertex.java
+++ b/traversal/procedure/ProcedureVertex.java
@@ -63,7 +63,6 @@ public abstract class ProcedureVertex<
         > extends TraversalVertex<ProcedureEdge<?, ?>, PROPERTIES> {
 
     private int order;
-    private ProcedureEdge<?, ?> lastInEdge;
     private List<ProcedureEdge<?, ?>> orderedOuts;
     private Set<ProcedureEdge<?, ?>> transitiveOuts;
 
@@ -73,23 +72,8 @@ public abstract class ProcedureVertex<
 
     public abstract Forwardable<? extends VERTEX, Order.Asc> iterator(GraphManager graphMgr, Traversal.Parameters parameters);
 
-    @Override
-    public void in(ProcedureEdge<?, ?> edge) {
-        super.in(edge);
-        if (lastInEdge == null || edge.order() > lastInEdge.order()) lastInEdge = edge;
-    }
-
-    /**
-     * TODO:
-     *  after query planning, we can multiple starting vertices and we'll have to distinguish the start
-     *  versus vertices without in edges
-     */
     public boolean isStartingVertex() {
-        return order() == 0;
-    }
-
-    ProcedureEdge<?, ?> lastInEdge() {
-        return lastInEdge;
+        return ins().size() == 0;
     }
 
     public Thing asThing() {
@@ -167,7 +151,7 @@ public abstract class ProcedureVertex<
 
         @Override
         public Forwardable<? extends ThingVertex, Order.Asc> iterator(GraphManager graphMgr, Traversal.Parameters parameters) {
-            assert isStartingVertex();
+//            assert isStartingVertex();
             if (props().hasIID()) return iterateAndFilterFromIID(graphMgr, parameters);
             else return iterateAndFilterFromTypes(graphMgr, parameters);
         }
@@ -321,7 +305,7 @@ public abstract class ProcedureVertex<
 
         @Override
         public Forwardable<? extends TypeVertex, Order.Asc> iterator(GraphManager graphMgr, Traversal.Parameters parameters) {
-            assert isStartingVertex() && id().isVariable();
+            assert id().isVariable();
             Forwardable<TypeVertex, Order.Asc> iterator = null;
 
             if (!props().labels().isEmpty()) iterator = iterateLabels(graphMgr);

--- a/traversal/procedure/VertexProcedure.java
+++ b/traversal/procedure/VertexProcedure.java
@@ -54,7 +54,7 @@ public class VertexProcedure implements PermutationProcedure {
         if (procedureVertex.isType()) procedureVertex.asType().props(structureVertex.asType().props());
         else procedureVertex.asThing().props(structureVertex.asThing().props());
         for (StructureEdge<?, ?> structureEdge : structureVertex.loops()) {
-            ProcedureEdge<?, ?> edge = ProcedureEdge.of(procedureVertex, procedureVertex, structureEdge, -1, true);
+            ProcedureEdge<?, ?> edge = ProcedureEdge.of(procedureVertex, procedureVertex, structureEdge, true);
             procedureVertex.loop(edge);
         }
         return new VertexProcedure(procedureVertex);


### PR DESCRIPTION
## What is the goal of this PR?

We implement a new formulation of the optimisation problem at the heart of query planning that allows the new traversal algorithm to start from multiple points in the query graph. The new query planner also takes into account the specifics of the traversal engine to directly optimise the expected computational costs of traversal.

## What are the changes implemented in this PR?

### Summary

The new vertex-ordering query planner places no restriction on the number of starting vertices to allow the new traversal engine to fully leverage the intersection iterators. The bulk of the meaningful change is contained in GraphPlanner and PlannerEdge/Vertex. This change leads to minor tweaks in GraphProcedure and GraphIterator that allow us to maintain compatibility between the classes.

The linear solver was also switched from the mixed-integer (that is, mixing integer and floating-point variables) SCIP mode to an integer SAT mode, which is optimised around all the variables and coefficients being integer valued, and as such allows the solver to arrive at a better or optimal solution faster.

### Query Planner

The new query planner attempts to directly estimate the number of database operations performed during traversal for a given query plan and minimizes that function. 

The traversal is performed as follows. For each value in the traversal procedure, the number of values we expect to hit every time we enter it is estimated to be either the minimum among the traversal cost of its incoming edges, or, if it has no incoming edges, the estimated size of the vertex itself. As the traversal is performed in an ordered fashion, the number of times we enter a vertex—and, therefore, the number of times we open an iterator into it and iterate through its values—depends straightforwardly on all the vertices we have visited before.

As an illustration, consider a diamond query graph with a given ordering.

```
   0
 ╱   ╲
1  —  2
 ╲   ╱
   3
```

Its traversal, in pseudocode, is performed like so:
```
i0 := iterate(0, {})
for v0 in i0:
    i1 := iterate(1, {v0})
    for v1 in i1:
        i2 := iterate(2, {v0, v1})
        for v2 in i2:
            i3 := iterate(3, {v1, v2})
            for v3 in i3:
                emit(v0, v1, v2, v3)
```

Let α(_v_) be the size of the vertex _v_, and β(_v_, _w_) be the number of values in _w_ that we expect to match for each value of the vertex _v_. Here is that same snippet, with each loop now annotated with the expected number of iterations:

```
i0 := iterate(0, {})
for v0 in i0:                           # α(0) iterations
    i1 := iterate(1, {v0})
    for v1 in i1:                       # β(0, 1) iterations
        i2 := iterate(2, {v0, v1})
        for v2 in i2:                   # min(β(0, 2), β(1, 2)) iterations
            i3 := iterate(3, {v1, v2})
            for v3 in i3:               # min(β(1, 3), β(2, 3)) iterations
                emit(v0, v1, v2, v3)
```

Note: we take minimum of βs, because the resulting set of values in a vertex is an intersection of the sets produced by all incoming edges, which has cardinality of at most min(β,..).

We will omit the parentheses in the α and β notation from this point on to improve legibility in the formulae.

It is easy to see that the number of iterators we create (or reset) in the previous snippet is

`seeks  = 1 + α0(1 + β01(1 + min(β02, β12)))`,

and the number of times we advance an iterator is 

`nexts  = α0(1 + β01(1 + min(β02, β12)(1 + min(β13, β23))))`.

Opening the brackets reveals that the difference between the two values is `α0 β01 min(β02, β12) min(β13, β23) - 1`. While seeks are significantly (5x to 10x) more expensive than nexts, optimising just them loses information on the cost of traversing the end vertices which will lead to the planner favouring expensive bipartite plans with as many ending vertices as possible. A simple solution therefore is to optimise the number of times the storage iterators are advanced. A more complex set of constraints taking that difference into account can be implemented in the future if needed.

To recap, so far the function we'd like to optimise looks like `α0(1 + β01(1 + min(β02, β12)(1 + min(β13, β23))))`. This is, however, not easily representable as a linear combination of some variables. The route we take is to instead minimize the function `(1 + α0) (1 + β01) (1 + min(β02, β12)) (1 + min(β13, β23))` (note the placement of parentheses). This formula strictly overestimates the number of operations performed.

This function generalizes to 

Π{_v_ ∈ S} (1 + α(_v_)) * Π{_v_ ∈ V}(1 + min({β(_x_, _v_): edge(_x_, _v_) is selected}))

where S is the set of starting vertices, V is the set of all vertices, and minimum of an empty set is defined to be 0.

Taking the natural logarithm of this expressions transforms the product into a sum of logarithms, which can be represented as a linear combination of boolean variables:

Σ{_v_ ∈ V} (log(1 + α(_v_)) * _v_:isStartingVertex) + Σ{_e_ ∈ E} (log(1 + β(_e_)) * _e_:isMinimal)

where:
* V is the set of all vertices,
* E is the set of all edges,
* β(_e_) is defined analogously to β(_v_, _w_) above (this accounts for edge multiplicity as well),
* _v_:isStartingVertex is true iff _v_ has no incoming edges,
* _e_:isMinimal is true iff _e_ is selected by the plan, and its cost is the lowest among all the incoming edges of its destination vertex.

This is the objective function of the new planner. The constraints serve to infer the values of these boolean variables from an ordering of the vertices.

### Performance measurements

The two commits we compare in this section are
* ec3b63054, which is exactly equivalent to master, but for the collection of the RocksDB usage statistics,
* a155d32b7, the latest commit in this PR at the time of measurement.

The main criterion we consider is the number of RocksDB operations, which we call here seeks and nexts. Timings are given as an intuitive reference only.

#### typedb-benchmark

The benchmark was run only once for each build. This was not intended as a true performance comparison, but as a smoke test, to make sure that the new planner does not degrage the server's performance.

With the build on current master, the simulation ran for 15 minutes and 45 seconds, performing 44 million seeks and 44 million nexts. 

With the new planner, the simulation ran for just over 12 minutes, performing 58 million seeks and 40 million nexts.

#### Complex queries (see #6550)

Each of the two queries—with and without attribute comparison—was run several times. After each query the statistics were collected and the server was restarted in order to purge all caches.

Both versions performed comparably on the query without attribute comparisons, performing around 3000 seeks and 2700 nexts and finishing within 600 to 700 ms.

On the query _with_ attribute comparisons, the version on master performed erratically, taking from 1 to 5 seconds to complete. It performed anywhere from 80'000 seeks, 300'000 nexts to 800'000 seeks, 600'000 nexts depending on the run. In contrast, the version in this PR performed around 3200 seeks and 10'000 next run after run, performance comparable to that of the query with no attribute comparisons.

### Smaller changes

* Improvements to `Optimiser`:
  * QoL improvements: native retrieval of the initial value, optimiser agnostic `value` retrieval;
  * allow to change constraints between optimiser passes;
  * bugfix: don't reset the model hint after first optimiser pass.
* Streamlined `GraphPlanner`:
  * easier to follow cost computation path:
    * costs computed separately from setting the objective function coefficients;
    * no back and forth calls between GraphPlanner and PlannerEdge/Vertex;
  * simplified value initialisation to a method;
  * methods reordered for readability.
* Stricter equality comparisons between `Identifier`s. 
* Stricter equality comparisons between `ProcedureEdge`s now that we can't rely on `order` for disambiguation. 