### PR TITLE
Pass conjunction bounds to reasoner's planner

### DIFF
--- a/reasoner/controller/ConditionController.java
+++ b/reasoner/controller/ConditionController.java
@@ -54,7 +54,7 @@ public class ConditionController extends ConjunctionController<
     protected Processor createProcessorFromDriver(Driver<Processor> processorDriver,
                                                           ConceptMap bounds) {
         return new Processor(
-                processorDriver, driver(), processorContext(), bounds, plan(),
+                processorDriver, driver(), processorContext(), bounds, plan(bounds.concepts().keySet()),
                 () -> Processor.class.getSimpleName() + "(pattern: " + condition.conjunction() + ", bounds: " + bounds + ")"
         );
     }

--- a/reasoner/controller/ConjunctionController.java
+++ b/reasoner/controller/ConjunctionController.java
@@ -108,9 +108,9 @@ public abstract class ConjunctionController<
 
     abstract Set<Concludable> concludablesTriggeringRules();
 
-    List<Resolvable<?>> plan() {
+    List<Resolvable<?>> plan(Set<Variable.Retrievable> boundVariables) {
         if (plan == null) {
-            plan = Planner.plan(resolvables, new HashMap<>(), set());
+            plan = Planner.plan(resolvables, new HashMap<>(), boundVariables);
             plan.addAll(negateds);
         }
         return plan;

--- a/reasoner/controller/NestedConjunctionController.java
+++ b/reasoner/controller/NestedConjunctionController.java
@@ -52,7 +52,7 @@ public class NestedConjunctionController extends ConjunctionController<
             ConceptMap bounds
     ) {
         return new NestedConjunctionProcessor(
-                processorDriver, driver(), processorContext(), bounds, plan(),
+                processorDriver, driver(), processorContext(), bounds, plan(bounds.concepts().keySet()),
                 () -> NestedConjunctionProcessor.class.getSimpleName() + "(pattern: " + conjunction + ", bounds: " + bounds + ")"
         );
     }

--- a/reasoner/controller/RootConjunctionController.java
+++ b/reasoner/controller/RootConjunctionController.java
@@ -58,7 +58,7 @@ public class RootConjunctionController
     @Override
     protected Processor createProcessorFromDriver(Driver<Processor> processorDriver, ConceptMap bounds) {
         return new Processor(
-                processorDriver, driver(), processorContext(), bounds, plan(), filter, explain, reasonerConsumer,
+                processorDriver, driver(), processorContext(), bounds, plan(bounds.concepts().keySet()), filter, explain, reasonerConsumer,
                 () -> Processor.class.getSimpleName() + "(pattern:" + conjunction + ", bounds: " + bounds + ")"
         );
     }


### PR DESCRIPTION
The current setup does not pass the information on which variables are bound to the reasoner Planner. This leads to create inefficient plans. Prior to 2.10, the bounds were indeed passed to the planner. 

## What is the goal of this PR?
Allow the reasoner planner to consider which variables are bound while planning.

## What are the changes implemented in this PR?
All Controllers pass the set of bound variables to the reasoner planner. 

Should fix #6597 