### PR TITLE
Check explanation completeness in reasoner tests

### DIFF
--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -385,7 +385,7 @@ public abstract class Concludable extends Resolvable<Conjunction> implements Alp
             Set<RolePlayer> thenRolePlayers = relationConclusion.relation().players();
 
             return matchRolePlayers(conjRolePlayers, thenRolePlayers, new HashMap<>(), conceptMgr)
-                    .map(mapping -> convertRPMappingToUnifier(mapping, unifierBuilder.clone(), conceptMgr));
+                    .map(mapping -> convertRPMappingToUnifier(mapping, unifierBuilder.clone(), conceptMgr)).distinct();
         }
 
         private FunctionalIterator<Map<RolePlayer, Set<RolePlayer>>> matchRolePlayers(

--- a/logic/resolvable/Unifier.java
+++ b/logic/resolvable/Unifier.java
@@ -186,6 +186,22 @@ public class Unifier {
         return "{" + unifier.entrySet().stream().map(e -> e.getKey() + "->" + e.getValue()).collect(Collectors.joining(",")) + "}";
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Unifier unifier1 = (Unifier) o;
+        return unifier.equals(unifier1.unifier) &&
+                reverseUnifier.equals(unifier1.reverseUnifier) &&
+                requirements.equals(unifier1.requirements) &&
+                unifiedRequirements.equals(unifier1.unifiedRequirements);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(unifier, reverseUnifier, requirements, unifiedRequirements);
+    }
+
     public static class Builder {
 
         private final Map<Retrievable, Set<Variable>> unifier;
@@ -364,6 +380,21 @@ public class Unifier {
                 isaExplicit.forEach(((identifier, labels) -> isaExplicitCopy.put(identifier, new HashSet<>(labels))));
                 predicates.forEach((predicatesCopy::put));
                 return new Constraint(typesCopy, isaExplicitCopy, predicatesCopy);
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                Constraint that = (Constraint) o;
+                return types.equals(that.types) &&
+                        isaExplicit.equals(that.isaExplicit) &&
+                        predicates.equals(that.predicates);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(types, isaExplicit, predicates);
             }
         }
 

--- a/reasoner/controller/ConcludableController.java
+++ b/reasoner/controller/ConcludableController.java
@@ -259,7 +259,19 @@ public abstract class ConcludableController<INPUT, OUTPUT,
 
             @Override
             protected FunctionalIterator<ConceptMap> filterNonInferred(ConceptMap conceptMap) {
-                if (!concludable.isInferredAnswer(conceptMap)) return Iterators.empty();
+                Concept conceptToCheck = null;
+                if (concludable.isAttribute()) {
+                    conceptToCheck = conceptMap.get(concludable.asAttribute().attribute().id());
+                } else if (concludable.isIsa()) {
+                    conceptToCheck = conceptMap.get(concludable.asIsa().isa().owner().id());
+                }
+                if (conceptToCheck != null) {
+                    if (conceptToCheck.asThing().isInferred()) {
+                        return Iterators.single(conceptMap);
+                    } else {
+                        return Iterators.empty();
+                    }
+                }
                 return Iterators.single(conceptMap);
             }
 
@@ -330,7 +342,21 @@ public abstract class ConcludableController<INPUT, OUTPUT,
 
             @Override
             protected FunctionalIterator<Explanation> filterNonInferred(Explanation explanation) {
-                if (!concludable.isInferredAnswer(explanation.conclusionAnswer().WHATCOMESHERE!)) return Iterators.empty();
+                Set<Variable> conclusionConceptsToCheck = null;
+                if (concludable.isAttribute()) {
+                    conclusionConceptsToCheck = explanation.variableMapping().get(concludable.asAttribute().attribute().id());
+                } else if (concludable.isIsa()) {
+                    conclusionConceptsToCheck = explanation.variableMapping().get(concludable.asIsa().isa().owner().id());
+                }
+                if (conclusionConceptsToCheck != null) {
+                    for (Variable toCheck : conclusionConceptsToCheck) {
+                        if (explanation.conclusionAnswer().concepts().get(toCheck).asThing().isInferred()) {
+                            return Iterators.single(explanation);
+                        } else {
+                            return Iterators.empty();
+                        }
+                    }
+                }
                 return Iterators.single(explanation);
             }
 

--- a/test/behaviour/reasoner/verification/CompletenessVerifier.java
+++ b/test/behaviour/reasoner/verification/CompletenessVerifier.java
@@ -73,7 +73,7 @@ class CompletenessVerifier {
                     verifyConclusionReasoning(materialisation.boundConclusion());
                 });
                 verifyConcludableReasoning(boundConcludable);
