### PR TITLE
Fix storage iterator forwarding

### DIFF
--- a/database/RocksIterator.java
+++ b/database/RocksIterator.java
@@ -215,7 +215,7 @@ public abstract class RocksIterator<T extends Key, ORDER extends Order>
 
         @Override
         public synchronized void forward(KeyValue<T, ByteArray> target) {
-            if (state == State.COMPLETED || ASC.isValidNext(target.key().bytes(), prefix.bytes())) return;
+            if (state == State.COMPLETED || !ASC.isValidNext(prefix.bytes(), target.key().bytes())) return;
             if (state == State.INIT) initialiseInternalIterator();
             internalRocksIterator.seek(target.key().bytes().getBytes());
             state = State.FORWARDED;
@@ -247,7 +247,7 @@ public abstract class RocksIterator<T extends Key, ORDER extends Order>
 
         @Override
         public synchronized void forward(KeyValue<T, ByteArray> target) {
-            if (state == State.COMPLETED || DESC.isValidNext(target.key().bytes(), prefix.bytes())) return;
+            if (state == State.COMPLETED || !DESC.isValidNext(prefix.bytes(), target.key().bytes())) return;
             if (state == State.INIT) initialiseInternalIterator();
             internalRocksIterator.seekForPrev(target.key().bytes().getBytes());
             state = State.FORWARDED;

--- a/database/RocksIterator.java
+++ b/database/RocksIterator.java
@@ -215,8 +215,8 @@ public abstract class RocksIterator<T extends Key, ORDER extends Order>
 
         @Override
         public synchronized void forward(KeyValue<T, ByteArray> target) {
-            if (state == State.COMPLETED) return;
-            else if (state == State.INIT) initialiseInternalIterator();
+            if (state == State.COMPLETED || ASC.isValidNext(target.key().bytes(), prefix.bytes())) return;
+            if (state == State.INIT) initialiseInternalIterator();
             internalRocksIterator.seek(target.key().bytes().getBytes());
             state = State.FORWARDED;
         }
@@ -247,8 +247,8 @@ public abstract class RocksIterator<T extends Key, ORDER extends Order>
 
         @Override
         public synchronized void forward(KeyValue<T, ByteArray> target) {
-            if (state == State.COMPLETED) return;
-            else if (state == State.INIT) initialiseInternalIterator();
+            if (state == State.COMPLETED || DESC.isValidNext(target.key().bytes(), prefix.bytes())) return;
+            if (state == State.INIT) initialiseInternalIterator();
             internalRocksIterator.seekForPrev(target.key().bytes().getBytes());
             state = State.FORWARDED;
         }


### PR DESCRIPTION
## What is the goal of this PR?

We fix the behaviour of our storage iterators when forwarding them to a target. Storage iterators are bound to a particular prefix internally. However forwarding them to a value before the prefix should still be a valid operation that returns the entire prefix range as before, rather than returning nothing.

## What are the changes implemented in this PR?

* Previously, forwarding a storage iterator to a value before the prefix would be allowed to proceed to performing a `seek()` operation on RocksDB
* However, this mean the next value retrieved from RocksDB wouldn't have the prefix that our storage iterator was bound to, and the storage iterator would immediately return with no answers
* Now, we do a no-op if the target is before the prefix that the iterator is bound to.