### PR TITLE
Sorted iterators do not require matched comparator and equality

### DIFF
--- a/common/iterator/AbstractFunctionalIterator.java
+++ b/common/iterator/AbstractFunctionalIterator.java
@@ -26,7 +26,6 @@ import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -203,14 +202,6 @@ public abstract class AbstractFunctionalIterator<T> implements FunctionalIterato
     public void toSet(Set<T> set) {
         this.forEachRemaining(set::add);
         recycle();
-    }
-
-    @Override
-    public LinkedHashSet<T> toLinkedSet() {
-        LinkedHashSet<T> linkedSet = new LinkedHashSet<>();
-        forEachRemaining(linkedSet::add);
-        recycle();
-        return linkedSet;
     }
 
     @Override

--- a/common/iterator/FunctionalIterator.java
+++ b/common/iterator/FunctionalIterator.java
@@ -84,8 +84,6 @@ public interface FunctionalIterator<T> extends Iterator<T> {
 
     void toSet(Set<T> set);
 
-    LinkedHashSet<T> toLinkedSet();
-
     long count();
 
     <ACC> ACC reduce(ACC initial, BiFunction<T, ACC, ACC> accumulate);

--- a/common/iterator/sorted/AbstractSortedIterator.java
+++ b/common/iterator/sorted/AbstractSortedIterator.java
@@ -32,7 +32,6 @@ import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Order;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.NavigableSet;
 import java.util.Objects;
@@ -231,14 +230,6 @@ public abstract class AbstractSortedIterator<T extends Comparable<? super T>, OR
     public void toSet(Set<T> set) {
         this.forEachRemaining(set::add);
         recycle();
-    }
-
-    @Override
-    public LinkedHashSet<T> toLinkedSet() {
-        LinkedHashSet<T> linkedSet = new LinkedHashSet<>();
-        forEachRemaining(linkedSet::add);
-        recycle();
-        return linkedSet;
     }
 
     @Override

--- a/common/iterator/sorted/DistinctSortedIterator.java
+++ b/common/iterator/sorted/DistinctSortedIterator.java
@@ -82,6 +82,7 @@ public class DistinctSortedIterator<T extends Comparable<? super T>, ORDER exten
     }
 
     private boolean fetchNext() {
+        assert last != null;
         while (iterator.hasNext()) {
             T next = iterator.peek();
             int comparison = next.compareTo(last);
@@ -126,9 +127,9 @@ public class DistinctSortedIterator<T extends Comparable<? super T>, ORDER exten
 
         @Override
         public void forward(T target) {
-            if (last != null && !order.isValidNext(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
+            if (state != State.INIT && !order.isValidNext(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
             iterator.forward(target);
-            state = State.EMPTY;
+            if (state == State.FETCHED) state = State.EMPTY;
         }
 
         @Override

--- a/common/iterator/sorted/DistinctSortedIterator.java
+++ b/common/iterator/sorted/DistinctSortedIterator.java
@@ -129,7 +129,8 @@ public class DistinctSortedIterator<T extends Comparable<? super T>, ORDER exten
         public void forward(T target) {
             if (last != null && !order.isValidNext(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
             iterator.forward(target);
-            if (state == State.FETCHED) state = State.EMPTY;
+            if (last == null) state = State.INIT;
+            else if (state == State.FETCHED) state = State.EMPTY;
         }
 
         @Override

--- a/common/iterator/sorted/DistinctSortedIterator.java
+++ b/common/iterator/sorted/DistinctSortedIterator.java
@@ -128,6 +128,7 @@ public class DistinctSortedIterator<T extends Comparable<? super T>, ORDER exten
         public void forward(T target) {
             if (last != null && !order.isValidNext(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
             iterator.forward(target);
+            state = State.EMPTY;
         }
 
         @Override

--- a/common/iterator/sorted/DistinctSortedIterator.java
+++ b/common/iterator/sorted/DistinctSortedIterator.java
@@ -127,7 +127,7 @@ public class DistinctSortedIterator<T extends Comparable<? super T>, ORDER exten
 
         @Override
         public void forward(T target) {
-            if (state != State.INIT && !order.isValidNext(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
+            if (last != null && !order.isValidNext(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
             iterator.forward(target);
             if (state == State.FETCHED) state = State.EMPTY;
         }

--- a/common/iterator/sorted/IntersectForwardableIterator.java
+++ b/common/iterator/sorted/IntersectForwardableIterator.java
@@ -53,7 +53,7 @@ public class IntersectForwardableIterator<T extends Comparable<? super T>, ORDER
             case INIT:
                 return fetch();
             case EMPTY:
-                iterators.forEach(Iterator::next);
+                iterators.forEach(Iterator::next); // TODO we should bump each iterator next() one at a time and check if the intersection based on comparator is still valid. We should also deduplicate immediately
                 return fetch();
             case FETCHED:
                 return true;
@@ -92,12 +92,12 @@ public class IntersectForwardableIterator<T extends Comparable<? super T>, ORDER
             if (!iterator.hasNext()) {
                 state = State.COMPLETED;
                 return;
-            } else if (!iterator.peek().equals(candidate)) {
+            } else if (iterator.peek().compareTo(candidate) != 0) {
                 assert order.isValidNext(candidate, iterator.peek());
                 candidate = iterator.peek();
                 candidateSource = i;
                 newCandidate = true;
-            }
+            } // TODO what happens if they are comparably equal but not actually equal here?
         }
         if (!newCandidate) state = State.FETCHED;
     }

--- a/common/iterator/sorted/IntersectForwardableIterator.java
+++ b/common/iterator/sorted/IntersectForwardableIterator.java
@@ -159,11 +159,8 @@ public class IntersectForwardableIterator<T extends Comparable<? super T>, ORDER
 
     @Override
     public void forward(T target) {
-        if (state == State.COMPLETED) return;
-        iterators.forEach(iterator -> iterator.forward(target));
-        if ((state == State.EMPTY || state == State.FETCHED) && isIntersection(target, candidate)) {
-            state = State.EMPTY;
-        } else {
+        if (state == State.INIT || !isIntersection(candidate, target)) {
+            iterators.forEach(iterator -> iterator.forward(target));
             intersectionIterators.clear();
             intersectionValues.clear();
             state = State.INIT;

--- a/common/iterator/sorted/IntersectForwardableIterator.java
+++ b/common/iterator/sorted/IntersectForwardableIterator.java
@@ -40,7 +40,7 @@ public class IntersectForwardableIterator<T extends Comparable<? super T>, ORDER
     private T candidate;
     private int candidateSource;
     private final List<Forwardable<T, ORDER>> atIntersection;
-    private final Set<T> valuesWithinIntersection;
+    private final Set<T> valuesAtIntersection;
     private State state;
 
     private enum State {INIT, EMPTY, FETCHED, COMPLETED}
@@ -49,7 +49,7 @@ public class IntersectForwardableIterator<T extends Comparable<? super T>, ORDER
         super(order);
         this.iterators = iterators;
         this.atIntersection = new LinkedList<>();
-        this.valuesWithinIntersection = new HashSet<>();
+        this.valuesAtIntersection = new HashSet<>();
         state = iterators.isEmpty() ? State.COMPLETED : State.INIT;
     }
 
@@ -76,7 +76,7 @@ public class IntersectForwardableIterator<T extends Comparable<? super T>, ORDER
             T next = iterator.peek();
             if (candidate.compareTo(next) == 0) {
                 iterator.next();
-                if (!valuesWithinIntersection.contains(next)) {
+                if (!valuesAtIntersection.contains(next)) {
                     candidate = next;
                     state = State.FETCHED;
                     return true;
@@ -86,7 +86,7 @@ public class IntersectForwardableIterator<T extends Comparable<? super T>, ORDER
                 atIntersection.remove(0);
             }
         }
-        valuesWithinIntersection.clear();
+        valuesAtIntersection.clear();
         return false;
     }
 
@@ -141,7 +141,7 @@ public class IntersectForwardableIterator<T extends Comparable<? super T>, ORDER
     public T next() {
         if (!hasNext()) throw new NoSuchElementException();
         state = State.EMPTY;
-        valuesWithinIntersection.add(candidate);
+        valuesAtIntersection.add(candidate);
         return candidate;
     }
 
@@ -149,7 +149,7 @@ public class IntersectForwardableIterator<T extends Comparable<? super T>, ORDER
     public void forward(T target) {
         iterators.forEach(iterator -> iterator.forward(target));
         atIntersection.clear();
-        valuesWithinIntersection.clear();
+        valuesAtIntersection.clear();
         state = State.INIT;
     }
 

--- a/common/iterator/sorted/IntersectForwardableIterator.java
+++ b/common/iterator/sorted/IntersectForwardableIterator.java
@@ -159,10 +159,15 @@ public class IntersectForwardableIterator<T extends Comparable<? super T>, ORDER
 
     @Override
     public void forward(T target) {
+        if (state == State.COMPLETED) return;
         iterators.forEach(iterator -> iterator.forward(target));
-        intersectionIterators.clear();
-        intersectionValues.clear();
-        state = State.INIT;
+        if ((state == State.EMPTY || state == State.FETCHED) && isIntersection(target, candidate)) {
+            state = State.EMPTY;
+        } else {
+            intersectionIterators.clear();
+            intersectionValues.clear();
+            state = State.INIT;
+        }
     }
 
     @Override

--- a/common/iterator/sorted/IntersectForwardableIterator.java
+++ b/common/iterator/sorted/IntersectForwardableIterator.java
@@ -31,6 +31,13 @@ import java.util.function.Predicate;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 
+/**
+ * Intersection iterator, defined as intersection based on the comparator only, not the equality function.
+ * If the equality and comparator functions are one-to-one, the intersection is effectively an equality-based intersection.
+ *
+ * The intersection of iterators with multiple values that are comparably == 0 is defined as the distinct
+ * union of all of these elements.
+ */
 public class IntersectForwardableIterator<T extends Comparable<? super T>, ORDER extends SortedIterator.Order>
         extends AbstractSortedIterator<T, ORDER>
         implements SortedIterator.Forwardable<T, ORDER> {

--- a/common/iterator/sorted/IntersectForwardableIterator.java
+++ b/common/iterator/sorted/IntersectForwardableIterator.java
@@ -148,6 +148,8 @@ public class IntersectForwardableIterator<T extends Comparable<? super T>, ORDER
     @Override
     public void forward(T target) {
         iterators.forEach(iterator -> iterator.forward(target));
+        atIntersection.clear();
+        valuesWithinIntersection.clear();
         state = State.INIT;
     }
 

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -80,9 +80,9 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
 
     @Override
     public RelationConstraint clone(Conjunction.ConstraintCloner cloner) {
-        LinkedHashSet<RolePlayer> rolePlayers = new LinkedHashSet<>();
-        iterate(rolePlayers).map(rolePlayer -> rolePlayer.clone(cloner)).toSet(rolePlayers);
-        return cloner.cloneVariable(owner()).relation(rolePlayers);
+        LinkedHashSet<RolePlayer> clonedRPs = new LinkedHashSet<>();
+        iterate(this.rolePlayers).map(rolePlayer -> rolePlayer.clone(cloner)).toSet(clonedRPs);
+        return cloner.cloneVariable(owner()).relation(clonedRPs);
     }
 
     public LinkedHashSet<RolePlayer> players() {

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -56,7 +56,7 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
 
     public RelationConstraint(ThingVariable owner, LinkedHashSet<RolePlayer> rolePlayers) {
         super(owner, rolePlayerVariables(rolePlayers));
-        assert rolePlayers != null && !rolePlayers.isEmpty();
+        assert !rolePlayers.isEmpty();
         this.rolePlayers = new LinkedHashSet<>(rolePlayers);
         this.hash = Objects.hash(RelationConstraint.class, this.owner, this.rolePlayers);
         for (RelationConstraint.RolePlayer rp : rolePlayers) {
@@ -67,21 +67,22 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
 
     static RelationConstraint of(ThingVariable owner, com.vaticle.typeql.lang.pattern.constraint.ThingConstraint.Relation constraint,
                                  VariableRegistry register) {
-        return new RelationConstraint(
-                owner, iterate(constraint.players()).map(rp -> RolePlayer.of(rp, register)).toLinkedSet()
-        );
+        LinkedHashSet<RolePlayer> rolePlayers = new LinkedHashSet<>();
+        iterate(constraint.players()).map(rp -> RolePlayer.of(rp, register)).toSet(rolePlayers);
+        return new RelationConstraint(owner, rolePlayers);
     }
 
     static RelationConstraint of(ThingVariable owner, RelationConstraint clone, VariableCloner cloner) {
-        return new RelationConstraint(
-                owner, iterate(clone.players()).map(rp -> RolePlayer.of(rp, cloner)).toLinkedSet()
-        );
+        LinkedHashSet<RolePlayer> rolePlayers = new LinkedHashSet<>();
+        iterate(clone.players()).map(rp -> RolePlayer.of(rp, cloner)).toSet(rolePlayers);
+        return new RelationConstraint(owner, rolePlayers);
     }
 
     @Override
     public RelationConstraint clone(Conjunction.ConstraintCloner cloner) {
-        return cloner.cloneVariable(owner()).relation(Iterators.iterate(rolePlayers).map(
-                rolePlayer -> rolePlayer.clone(cloner)).toLinkedSet());
+        LinkedHashSet<RolePlayer> rolePlayers = new LinkedHashSet<>();
+        iterate(rolePlayers).map(rolePlayer -> rolePlayer.clone(cloner)).toSet(rolePlayers);
+        return cloner.cloneVariable(owner()).relation(rolePlayers);
     }
 
     public LinkedHashSet<RolePlayer> players() {


### PR DESCRIPTION
## What is the goal of this PR?

We relax sorted iterators' implicit contract, which previously required that `equals() == true` iif `compareTo() == 0`. TypeDB's sorted iterators now require that when if `equals() == true`, then `compareTo() == 0`, but not vice versa. This allows using comparators that order based on a subset of the comparable elements' state.

Future uses of this includes sorted iterators of comparable `ConceptMap`s by particular variables, for example.

## What are the changes implemented in this PR?

* remove `toLinkedSet()` API on `FunctionalIterator` since it can be reduced to the more minimal existing API: `toSet(Set<T> collector)`
* `Distinct` sorted iterators now keep a deduplication set as long as the next element has `compareTo(last) == 0`. This implementation means that when equality and comparator are perfectly aligned, the deduplication set never grows larger than a size of 1, while also handling the more general case of deduplicating repeated and but comparably equal values.
* `Intersection` iterator now performs the intersection _purely_ by `compareTo() == 0`. To preserve correctness, the intersection now returns ALL elements that are comparably equal but not equal by equality function.

For example:
Intersecting `[(1,2), (2,10)]` and `[(1,5), (1,2), (3,20)]`, comparing just by the first element, yields `[(1,2), (1,5)]`, where no ordering is guaranteed between these two elements.
