### PR TITLE
Improve negative-cycle detection during rule-validation

### DIFF
--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -130,10 +130,6 @@ public class LogicManager {
     }
 
     private void validateCyclesThroughNegations(ConceptManager conceptMgr, LogicManager logicMgr) {
-        // Problem: When a derivation of an inferred concept contains its own negation.
-        // Tracking this at runtime is impractical - statically detect & disallow.
-        // Detect: A cycle which passes through atleast one negation.
-        //      Equivalently - a cycle starting from a negated concept in a rule.
         Set<Rule> negationRulesTriggeringRules = logicMgr.rulesWithNegations()
                 .filter(rule -> !rule.condition().negatedConcludablesTriggeringRules(conceptMgr, logicMgr).isEmpty())
                 .toSet();
@@ -152,9 +148,7 @@ public class LogicManager {
                     Set<RuleDependency> recursive = ruleDependencies(dependency.recursiveRule, conceptMgr, logicMgr);
                     iterate(recursive)
                             .filter(rule -> !visitedDependentRules.containsKey(rule.recursiveRule))
-                            .forEachRemaining(ruleDependency -> {
-                                frontier.add(ruleDependency);
-                            });
+                            .forEachRemaining(frontier::add);
                 }
             }
         }

--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -151,10 +151,10 @@ public class LogicManager {
                 } else {
                     Set<RuleDependency> recursive = ruleDependencies(dependency.recursiveRule, conceptMgr, logicMgr);
                     iterate(recursive)
-                        .filter(rule -> !visitedDependentRules.containsKey(rule.recursiveRule))
-                        .forEachRemaining( ruleDependency -> {
-                            frontier.add(ruleDependency);
-                        });
+                            .filter(rule -> !visitedDependentRules.containsKey(rule.recursiveRule))
+                            .forEachRemaining(ruleDependency -> {
+                                frontier.add(ruleDependency);
+                            });
                 }
             }
         }
@@ -162,7 +162,7 @@ public class LogicManager {
 
     private Set<RuleDependency> ruleDependencies(Rule rule, ConceptManager conceptMgr, LogicManager logicMgr) {
         return link(iterate(rule.condition().concludablesTriggeringRules(conceptMgr, logicMgr)),
-                    iterate(rule.condition().negatedConcludablesTriggeringRules(conceptMgr, logicMgr)))
+                iterate(rule.condition().negatedConcludablesTriggeringRules(conceptMgr, logicMgr)))
                 .flatMap(concludable -> concludable.getApplicableRules(conceptMgr, logicMgr))
                 .map(recursiveRule -> RuleDependency.of(recursiveRule, rule)).toSet();
     }


### PR DESCRIPTION
## What is the goal of this PR?
The part of rule validation which prevents negative cycles (validateRulesThroughNegativeCycles) currently:
1.  Hangs on rule-commit in certain situations because of an infinite loop (#6500)
2. Falsely flags rules without negative cycles (#6599)

This PR fixes both.

## What are the changes implemented in this PR?
When traversing the dependency tree, the set of visited nodes was tracked using the valueSet of a back-pointer map. Duplicate keys caused an overwrite of certain nodes, allowing infinite looping. This is fixed by using the keyset.

Any cycle involving a rule containing negated concludables was flagged. This was narrowed down to only flag rules where the cycle starts at a negated concludable.

- fixes #6500 
- fixes #6599 
