### PR TITLE
Reasoning test oracle uses stratified forward chaining

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,8 +48,8 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "2e2dc66fddf4748f9c6377ad925bffbce88f2291", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "223ac25a7c42ef3c0e27e50b3e3f5d54a3a79199", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,8 +48,8 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "6bfc7aa0cc3689c6328ceee3323b6ebc57173396", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "2e2dc66fddf4748f9c6377ad925bffbce88f2291", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -257,7 +257,7 @@ public class Rule {
             return concludablesTriggeringRules;
         }
 
-        Set<Concludable> negatedConcludablesTriggeringRules(ConceptManager conceptMgr, LogicManager logicMgr) {
+        public Set<Concludable> negatedConcludablesTriggeringRules(ConceptManager conceptMgr, LogicManager logicMgr) {
             synchronized (this) { // can be more contentious as only used for validation
                 if (negatedConcludablesTriggeringRules == null) {
                     negatedConcludablesTriggeringRules = concludables(rule.when().negations())


### PR DESCRIPTION
## What is the goal of this PR?
Fix how the forward-chaining oracle ( used in reasoner behaviour tests) behaves in the presence of negation.
The current implementation iteratively re-evaluates every rule to derive new inferred concepts, and terminates when no new concepts are inferred. This fails with negated rules, since it may prematurely conclude a negation is satisfied before a contradictory concept is inferred. 

## What are the changes implemented in this PR?
The oracle now computes the stratification of rules (for [stratified negation](https://en.wikipedia.org/wiki/Stratification_(mathematics)#In_mathematical_logic)) in the schema and evaluates rules accordingly - it first derives all concepts inferable from a given strata before moving on to the next.