### PR TITLE
Set system locale of Docker image to C.UTF-8

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -26,8 +26,8 @@ load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
 load("@vaticle_dependencies//distribution/artifact:rules.bzl", "artifact_repackage")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@vaticle_dependencies//tool/release/deps:rules.bzl", "release_validate_deps")
-load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
-load("@io_bazel_rules_docker//container:image.bzl", "container_image")
+load("@io_bazel_rules_docker//container:bundle.bzl", docker_container_bundle = "container_bundle")
+load("@io_bazel_rules_docker//container:image.bzl", docker_container_image = "container_image")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 
 exports_files(
@@ -201,19 +201,23 @@ release_validate_deps(
     tags = ["manual"]  # in order for bazel test //... to not fail
 )
 
-container_image(
+docker_container_image(
     name = "assemble-docker",
     base = "@vaticle_ubuntu_image//image",
     tars = [":assemble-linux-targz"],
     directory = "opt",
     workdir = "/opt/typedb-all-linux",
     ports = ["1729"],
+    env = {
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+    },
     cmd = ["/opt/typedb-all-linux/typedb", "server"],
     volumes = ["/opt/typedb-all-linux/server/data/"],
     visibility = ["//test:__subpackages__"],
 )
 
-container_bundle(
+docker_container_bundle(
     name = "assemble-docker-bundle",
     images = {
         "{}/{}/{}:{{DOCKER_VERSION}}".format(


### PR DESCRIPTION
## What is the goal of this PR?

Previously, when running TypeDB Console from within the TypeDB Docker image, it would be impossible to insert non-ASCII characters (e.g. Chinese characters) as the values of string attributes, because the image's system locale was POSIX, which is unable to represent these characters.

We've updated the system locale of our Docker image to C.UTF-8, which can represent all Unicode characters.

## What are the changes implemented in this PR?

This PR closes #6496, an issue reported by a user using Console in their Docker container, who was unable to insert Chinese text into attribute values. 

On further investigation, we discovered that even while the Docker container's locale was POSIX, we were able to correctly interface with the DB by connecting to it from a TypeDB Console run on our local Mac machine (which supported UTF8). We were able to insert Chinese text and retrieve it correctly. This implied that the bug was not in TypeDB Server.

We then attempted to copy Chinese text from our Mac to a TypeDB Console process run inside Docker. This resulted in a number of "????????" symbols appearing in the terminal. Nonetheless, we committed the data.

When we then queried that data, either via the Docker-hosted Console, or Studio on our Mac, we found that the data had become corrupted - it was just printing question marks. This indicates that the data became corrupted the moment we pasted it from our local machine into our Docker container's Console process host, and we understand this is because the POSIX locale is unable to represent all Unicode characters - only those defined in ASCII (approximately).

There are therefore two fixes we would like to make:

1. Set the system locale of our Docker image to C.UTF-8. This locale comes pre-installed with the image so it does not require any additional download, and it supports all Unicode characters.
2. When the user runs TypeDB Console, verify that the locale of the execution environment (typically the system's default locale) is one that supports all Unicode characters (such as UTF8) and not a restricted one such as ASCII. If it doesn't support all Unicode characters, print a warning saying that the current locale ({locale_name}) is not compatible with all Unicode characters.

In this PR, we implement (1). (2) is more involved. It may also be unnecessary to actually implement it, as if the user is using Console and seeing question marks when they paste in Chinese text, it is inferrable what the problem is. Nonetheless, I've raised:
- https://github.com/vaticle/typedb-console/issues/186