-            }
+            }  // TODO: If not inferred should we do a traversal to check?
         });
     }
 
@@ -135,8 +135,8 @@ class CompletenessVerifier {
                                                        new Options.Transaction().infer(true))) {
             Disjunction disjunction = new Disjunction(Collections.singletonList(boundConjunction.conjunction()));
             tx.logic().typeInference().applyCombination(disjunction);
-            return tx.reasoner().executeReasoner(disjunction, filter,
-                    new Context.Query(tx.context(), new Options.Query())
+            return tx.reasoner().executeReasoner(
+                    disjunction, filter, new Context.Query(tx.context(), new Options.Query())
             ).toList().size();
         }
     }

--- a/test/behaviour/reasoner/verification/ForwardChainingMaterialiser.java
+++ b/test/behaviour/reasoner/verification/ForwardChainingMaterialiser.java
@@ -181,13 +181,15 @@ public class ForwardChainingMaterialiser {
 
         private FunctionalIterator<Materialisation> forConcludable(BoundConcludable boundConcludable) {
             FunctionalIterator<Materialisation> materialisations = empty();
-            Optional<Thing> inferredConcept = boundConcludable.inferredConcept();
-            if (inferredConcept.isPresent()) {
-                materialisations = materialisations.link(forThing(inferredConcept.get()));
-            }
+
             Optional<Pair<Thing, Attribute>> inferredHas = boundConcludable.inferredHas();
             if (inferredHas.isPresent()) {
                 materialisations = materialisations.link(forHas(inferredHas.get().first(), inferredHas.get().second()));
+            }else{
+                Optional<Thing> inferredConcept = boundConcludable.inferredConcept();
+                if (inferredConcept.isPresent()) {
+                    materialisations = materialisations.link(forThing(inferredConcept.get()));
+                }
             }
             return materialisations;
         }

--- a/test/behaviour/reasoner/verification/ForwardChainingMaterialiser.java
+++ b/test/behaviour/reasoner/verification/ForwardChainingMaterialiser.java
@@ -84,8 +84,8 @@ public class ForwardChainingMaterialiser {
 
     private FunctionalIterator<ConceptMap> traverse(Conjunction conjunction) {
         return tx.reasoner().executeTraversal(new Disjunction(singletonList(conjunction)),
-                                              new Context.Query(tx.context(), new Options.Query()),
-                                              conjunction.retrieves());
+                new Context.Query(tx.context(), new Options.Query()),
+                conjunction.retrieves());
     }
 
     void close() {
@@ -185,7 +185,7 @@ public class ForwardChainingMaterialiser {
             Optional<Pair<Thing, Attribute>> inferredHas = boundConcludable.inferredHas();
             if (inferredHas.isPresent()) {
                 materialisations = materialisations.link(forHas(inferredHas.get().first(), inferredHas.get().second()));
-            }else{
+            } else {
                 Optional<Thing> inferredConcept = boundConcludable.inferredConcept();
                 if (inferredConcept.isPresent()) {
                     materialisations = materialisations.link(forThing(inferredConcept.get()));
@@ -238,7 +238,7 @@ public class ForwardChainingMaterialiser {
         static Materialisation create(com.vaticle.typedb.core.logic.Rule rule, ConceptMap conditionAnswer,
                                       Map<Variable, Concept> conclusionAnswer) {
             return new Materialisation(rule, BoundCondition.create(rule.condition(), conditionAnswer),
-                                       BoundConclusion.create(rule.conclusion(), conclusionAnswer));
+                    BoundConclusion.create(rule.conclusion(), conclusionAnswer));
         }
 
         BoundCondition boundCondition() {

--- a/test/behaviour/reasoner/verification/SoundnessVerifier.java
+++ b/test/behaviour/reasoner/verification/SoundnessVerifier.java
@@ -68,7 +68,7 @@ class SoundnessVerifier {
                 new Options.Transaction().infer(true).explain(true))) {
             collectedExplanations.clear();
             // recursively collects explanations, partially verifies the answer.
-            tx.query().match(inferenceQuery).forEachRemaining(ans -> verifyAnswerAndCollectExplanations(ans, tx));
+            tx.query().match(inferenceQuery).forEachRemaining(ans -> verifyAnswerAndCollectExplanations(inferenceQuery, ans, tx));
 
             // We can only verify an explanation once all concepts in it's condition have been "mapped"
             // Concepts are mapped when an explanation containing them in the conclusion is verified.

--- a/test/behaviour/reasoner/verification/SoundnessVerifier.java
+++ b/test/behaviour/reasoner/verification/SoundnessVerifier.java
@@ -99,7 +99,7 @@ class SoundnessVerifier {
             }
             collectedExplanations.clear();
 
-            for (Pair<Conjunction, ConceptMap> deferredBindableConjunction: deferredExplanationCount.keySet()) {
+            for (Pair<Conjunction, ConceptMap> deferredBindableConjunction : deferredExplanationCount.keySet()) {
                 verifyNumberOfExplanations(tx, inferenceQuery, deferredBindableConjunction);
             }
         }
@@ -139,6 +139,7 @@ class SoundnessVerifier {
         boundConcludable.forEach(bc -> {
             bc.concludable().getApplicableRules(tx.concepts(), tx.logic());
             AtomicInteger numExplanationsExpected = new AtomicInteger();
+
             materialiser.concludableMaterialisations(bc).forEachRemaining(materialisation -> {
                 bc.concludable().getUnifiers(materialisation.boundConclusion().conclusion().rule()).forEachRemaining(unifier -> {
                     Optional<Pair<ConceptMap, Unifier.Requirements.Instance>> boundsAndRequirements = unifier.unify(bc.pattern().bounds());
@@ -234,10 +235,15 @@ class SoundnessVerifier {
     private ConceptMap mapInferredConcepts(ConceptMap inferredAnswer) {
         Map<Retrievable, Concept> substituted = new HashMap<>();
         inferredAnswer.concepts().forEach((var, concept) -> {
-            if (inferredConceptMapping.containsKey(concept)) {
-                substituted.put(var, inferredConceptMapping.get(concept));
+            if (concept.isThing()) {
+                if (inferredConceptMapping.containsKey(concept)) {
+                    substituted.put(var, inferredConceptMapping.get(concept));
+                } else {
+                    assert !concept.asThing().isInferred();
+                    substituted.put(var, concept);
+                }
             } else {
-                assert !concept.asThing().isInferred();
+                assert concept.isType();
                 substituted.put(var, concept);
             }
         });


### PR DESCRIPTION
## What is the goal of this PR?

Reasoner correctness checks, specifically Completness checks, are enabled on explanations, and bugs uncovered as a result are fixed.

## What are the changes implemented in this PR?
 This PR adds a check for the completeness of explanations - The number of explanations must match the the number of  materialisations found for the same materializable ( or, the number of conditions which lead to the same conclusion)

This PR also includes fixes bugs found in the explain-specific parts of the reasoner:
1. Disallow creating an inferred attribute where a nonInferred attribute exists, when an explicit-has is being inferred ([more](https://github.com/vaticle/typedb/pull/6611/files#r924398135)).
2. An explanation did not enforce the unifier requirements on answers received, leading to answers with mismatched role-variables being accepted as valid-explanations. ([more](https://github.com/vaticle/typedb/pull/6611/files#r924400333))
