### PR TITLE
Fix assertion error on planner optimisation failure

### DIFF
--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -268,7 +268,6 @@ public class GraphPlanner implements Planner {
         optimiser.optimise(totalDuration);
         endSolver = Instant.now();
         if (isError()) throwPlanningError();
-        else assert isPlanned();
 
         createProcedure();
         end = Instant.now();


### PR DESCRIPTION
## What is the goal of this PR?

We remove the defunct assertion from the query planner.

## What are the changes implemented in this PR?

We no longer require the optimiser to find a feasible solution in the allotted time to be able to create the graph procedure, as we can reuse the initial greedy solution values. The assertion would now look like `!isError()`, and is therefore unnecessary.
