### PR TITLE
Query planner emulates incremental solving

### DIFF
--- a/common/optimiser/Optimiser.java
+++ b/common/optimiser/Optimiser.java
@@ -123,7 +123,7 @@ public class Optimiser {
         variables.forEach(var -> var.initialise(solver));
         constraints.forEach(constraint -> constraint.initialise(solver));
         setConstraintCoefficients();
-        applyObjective();
+        setObjective();
     }
 
     private void setConstraintCoefficients() {
@@ -150,7 +150,7 @@ public class Optimiser {
         solver.setHint(mpVariables, hints);
     }
 
-    private void applyObjective() {
+    private void setObjective() {
         objectiveCoefficients.forEach((var, coeff) -> solver.objective().setCoefficient(var.mpVariable(), coeff));
     }
 

--- a/common/optimiser/Optimiser.java
+++ b/common/optimiser/Optimiser.java
@@ -87,7 +87,7 @@ public class Optimiser {
     }
 
     private void recordSolverValues() {
-        if ((isFeasible() || isOptimal()) && (objectiveValue == null || solver.objective().value() < objectiveValue)) {
+        if ((isFeasible() || isOptimal()) && solver.objective().value() < objectiveValue()) {
             objectiveValue = solver.objective().value();
             variables.forEach(OptimiserVariable::recordSolutionValue);
         }

--- a/common/optimiser/Optimiser.java
+++ b/common/optimiser/Optimiser.java
@@ -225,7 +225,7 @@ public class Optimiser {
 
     @Override
     public String toString() {
-        return "Optimiser[" + "hasSolver=" + (solver == null) + ", variables=" + variables.size() +
+        return "Optimiser[" + "hasSolver=" + (solver != null) + ", variables=" + variables.size() +
                 ", constraints=" + constraints.size() + "]" + (solver != null ? solver.exportModelAsLpFormat() : "");
     }
 }

--- a/common/optimiser/Optimiser.java
+++ b/common/optimiser/Optimiser.java
@@ -62,7 +62,7 @@ public class Optimiser {
         objectiveCoefficients = new HashMap<>();
         status = Status.NOT_SOLVED;
         objectiveValue = null;
-        isConstraintsUpToDate = false;
+        isConstraintsUpToDate = true;
     }
 
     public synchronized Status optimise(long timeLimitMillis) {
@@ -80,7 +80,7 @@ public class Optimiser {
 
     private void maySetSolver() {
         if (solver == null) createSolver();
-        else if (isConstraintsUpToDate) {
+        else if (!isConstraintsUpToDate) {
             solver.reset();
             setConstraintCoefficients();
         }
@@ -111,7 +111,7 @@ public class Optimiser {
     }
 
     public void setConstraintsChanged() {
-        isConstraintsUpToDate = true;
+        isConstraintsUpToDate = false;
     }
 
     private void createSolver() {
@@ -128,7 +128,7 @@ public class Optimiser {
 
     private void setConstraintCoefficients() {
         constraints.forEach(OptimiserConstraint::setCoefficients);
-        isConstraintsUpToDate = false;
+        isConstraintsUpToDate = true;
     }
 
     private void releaseSolver() {

--- a/common/optimiser/OptimiserConstraint.java
+++ b/common/optimiser/OptimiserConstraint.java
@@ -52,7 +52,7 @@ public class OptimiserConstraint {
         this.mpConstraint = solver.makeConstraint(lowerBound, upperBound, name);
     }
 
-    synchronized void applyCoefficients() {
+    synchronized void setCoefficients() {
         coefficients.forEach((var, coeff) -> mpConstraint.setCoefficient(var.mpVariable(), coeff));
     }
 

--- a/common/optimiser/OptimiserConstraint.java
+++ b/common/optimiser/OptimiserConstraint.java
@@ -55,4 +55,12 @@ public class OptimiserConstraint {
         mpConstraint.delete();
         mpConstraint = null;
     }
+
+    public boolean isSatisfied() {
+        double total = 0.0;
+        for (Map.Entry<OptimiserVariable<?>, Double> entry : coefficients.entrySet()) {
+            total += entry.getKey().valueAsDouble() * entry.getValue();
+        }
+        return lowerBound <= total && total <= upperBound;
+    }
 }

--- a/common/optimiser/OptimiserConstraint.java
+++ b/common/optimiser/OptimiserConstraint.java
@@ -23,16 +23,19 @@ import com.google.ortools.linearsolver.MPSolver;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class OptimiserConstraint {
 
+    private final Optimiser optimiser;
     private final double lowerBound;
     private final double upperBound;
     private final String name;
     private final Map<OptimiserVariable<?>, Double> coefficients;
     private MPConstraint mpConstraint;
 
-    public OptimiserConstraint(double lowerBound, double upperBound, String name) {
+    public OptimiserConstraint(Optimiser optimiser, double lowerBound, double upperBound, String name) {
+        this.optimiser = optimiser;
         this.lowerBound = lowerBound;
         this.upperBound = upperBound;
         this.coefficients = new HashMap<>();
@@ -40,14 +43,16 @@ public class OptimiserConstraint {
     }
 
     public void setCoefficient(OptimiserVariable<?> variable, double coeff) {
-        coefficients.put(variable, coeff);
+        assert mpConstraint == null || coefficients.containsKey(variable);
+        Double prevCoeff = coefficients.put(variable, coeff);
+        if (!Objects.equals(prevCoeff, coeff)) optimiser.setConstraintsChanged();
     }
 
     synchronized void initialise(MPSolver solver) {
         this.mpConstraint = solver.makeConstraint(lowerBound, upperBound, name);
     }
 
-    synchronized void updateCoefficients() {
+    synchronized void applyCoefficients() {
         coefficients.forEach((var, coeff) -> mpConstraint.setCoefficient(var.mpVariable(), coeff));
     }
 
@@ -56,7 +61,7 @@ public class OptimiserConstraint {
         mpConstraint = null;
     }
 
-    public boolean isSatisfied() {
+    boolean isSatisfied() {
         double total = 0.0;
         for (Map.Entry<OptimiserVariable<?>, Double> entry : coefficients.entrySet()) {
             total += entry.getKey().valueAsDouble() * entry.getValue();

--- a/common/optimiser/OptimiserVariable.java
+++ b/common/optimiser/OptimiserVariable.java
@@ -47,7 +47,7 @@ public abstract class OptimiserVariable<T> {
         this.value = value;
     }
 
-    public abstract double hint();
+    public abstract double valueAsDouble();
 
     MPVariable mpVariable() {
         return mpVariable;
@@ -56,6 +56,8 @@ public abstract class OptimiserVariable<T> {
     abstract void recordSolutionValue();
 
     abstract void initialise(MPSolver solver);
+
+    public abstract boolean isSatisfied();
 
     synchronized void release() {
         this.mpVariable.delete();
@@ -85,10 +87,15 @@ public abstract class OptimiserVariable<T> {
         }
 
         @Override
-        public double hint() {
+        public double valueAsDouble() {
             assert hasValue();
             if (value) return 1.0;
             else return 0.0;
+        }
+
+        @Override
+        public boolean isSatisfied() {
+            return hasValue();
         }
     }
 
@@ -114,9 +121,14 @@ public abstract class OptimiserVariable<T> {
         }
 
         @Override
-        public double hint() {
+        public double valueAsDouble() {
             assert hasValue();
             return value;
+        }
+
+        @Override
+        public boolean isSatisfied() {
+            return hasValue() && lowerBound <= valueAsDouble() && valueAsDouble() <= upperBound;
         }
     }
 }

--- a/common/optimiser/OptimiserVariable.java
+++ b/common/optimiser/OptimiserVariable.java
@@ -26,10 +26,9 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNE
 
 public abstract class OptimiserVariable<T> {
 
-    protected T value;
-    protected MPVariable mpVariable;
-
     final String name;
+    MPVariable mpVariable;
+    T value;
 
     OptimiserVariable(String name) {
         this.name = name;

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -70,7 +70,6 @@ public class GraphPlanner implements Planner {
     protected volatile GraphProcedure procedure;
     private volatile boolean isUpToDate;
     private volatile boolean isVertexOrderInitialised;
-    private volatile long totalDuration;
     private volatile long snapshot;
 
     private volatile double totalCostLastRecorded;
@@ -84,7 +83,6 @@ public class GraphPlanner implements Planner {
         firstOptimisingLock = new StampedLock().asReadWriteLock();
         isUpToDate = false;
         isVertexOrderInitialised = false;
-        totalDuration = 0L;
         totalCostLastRecorded = INIT_ZERO;
         totalCost = INIT_ZERO;
         snapshot = -1L;

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -250,7 +250,6 @@ public class GraphPlanner implements Planner {
         }
     }
 
-    @SuppressWarnings("NonAtomicOperationOnVolatileField")
     private void optimise(GraphManager graphMgr, boolean singleUse) {
         updateTraversalCosts(graphMgr);
         if (isUpToDate() && isOptimal()) {
@@ -262,10 +261,9 @@ public class GraphPlanner implements Planner {
         // TODO: we should have a more clever logic to allocate extra time
         long allocatedDuration = singleUse ? HIGHER_TIME_LIMIT_MILLIS : DEFAULT_TIME_LIMIT_MILLIS;
         Instant start, endSolver, end;
-        totalDuration += allocatedDuration;
 
         start = Instant.now();
-        optimiser.optimise(totalDuration);
+        optimiser.optimise(allocatedDuration);
         endSolver = Instant.now();
         if (isError()) throwPlanningError();
 
@@ -273,7 +271,6 @@ public class GraphPlanner implements Planner {
         end = Instant.now();
 
         isUpToDate = true;
-        totalDuration -= allocatedDuration - between(start, endSolver).toMillis();
         printDebug(start, endSolver, end);
     }
 

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -279,7 +279,6 @@ public class GraphPlanner implements Planner {
         updateOptimiserConstraints();
         if (!isVertexOrderInitialised) initialiseVertexOrderGreedy();
         setOptimiserValues();
-        optimiser.restartFromSolution();
         if (LOG.isTraceEnabled()) LOG.trace(optimiser.toString());
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

Query planner implement incremental solving, on top of OR-Tools solvers that do not support incremental solving. To implement this, the planner always restarts a new solver and provides the previous solution as a hint to the next invocation.

## What are the changes implemented in this PR?

* Refactor `Optimiser` to hide unnecessary APIs dealing with dynamically reconfiguring the optimisation model
* Add sanity check to validate that the solution held in each `OptimiserVariable` satisfies each constraint
* Always set the hints before invocing the OR-Tools solver to emulate incremental solutions
* SAT solver doesn't need increasing amounts of time allocated, we can just provide a new 100ms window each time