### PR TITLE
Update TypeDB runner

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -106,17 +106,17 @@ build:
         bazel test //test/behaviour/reasoner/tests/variable_roles:test --test_output=streamed
     test-assembly-linux-targz:
       image: vaticle-ubuntu-21.04
-#      filter:
-#        owner: vaticle
-#        branch: master
+      filter:
+        owner: vaticle
+        branch: master
       dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-match, test-behaviour-writable, test-behaviour-definable, test-behaviour-reasoner]
       command: |
         bazel test //test/assembly:assembly --test_output=streamed
     test-assembly-docker:
       image: vaticle-ubuntu-21.04
-#      filter:
-#        owner: vaticle
-#        branch: master
+      filter:
+        owner: vaticle
+        branch: master
       dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-match, test-behaviour-writable, test-behaviour-definable, test-behaviour-reasoner]
       command: |
         bazel test //test/assembly:docker --test_output=streamed
@@ -134,9 +134,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-zip -- snapshot
     deploy-apt-snapshot:
       image: vaticle-ubuntu-21.04
-#      filter:
-#        owner: vaticle
-#        branch: master
+      filter:
+        owner: vaticle
+        branch: master
       dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
@@ -150,9 +150,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //:deploy-apt -- snapshot
     test-deployment-apt:
       image: vaticle-ubuntu-21.04
-#      filter:
-#        owner: vaticle
-#        branch: master
+      filter:
+        owner: vaticle
+        branch: master
       dependencies: [deploy-apt-snapshot]
       command: |
         export TEST_DEPLOYMENT_APT_COMMIT=$GRABL_COMMIT

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -106,17 +106,17 @@ build:
         bazel test //test/behaviour/reasoner/tests/variable_roles:test --test_output=streamed
     test-assembly-linux-targz:
       image: vaticle-ubuntu-21.04
-      filter:
-        owner: vaticle
-        branch: master
+#      filter:
+#        owner: vaticle
+#        branch: master
       dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-match, test-behaviour-writable, test-behaviour-definable, test-behaviour-reasoner]
       command: |
         bazel test //test/assembly:assembly --test_output=streamed
     test-assembly-docker:
       image: vaticle-ubuntu-21.04
-      filter:
-        owner: vaticle
-        branch: master
+#      filter:
+#        owner: vaticle
+#        branch: master
       dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-match, test-behaviour-writable, test-behaviour-definable, test-behaviour-reasoner]
       command: |
         bazel test //test/assembly:docker --test_output=streamed
@@ -134,9 +134,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-zip -- snapshot
     deploy-apt-snapshot:
       image: vaticle-ubuntu-21.04
-      filter:
-        owner: vaticle
-        branch: master
+#      filter:
+#        owner: vaticle
+#        branch: master
       dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
@@ -150,9 +150,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //:deploy-apt -- snapshot
     test-deployment-apt:
       image: vaticle-ubuntu-21.04
-      filter:
-        owner: vaticle
-        branch: master
+#      filter:
+#        owner: vaticle
+#        branch: master
       dependencies: [deploy-apt-snapshot]
       command: |
         export TEST_DEPLOYMENT_APT_COMMIT=$GRABL_COMMIT

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,7 +35,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.9.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "36a82cedcdf3a29ac11779e9ec0a0d4f2a044edc" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():

--- a/test/assembly/AssemblyTest.java
+++ b/test/assembly/AssemblyTest.java
@@ -19,7 +19,7 @@
 package com.vaticle.typedb.core.test.assembly;
 
 import com.vaticle.typedb.common.test.console.TypeDBConsoleRunner;
-import com.vaticle.typedb.common.test.server.TypeDBCoreRunner;
+import com.vaticle.typedb.common.test.core.TypeDBCoreRunner;
 import org.junit.Test;
 
 import java.io.IOException;


### PR DESCRIPTION
## What is the goal of this PR?

We updated TypeDB runner usage according to the latest version of the API

## What are the changes implemented in this PR?

1.  Updated the version of `@vaticle_typedb_common`.
2. Updated the declaration of TypeDB runner according to the latest version of the API / syntax.