### PR TITLE
Correctly add RocksDB JAR to the distribution

### DIFF
--- a/server/BUILD
+++ b/server/BUILD
@@ -147,6 +147,13 @@ java_binary( # TODO: this target should not be needed if :server-deps-windows ca
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-server-bin-deps:{pom_version}"],
 )
 
+java_binary( # TODO: this target should not be needed if :server-deps-prod can depend directly on @maven//:org_rocksdb_rocksdbjni (lib)
+    name = "server-bin-deps-prod",
+    main_class = "com.vaticle.typedb.core.server.TypeDBServer",
+    runtime_deps = ["@maven//:org_rocksdb_rocksdbjni"],
+    tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-server-bin-deps-prod:{pom_version}"],
+)
+
 java_deps(
     name = "server-deps-mac",
     target = ":server-bin-deps-mac",
@@ -182,7 +189,7 @@ java_deps(
 
 java_deps(
     name = "server-deps-prod",
-    target = "@maven//:org_rocksdb_rocksdbjni",
+    target = ":server-bin-deps-prod",
     java_deps_root = "server/lib/prod/",
     visibility = ["//:__pkg__"],
     maven_name = True,


### PR DESCRIPTION
## What is the goal of this PR?

We updated our distribution targets to ensure the RocksDB JAR is correctly added.

## What are the changes implemented in this PR?

The RocksDB JAR is added to the output distribution via its own `java_deps` target, named `//server:server-deps-prod`. `java_deps` used to package both the `data_runfiles` and `files` of the `java_library` and `java_binary` targets passed to it. This was largely superfluous, as when called on a `java_binary`, `data_runfiles` would contain all necessary files. But `:server-deps-prod` was incidentally working because of it.

To fix it, we've introduced a `java_binary` target, `:server-bin-deps-prod`, in line with our other uses of `java_deps` in this repo (e.g: `server-bin-deps-mac`.