### PR TITLE
Reasoner tracing: Fix initialization race & handle case when directory does not exist

### DIFF
--- a/reasoner/common/Tracer.java
+++ b/reasoner/common/Tracer.java
@@ -48,6 +48,7 @@ public class Tracer {
     public Tracer(long id, Path logDir) {
         this.id = id;
         this.logDir = logDir;
+        traceWriter();
     }
 
     private TraceWriter traceWriter() {
@@ -149,7 +150,7 @@ public class Tracer {
             try {
                 LOG.debug("Writing reasoner traces to {}", path.get().toAbsolutePath());
                 File file = path.get().toFile();
-                if (!file.getParentFile().mkdirs()) {
+                if (!file.getParentFile().exists() && !file.getParentFile().mkdirs()) {
                     throw TypeDBException.of(REASONER_TRACING_DIRECTORY_COULD_NOT_BE_FOUND);
                 }
                 writer = new PrintWriter(file, "UTF-8");


### PR DESCRIPTION
## What is the goal of this PR?
Fix bugs occurring whe reasoner tracing is used in multiple transactions during the same session.

## What are the changes implemented in this PR?
The TraceWriter member used to be initialised lazily by the traceWriter method when first accessed. This has a concurrency bug which is triggered with multiple writers. Now it  is initialised in the constructor of Tracer.

Also, initialisation would fail when the output directory already exists. This is fixed with a check for directory existence.