### PR TITLE
Refactor reasoner graph construction to use logic data-structures 

### DIFF
--- a/logic/resolvable/Negated.java
+++ b/logic/resolvable/Negated.java
@@ -35,8 +35,8 @@ public class Negated extends Resolvable<Disjunction> {
 
     public Negated(Negation negation) {
         super(negation.disjunction());
-        this.identifiers = new HashSet<>();
         this.disjunction = ResolvableDisjunction.of(negation.disjunction());
+        this.identifiers = new HashSet<>();
         pattern().conjunctions().forEach(c -> iterate(c.retrieves()).forEachRemaining(identifiers::add));
     }
 

--- a/logic/resolvable/ResolvableConjunction.java
+++ b/logic/resolvable/ResolvableConjunction.java
@@ -30,8 +30,8 @@ public class ResolvableConjunction {
     private final Set<Negated> negations;
     private final Set<Concludable> concludables;
 
-    private ResolvableConjunction(Conjunction conjunction, Set<Concludable> concludables, Set<Negated> negations) {
-        this.conjunctionPattern = conjunction;
+    private ResolvableConjunction(Conjunction conjunctionPattern, Set<Concludable> concludables, Set<Negated> negations) {
+        this.conjunctionPattern = conjunctionPattern;
         this.negations = negations;
         this.concludables = concludables;
     }

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -22,6 +22,8 @@ import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.concurrent.actor.Actor;
 import com.vaticle.typedb.core.concurrent.producer.Producer;
 import com.vaticle.typedb.core.logic.resolvable.Concludable;
+import com.vaticle.typedb.core.logic.resolvable.ResolvableConjunction;
+import com.vaticle.typedb.core.logic.resolvable.ResolvableDisjunction;
 import com.vaticle.typedb.core.reasoner.answer.Explanation;
 import com.vaticle.typedb.core.reasoner.controller.ControllerRegistry;
 import com.vaticle.typedb.core.reasoner.processor.AbstractProcessor;
@@ -182,7 +184,7 @@ public abstract class ReasonerProducer<ANSWER> implements Producer<ANSWER>, Reas
 
             @Override
             protected synchronized void initialiseRootController() {
-                controllerRegistry().createRootConjunction(conjunction, filter, options.explain(), this);
+                controllerRegistry().createRootConjunction(ResolvableConjunction.of(conjunction), filter, options.explain(), this);
             }
         }
 
@@ -201,7 +203,7 @@ public abstract class ReasonerProducer<ANSWER> implements Producer<ANSWER>, Reas
 
             @Override
             protected synchronized void initialiseRootController() {
-                controllerRegistry().createRootDisjunction(disjunction, filter, options.explain(), this);
+                controllerRegistry().createRootDisjunction(ResolvableDisjunction.of(disjunction), filter, options.explain(), this);
             }
         }
     }

--- a/reasoner/controller/ConditionController.java
+++ b/reasoner/controller/ConditionController.java
@@ -42,7 +42,7 @@ public class ConditionController extends ConjunctionController<
     private final Rule.Condition condition;
 
     ConditionController(Driver<ConditionController> driver, Rule.Condition condition, Context context) {
-        super(driver, condition.pattern(), context);
+        super(driver, condition.conjunction(), context);
         this.condition = condition;
     }
 

--- a/reasoner/controller/ControllerRegistry.java
+++ b/reasoner/controller/ControllerRegistry.java
@@ -30,9 +30,10 @@ import com.vaticle.typedb.core.logic.Rule;
 import com.vaticle.typedb.core.logic.resolvable.Concludable;
 import com.vaticle.typedb.core.logic.resolvable.Negated;
 import com.vaticle.typedb.core.logic.resolvable.Resolvable;
+import com.vaticle.typedb.core.logic.resolvable.ResolvableConjunction;
+import com.vaticle.typedb.core.logic.resolvable.ResolvableDisjunction;
 import com.vaticle.typedb.core.logic.resolvable.Retrievable;
 import com.vaticle.typedb.core.pattern.Conjunction;
-import com.vaticle.typedb.core.pattern.Disjunction;
 import com.vaticle.typedb.core.pattern.equivalence.AlphaEquivalence;
 import com.vaticle.typedb.core.reasoner.ReasonerConsumer;
 import com.vaticle.typedb.core.reasoner.answer.Explanation;
@@ -141,7 +142,7 @@ public class ControllerRegistry {
         return controller;
     }
 
