### PR TITLE
Fix erroneous session timeouts

### DIFF
--- a/server/SessionService.java
+++ b/server/SessionService.java
@@ -56,10 +56,6 @@ public class SessionService implements AutoCloseable {
         startIdleTimeout();
     }
 
-    private synchronized void startIdleTimeout() {
-        idleTimeoutTask = scheduled().schedule(this::idleTimeout, options.sessionIdleTimeoutMillis(), MILLISECONDS);
-    }
-
     void register(TransactionService transactionSvc) {
         try {
             accessLock.readLock().lock();
@@ -103,12 +99,16 @@ public class SessionService implements AutoCloseable {
     }
 
     private synchronized void mayStartIdleTimeout() {
-        if (isOpen() && transactionServices.isEmpty() && !idleTimeoutActive()) {
+        if (isOpen() && transactionServices.isEmpty() && !isIdleTimeoutActive()) {
             startIdleTimeout();
         }
     }
 
-    private boolean idleTimeoutActive() {
+    private synchronized void startIdleTimeout() {
+        idleTimeoutTask = scheduled().schedule(this::idleTimeout, options.sessionIdleTimeoutMillis(), MILLISECONDS);
+    }
+
+    private boolean isIdleTimeoutActive() {
         return !idleTimeoutTask.isDone();
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We fix a bug which allowed session idle timeouts to trigger unexpectedly.

## What are the changes implemented in this PR?

If `mayStartIdleTimeout()` was called at the same time in two different threads, as long as the session had no open transactions, two timeouts were scheduled. The object only holds on to one reference though, so if a new transaction is opened, only one future is cancelled. If, when the timer runs out, no transactions happen to be open, the other future—which could never be cancelled—would close the session. From the outside that looks like occasionally the timeout triggers immediately (within milliseconds) after the last transaction is closed.

We now refuse to schedule a timeout if one is already scheduled.