### PR TITLE
Parse type label for exceptions

### DIFF
--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -34,6 +34,7 @@ import com.vaticle.typedb.core.graph.common.Encoding;
 import com.vaticle.typedb.core.graph.structure.RuleStructure;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 import com.vaticle.typeql.lang.TypeQL;
+import com.vaticle.typeql.lang.common.exception.TypeQLException;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -99,6 +100,11 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
 
     @Override
     public void setLabel(String label) {
+        try {
+            TypeQL.parseLabel(label);
+        } catch (TypeQLException e) {
+            throw TypeDBException.of(e);
+        }
         validateIsNotDeleted();
         vertex.label(label);
     }


### PR DESCRIPTION
## What is the goal of this PR?

TypeDB validates label names that are assigned, conforming to the requirements set by the TypeQL parser. This addresses #6627.

## What are the changes implemented in this PR?

* parse the new label, catching any exceptions generated, before setting it on the Type vertex