-    public void createRootConjunction(Conjunction conjunction, Set<Variable.Retrievable> filter,
+    public void createRootConjunction(ResolvableConjunction conjunction, Set<Variable.Retrievable> filter,
                                       boolean explain, ReasonerConsumer<ConceptMap> reasonerConsumer) {
         Function<Driver<RootConjunctionController>, RootConjunctionController> actorFn = driver ->
                 new RootConjunctionController(driver, conjunction, filter, explain, controllerContext, reasonerConsumer);
@@ -149,7 +150,7 @@ public class ControllerRegistry {
         createRootController(reasonerConsumer, actorFn);
     }
 
-    public void createRootDisjunction(Disjunction disjunction, Set<Variable.Retrievable> filter,
+    public void createRootDisjunction(ResolvableDisjunction disjunction, Set<Variable.Retrievable> filter,
                                       boolean explain, ReasonerConsumer<ConceptMap> reasonerConsumer) {
         Function<Driver<RootDisjunctionController>, RootDisjunctionController> actorFn =
                 driver -> new RootDisjunctionController(driver, disjunction, filter, explain, controllerContext, reasonerConsumer);
@@ -164,14 +165,14 @@ public class ControllerRegistry {
         createRootController(reasonerConsumer, actorFn);
     }
 
-    Driver<NestedConjunctionController> createNestedConjunction(Conjunction conjunction) {
+    Driver<NestedConjunctionController> createNestedConjunction(ResolvableConjunction conjunction) {
         Function<Driver<NestedConjunctionController>, NestedConjunctionController> actorFn =
                 driver -> new NestedConjunctionController(driver, conjunction, controllerContext);
         LOG.debug("Create Nested Conjunction for: '{}'", conjunction);
         return createController(actorFn);
     }
 
-    Driver<NestedDisjunctionController> createNestedDisjunction(Disjunction disjunction) {
+    Driver<NestedDisjunctionController> createNestedDisjunction(ResolvableDisjunction disjunction) {
         Function<Driver<NestedDisjunctionController>, NestedDisjunctionController> actorFn =
                 driver -> new NestedDisjunctionController(driver, disjunction, controllerContext);
         LOG.debug("Create Nested Disjunction for: '{}'", disjunction);
@@ -222,15 +223,15 @@ public class ControllerRegistry {
         return ControllerView.retrievable(createController(actorFn), retrievable.retrieves());
     }
 
-    ControllerView.FilteredNegation createNegation(Negated negated, Conjunction conjunction) {
+    ControllerView.FilteredNegation createNegation(Negated negated, ResolvableConjunction conjunction) {
         Function<Driver<NegationController>, NegationController> actorFn =
                 driver -> new NegationController(driver, negated, controllerContext);
         LOG.debug("Create NegationController for : {}", negated);
         return ControllerView.negation(createController(actorFn), filter(conjunction, negated));
     }
 
-    private static Set<Variable.Retrievable> filter(Conjunction scope, Negated inner) {
-        return scope.variables().stream()
+    private static Set<Variable.Retrievable> filter(ResolvableConjunction scope, Negated inner) {
+        return scope.pattern().variables().stream()
                 .filter(var -> var.id().isRetrievable() && inner.retrieves().contains(var.id().asRetrievable()))
                 .map(var -> var.id().asRetrievable())
                 .collect(Collectors.toSet());

--- a/reasoner/controller/NegationController.java
+++ b/reasoner/controller/NegationController.java
@@ -58,7 +58,7 @@ public class NegationController extends AbstractController<
 
     @Override
     public void setUpUpstreamControllers() {
-        disjunctionContoller = registry().createNestedDisjunction(negated.pattern());
+        disjunctionContoller = registry().createNestedDisjunction(negated.disjunction());
     }
 
     @Override

--- a/reasoner/controller/NestedConjunctionController.java
+++ b/reasoner/controller/NestedConjunctionController.java
@@ -23,7 +23,7 @@ import com.vaticle.typedb.core.common.iterator.Iterators;
 import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.logic.resolvable.Concludable;
 import com.vaticle.typedb.core.logic.resolvable.Resolvable;
-import com.vaticle.typedb.core.pattern.Conjunction;
+import com.vaticle.typedb.core.logic.resolvable.ResolvableConjunction;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -34,14 +34,14 @@ public class NestedConjunctionController extends ConjunctionController<
         NestedConjunctionController.NestedConjunctionProcessor
         > {
 
-    public NestedConjunctionController(Driver<NestedConjunctionController> driver, Conjunction conjunction,
+    public NestedConjunctionController(Driver<NestedConjunctionController> driver, ResolvableConjunction conjunction,
                                        Context context) {
         super(driver, conjunction, context);
     }
 
     @Override
     FunctionalIterator<Concludable> concludablesTriggeringRules() {
-        return Iterators.iterate(Concludable.create(conjunction))
+        return Iterators.iterate(conjunction.positiveConcludables())
                 .filter(c -> !registry().logicManager().applicableRules(c).isEmpty());
     }
 

--- a/reasoner/controller/NestedDisjunctionController.java
+++ b/reasoner/controller/NestedDisjunctionController.java
@@ -19,14 +19,14 @@
 package com.vaticle.typedb.core.reasoner.controller;
 
 import com.vaticle.typedb.core.concept.answer.ConceptMap;
-import com.vaticle.typedb.core.pattern.Disjunction;
+import com.vaticle.typedb.core.logic.resolvable.ResolvableDisjunction;
 
 import java.util.function.Supplier;
 
 public class NestedDisjunctionController
         extends DisjunctionController<NestedDisjunctionController.Processor, NestedDisjunctionController>{
 
-    NestedDisjunctionController(Driver<NestedDisjunctionController> driver, Disjunction disjunction,
+    NestedDisjunctionController(Driver<NestedDisjunctionController> driver, ResolvableDisjunction disjunction,
                                 Context context) {
         super(driver, disjunction, context);
     }
@@ -45,7 +45,7 @@ public class NestedDisjunctionController
 
         private Processor(Driver<Processor> driver,
                           Driver<NestedDisjunctionController> controller, Context context,
-                          Disjunction disjunction, ConceptMap bounds, Supplier<String> debugName) {
+                          ResolvableDisjunction disjunction, ConceptMap bounds, Supplier<String> debugName) {
             super(driver, controller, context, disjunction, bounds, debugName);
         }
     }

--- a/reasoner/controller/RootConjunctionController.java
+++ b/reasoner/controller/RootConjunctionController.java
@@ -23,7 +23,7 @@ import com.vaticle.typedb.core.common.iterator.Iterators;
 import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.logic.resolvable.Concludable;
 import com.vaticle.typedb.core.logic.resolvable.Resolvable;
-import com.vaticle.typedb.core.pattern.Conjunction;
+import com.vaticle.typedb.core.logic.resolvable.ResolvableConjunction;
 import com.vaticle.typedb.core.reasoner.ReasonerConsumer;
 import com.vaticle.typedb.core.reasoner.processor.reactive.Reactive;
 import com.vaticle.typedb.core.reasoner.processor.reactive.Reactive.Stream;
@@ -41,7 +41,7 @@ public class RootConjunctionController
     private final boolean explain;
     private final ReasonerConsumer<ConceptMap> reasonerConsumer;
 
-    RootConjunctionController(Driver<RootConjunctionController> driver, Conjunction conjunction,
+    RootConjunctionController(Driver<RootConjunctionController> driver, ResolvableConjunction conjunction,
                               Set<Identifier.Variable.Retrievable> filter, boolean explain,
                               Context context, ReasonerConsumer<ConceptMap> reasonerConsumer) {
         super(driver, conjunction, context);
@@ -66,7 +66,7 @@ public class RootConjunctionController
 
     @Override
     FunctionalIterator<Concludable> concludablesTriggeringRules() {
-        return Iterators.iterate(Concludable.create(conjunction))
+        return Iterators.iterate(conjunction.positiveConcludables())
                 .filter(c -> !registry().logicManager().applicableRules(c).isEmpty());
     }
 

--- a/reasoner/controller/RootDisjunctionController.java
+++ b/reasoner/controller/RootDisjunctionController.java
@@ -19,7 +19,7 @@
 package com.vaticle.typedb.core.reasoner.controller;
 
 import com.vaticle.typedb.core.concept.answer.ConceptMap;
-import com.vaticle.typedb.core.pattern.Disjunction;
+import com.vaticle.typedb.core.logic.resolvable.ResolvableDisjunction;
 import com.vaticle.typedb.core.reasoner.ReasonerConsumer;
 import com.vaticle.typedb.core.reasoner.processor.reactive.Reactive;
 import com.vaticle.typedb.core.reasoner.processor.reactive.Reactive.Stream;
@@ -36,7 +36,7 @@ public class RootDisjunctionController
     private final boolean explain;
     private final ReasonerConsumer<ConceptMap> reasonerConsumer;
 
-    RootDisjunctionController(Driver<RootDisjunctionController> driver, Disjunction disjunction,
+    RootDisjunctionController(Driver<RootDisjunctionController> driver, ResolvableDisjunction disjunction,
                               Set<Identifier.Variable.Retrievable> filter, boolean explain,
                               Context context, ReasonerConsumer<ConceptMap> reasonerConsumer) {
         super(driver, disjunction, context);
@@ -74,7 +74,7 @@ public class RootDisjunctionController
         private RootSink<ConceptMap> rootSink;
 
         private Processor(Driver<Processor> driver, Driver<RootDisjunctionController> controller,
-                          Context context, Disjunction disjunction, ConceptMap bounds,
+                          Context context, ResolvableDisjunction disjunction, ConceptMap bounds,
                           Set<Identifier.Variable.Retrievable> filter, boolean explain,
                           ReasonerConsumer<ConceptMap> reasonerConsumer, Supplier<String> debugName) {
             super(driver, controller, context, disjunction, bounds, debugName);

--- a/test/integration/reasoner/controller/ControllerTest.java
+++ b/test/integration/reasoner/controller/ControllerTest.java
@@ -28,6 +28,8 @@ import com.vaticle.typedb.core.database.CoreDatabaseManager;
 import com.vaticle.typedb.core.database.CoreSession;
 import com.vaticle.typedb.core.database.CoreTransaction;
 import com.vaticle.typedb.core.logic.LogicManager;
+import com.vaticle.typedb.core.logic.resolvable.ResolvableConjunction;
+import com.vaticle.typedb.core.logic.resolvable.ResolvableDisjunction;
 import com.vaticle.typedb.core.pattern.Conjunction;
 import com.vaticle.typedb.core.pattern.Disjunction;
 import com.vaticle.typedb.core.pattern.variable.Variable;
@@ -54,7 +56,6 @@ import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.core.common.collection.Bytes.MB;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Reasoner.REASONING_TERMINATED_WITH_CAUSE;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
-import static java.lang.Thread.sleep;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.assertTrue;
@@ -135,7 +136,7 @@ public class ControllerTest {
                 ControllerRegistry registry = transaction.reasoner().controllerRegistry();
                 AnswerProducer answerProducer = new AnswerProducer();
                 try {
-                    registry.createRootConjunction(conjunctionPattern, new HashSet<>(), options.explain(), answerProducer);
+                    registry.createRootConjunction(ResolvableConjunction.of(conjunctionPattern), new HashSet<>(), options.explain(), answerProducer);
                 } catch (TypeDBException e) {
                     fail();
                 }
@@ -541,7 +542,7 @@ public class ControllerTest {
         AnswerProducer answerProducer = new AnswerProducer();
         answerProducer.getNextAnswer();
         try {
-             registry.createRootDisjunction(disjunction, filter, options.explain(), answerProducer);
+             registry.createRootDisjunction(ResolvableDisjunction.of(disjunction), filter, options.explain(), answerProducer);
         } catch (TypeDBException e) {
             fail();
             return;
@@ -558,7 +559,7 @@ public class ControllerTest {
         AnswerProducer answerProducer = new AnswerProducer();
         answerProducer.getNextAnswer();
         try {
-            registry.createRootConjunction(conjunction, filter, options.explain(), answerProducer);
+            registry.createRootConjunction(ResolvableConjunction.of(conjunction), filter, options.explain(), answerProducer);
         } catch (TypeDBException e) {
             fail();
             return;


### PR DESCRIPTION
## What is the goal of this PR?
We update the reasoner controllers to use the (new) logic conjunction & disjunctions in place of the patterns - enabling a cleaner mapping between the structures of the logical-theory (conjunctions, concludables etc) and the computation-graph.
 
The reasoner views Conjunctions as a set of Resolvables. Because conjunctions are concepts in the lower 'pattern' domain and Resolvables are concepts from the higher logic domain, conjunctions do not store this mapping. 

Since  Resolvables nor Conjunctions have a reliable equality test, we rely on object identity and pass the objects themselves around when required. This is limiting in the reasoner - If we need the constituent concludables of a conjunction - we would need to pass them around with the conjunction.

## What are the changes implemented in this PR?
* Refactor Controllers & Processors use ResolvableConjunction, ResolvableDisjunciton in place of corresponding patterns