### PR TITLE
Native disconnected graph traversal

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -34,9 +34,10 @@ def vaticle_typeql():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "00225f129dfe6be2ac45fb736a7ae021af7d5cda" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/flyingsilverfin/typedb-common",
+        commit = "ade03259f43e7779098f7174111078e7810bc890" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
+
 
 def vaticle_typedb_protocol():
     git_repository(

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -38,7 +38,6 @@ def vaticle_typedb_common():
         commit = "ade03259f43e7779098f7174111078e7810bc890" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
-
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -160,15 +160,13 @@ public class Reasoner {
 
     private Producer<ConceptMap> producer(Conjunction conjunction, Set<Identifier.Variable.Retrievable> filter) {
         if (conjunction.negations().isEmpty()) {
-            return traversalEng.producer(
-                    conjunction.traversal(filter), PARALLELISATION_FACTOR
-            ).map(conceptMgr::conceptMap);
+            return traversalEng.producer(conjunction.traversal(filter), PARALLELISATION_FACTOR)
+                    .map(conceptMgr::conceptMap);
         } else {
-            return traversalEng.producer(
-                    conjunction.traversal(), PARALLELISATION_FACTOR
-            ).map(conceptMgr::conceptMap).filter(answer -> !iterate(conjunction.negations()).flatMap(
-                    negation -> iterator(negation.disjunction(), answer)
-            ).hasNext()).map(answer -> answer.filter(filter)).distinct();
+            return traversalEng.producer(conjunction.traversal(), PARALLELISATION_FACTOR)
+                    .map(conceptMgr::conceptMap).filter(answer -> !iterate(conjunction.negations()).flatMap(
+                            negation -> iterator(negation.disjunction(), answer)).hasNext()
+                    ).map(answer -> answer.filter(filter)).distinct();
         }
     }
 
@@ -203,7 +201,7 @@ public class Reasoner {
         ConceptMap explainableBounds = explainablesManager.getBounds(explainableId);
         return Producers.produce(
                 list(new ReasonerProducer.Explain(explainableConcludable, explainableBounds, defaultContext.options(),
-                                                  controllerRegistry, explainablesManager)),
+                        controllerRegistry, explainablesManager)),
                 Either.first(Arguments.Query.Producer.INCREMENTAL),
                 async1()
         );

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -44,8 +44,6 @@ import com.vaticle.typedb.core.traversal.TraversalEngine;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typeql.lang.pattern.variable.UnboundVariable;
 import com.vaticle.typeql.lang.query.TypeQLMatch;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
 import java.util.List;
@@ -155,20 +153,19 @@ public class Reasoner {
         FunctionalIterator<ConceptMap> answers;
         FunctionalIterator<Conjunction> conjs = iterate(disjunction.conjunctions());
         if (!context.options().parallel()) answers = conjs.flatMap(conj -> iterator(conj, filter));
-        else answers = produce(conjs.map(c -> producer(c, filter, context)).toList(), context.producer(), async1());
+        else answers = produce(conjs.map(c -> producer(c, filter)).toList(), context.producer(), async1());
         if (disjunction.conjunctions().size() > 1) answers = answers.distinct();
         return answers;
     }
 
-    private Producer<ConceptMap> producer(Conjunction conjunction, Set<Identifier.Variable.Retrievable> filter,
-                                          Context.Query context) {
+    private Producer<ConceptMap> producer(Conjunction conjunction, Set<Identifier.Variable.Retrievable> filter) {
         if (conjunction.negations().isEmpty()) {
             return traversalEng.producer(
-                    conjunction.traversal(filter), context.producer(), PARALLELISATION_FACTOR
+                    conjunction.traversal(filter), PARALLELISATION_FACTOR
             ).map(conceptMgr::conceptMap);
         } else {
             return traversalEng.producer(
-                    conjunction.traversal(), context.producer(), PARALLELISATION_FACTOR
+                    conjunction.traversal(), PARALLELISATION_FACTOR
             ).map(conceptMgr::conceptMap).filter(answer -> !iterate(conjunction.negations()).flatMap(
                     negation -> iterator(negation.disjunction(), answer)
             ).hasNext()).map(answer -> answer.filter(filter)).distinct();

--- a/reasoner/common/Traversal.java
+++ b/reasoner/common/Traversal.java
@@ -18,7 +18,6 @@
 
 package com.vaticle.typedb.core.reasoner.common;
 
-import com.vaticle.typedb.common.collection.Either;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.iterator.Iterators;
@@ -37,7 +36,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static com.vaticle.typedb.core.common.parameters.Arguments.Query.Producer.INCREMENTAL;
 
 public class Traversal {
 
@@ -53,7 +51,7 @@ public class Traversal {
                                                          ConceptMap bounds, int parallelisation) {
         return compatibleBounds(conjunction, bounds).map(b -> {
             GraphTraversal.Thing traversal = boundTraversal(conjunction.traversal(), b);
-            return registry.traversalEngine().producer(traversal, Either.first(INCREMENTAL), parallelisation)
+            return registry.traversalEngine().producer(traversal, parallelisation)
                     .map(vertexMap -> registry.conceptManager().conceptMap(vertexMap));
         }).orElse(Producers.empty());
     }

--- a/test/behaviour/typeql/TypeQLSteps.java
+++ b/test/behaviour/typeql/TypeQLSteps.java
@@ -32,7 +32,6 @@ import com.vaticle.typedb.core.traversal.GraphTraversal;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typedb.core.traversal.common.VertexMap;
 import com.vaticle.typedb.core.traversal.procedure.GraphProcedure;
-import com.vaticle.typedb.core.traversal.structure.Structure;
 import com.vaticle.typedb.core.traversal.test.ProcedurePermutator;
 import com.vaticle.typeql.lang.TypeQL;
 import com.vaticle.typeql.lang.common.exception.TypeQLException;
@@ -186,16 +185,10 @@ public class TypeQLSteps {
             FunctionalIterator<GraphProcedure> procedurePermutations = ProcedurePermutator.generate(traversal.structure()).limit(5000);
             Set<VertexMap> answers = procedurePermutations.next().iterator(tx().concepts().graph(),
                     traversal.parameters(), filter).toSet();
-            int i = 0;
-            while (procedurePermutations.hasNext()) {
-                i++;
-                long start = System.nanoTime();
+            for (int i = 0; procedurePermutations.hasNext(); i++) {
                 Set<VertexMap> permutationAnswers = procedurePermutations.next().iterator(tx().concepts().graph(),
                         traversal.parameters(), filter).toSet();
                 assertEquals(answers, permutationAnswers);
-                long end = System.nanoTime();
-                long elapsed = end - start;
-                start = 0 ;
             }
         }
     }

--- a/test/behaviour/typeql/TypeQLSteps.java
+++ b/test/behaviour/typeql/TypeQLSteps.java
@@ -181,18 +181,13 @@ public class TypeQLSteps {
                 .toSet();
         for (Conjunction conjunction : disjunction.conjunctions()) {
             GraphTraversal.Thing traversal = conjunction.traversal(filter);
-            // TODO we expect there to be be only 1 structure in the future
-            List<Structure> structures = traversal.structure().asGraphs();
-            for (Structure structure : structures) {
-                if (structure.vertices().size() == 1) continue;
-                List<GraphProcedure> procedurePermutations = ProcedurePermutator.generate(structure);
-                Set<VertexMap> answers = procedurePermutations.get(0).iterator(tx().concepts().graph(),
+            List<GraphProcedure> procedurePermutations = ProcedurePermutator.generate(traversal.structure());
+            Set<VertexMap> answers = procedurePermutations.get(0).iterator(tx().concepts().graph(),
+                    traversal.parameters(), filter).toSet();
+            for (int i = 1; i < procedurePermutations.size(); i++) {
+                Set<VertexMap> permutationAnswers = procedurePermutations.get(i).iterator(tx().concepts().graph(),
                         traversal.parameters(), filter).toSet();
-                for (int i = 1; i < procedurePermutations.size(); i++) {
-                    Set<VertexMap> permutationAnswers = procedurePermutations.get(i).iterator(tx().concepts().graph(),
-                            traversal.parameters(), filter).toSet();
-                    assertEquals(answers, permutationAnswers);
-                }
+                assertEquals(answers, permutationAnswers);
             }
         }
     }

--- a/traversal/TraversalCache.java
+++ b/traversal/TraversalCache.java
@@ -22,7 +22,6 @@ import com.vaticle.typedb.core.common.cache.CommonCache;
 import com.vaticle.typedb.core.traversal.planner.Planner;
 import com.vaticle.typedb.core.traversal.structure.Structure;
 
-import java.util.Map;
 import java.util.function.Function;
 
 public class TraversalCache {
@@ -41,15 +40,13 @@ public class TraversalCache {
         return activePlanners.get(structure, constructor);
     }
 
-    public void mayUpdatePlanners(Map<Structure, Planner> planners) {
-        planners.forEach((structure, planner) -> {
-            if (planner.isOptimal() && optimalPlanners.getIfPresent(structure) == null) {
-                optimalPlanners.put(structure, planner);
-                activePlanners.invalidate(structure);
-            } else if (!planner.isOptimal() && activePlanners.getIfPresent(structure) == null) {
-                activePlanners.put(structure, planner);
-                optimalPlanners.invalidate(structure);
-            }
-        });
+    public void mayUpdatePlanner(Structure structure, Planner planner) {
+        if (planner.isOptimal() && optimalPlanners.getIfPresent(structure) == null) {
+            optimalPlanners.put(structure, planner);
+            activePlanners.invalidate(structure);
+        } else if (!planner.isOptimal() && activePlanners.getIfPresent(structure) == null) {
+            activePlanners.put(structure, planner);
+            optimalPlanners.invalidate(structure);
+        }
     }
 }

--- a/traversal/TraversalEngine.java
+++ b/traversal/TraversalEngine.java
@@ -18,9 +18,7 @@
 
 package com.vaticle.typedb.core.traversal;
 
-import com.vaticle.typedb.common.collection.Either;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
-import com.vaticle.typedb.core.common.parameters.Arguments;
 import com.vaticle.typedb.core.concurrent.producer.FunctionalProducer;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
@@ -45,10 +43,9 @@ public class TraversalEngine {
         return graphMgr;
     }
 
-    public FunctionalProducer<VertexMap> producer(GraphTraversal.Thing traversal, Either<Arguments.Query.Producer, Long> context,
-                                                  int parallelisation) {
+    public FunctionalProducer<VertexMap> producer(GraphTraversal.Thing traversal, int parallelisation) {
         traversal.initialise(cache);
-        return traversal.permutationProducer(graphMgr, context, parallelisation);
+        return traversal.permutationProducer(graphMgr, parallelisation);
     }
 
     public FunctionalIterator<VertexMap> iterator(GraphTraversal.Thing traversal) {

--- a/traversal/planner/ConnectedPlanner.java
+++ b/traversal/planner/ConnectedPlanner.java
@@ -1,0 +1,13 @@
+package com.vaticle.typedb.core.traversal.planner;
+
+import com.vaticle.typedb.core.traversal.structure.Structure;
+
+public interface ConnectedPlanner extends Planner {
+
+    static ConnectedPlanner create(Structure structure) {
+        assert structure.asGraphs().size() == 1;
+        if (structure.vertices().size() == 1) return VertexPlanner.create(structure.vertices().iterator().next());
+        else return GraphPlanner.create(structure);
+    }
+
+}

--- a/traversal/planner/ConnectedPlanner.java
+++ b/traversal/planner/ConnectedPlanner.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package com.vaticle.typedb.core.traversal.planner;
 
 import com.vaticle.typedb.core.traversal.structure.Structure;

--- a/traversal/planner/ConnectedPlanner.java
+++ b/traversal/planner/ConnectedPlanner.java
@@ -18,7 +18,11 @@
 
 package com.vaticle.typedb.core.traversal.planner;
 
+import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.traversal.structure.Structure;
+
+import static com.vaticle.typedb.common.util.Objects.className;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 
 public interface ConnectedPlanner extends Planner {
 
@@ -28,4 +32,19 @@ public interface ConnectedPlanner extends Planner {
         else return GraphPlanner.create(structure);
     }
 
+    default boolean isVertex() {
+        return false;
+    }
+
+    default boolean isGraph() {
+        return false;
+    }
+
+    default VertexPlanner asVertex() {
+        throw TypeDBException.of(ILLEGAL_CAST, className(this.getClass()), className(VertexPlanner.class));
+    }
+
+    default GraphPlanner asGraph() {
+        throw TypeDBException.of(ILLEGAL_CAST, className(this.getClass()), className(GraphPlanner.class));
+    }
 }

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -96,7 +96,7 @@ public class GraphPlanner implements Planner {
         Set<StructureVertex<?>> registeredVertices = new HashSet<>();
         Set<StructureEdge<?, ?>> registeredEdges = new HashSet<>();
         structure.vertices().forEach(vertex -> planner.registerVertex(vertex, registeredVertices, registeredEdges));
-        assert planner.vertices().size() > 1 && !planner.edges().isEmpty();
+        assert planner.vertices().size() > 1;
         planner.initialiseOptimiserModel();
         return planner;
     }

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -90,18 +90,13 @@ public class GraphPlanner implements Planner {
         snapshot = -1L;
     }
 
-    static GraphPlanner create(Structure structure) {
-        assert structure.vertices().size() > 1;
+    static GraphPlanner create(List<Structure> structures) {
         GraphPlanner planner = new GraphPlanner();
         Set<StructureVertex<?>> registeredVertices = new HashSet<>();
         Set<StructureEdge<?, ?>> registeredEdges = new HashSet<>();
-        structure.asGraphs().forEach(s -> {
-            // we can eliminate subgraphs that are not retrievable
-            // TODO elimination can further be improved if the planning includes the traversal filter
-            if (iterate(s.vertices()).anyMatch(v -> v.id().isRetrievable())) {
-                s.vertices().forEach(vertex -> planner.registerVertex(vertex, registeredVertices, registeredEdges));
-            }
-        });
+        structures.forEach(s ->
+                s.vertices().forEach(vertex -> planner.registerVertex(vertex, registeredVertices, registeredEdges))
+        );
         assert planner.vertices().size() > 1;
         planner.initialiseOptimiserModel();
         return planner;

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -95,7 +95,13 @@ public class GraphPlanner implements Planner {
         GraphPlanner planner = new GraphPlanner();
         Set<StructureVertex<?>> registeredVertices = new HashSet<>();
         Set<StructureEdge<?, ?>> registeredEdges = new HashSet<>();
-        structure.vertices().forEach(vertex -> planner.registerVertex(vertex, registeredVertices, registeredEdges));
+        structure.asGraphs().forEach(s -> {
+            // we can eliminate subgraphs that are not retrievable
+            // TODO elimination can further be improved if the planning includes the traversal filter
+            if (iterate(s.vertices()).anyMatch(v -> v.id().isRetrievable())) {
+                s.vertices().forEach(vertex -> planner.registerVertex(vertex, registeredVertices, registeredEdges));
+            }
+        });
         assert planner.vertices().size() > 1;
         planner.initialiseOptimiserModel();
         return planner;

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNEXPECTED_PLANNING_ERROR;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.concurrent.executor.Executors.async2;
@@ -375,7 +376,7 @@ public class GraphPlanner implements ConnectedPlanner {
 
     private void createProcedure() {
         assert iterate(vertices.values()).allMatch(PlannerVertex::validResults);
-        procedure = GraphProcedure.create(this);
+        procedure = GraphProcedure.create(list(this));
     }
 
     @Override

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -57,6 +57,8 @@ public class GraphPlanner implements ConnectedPlanner {
 
     private static final Logger LOG = LoggerFactory.getLogger(GraphPlanner.class);
 
+    static final long DEFAULT_TIME_LIMIT_MILLIS = 100;
+    static final long HIGHER_TIME_LIMIT_MILLIS = 200;
     static final double OBJECTIVE_PLANNER_COST_MAX_CHANGE = 0.2;
     static final double OBJECTIVE_VARIABLE_COST_MAX_CHANGE = 2.0;
     static final double OBJECTIVE_VARIABLE_TO_PLANNER_COST_MIN_CHANGE = 0.02;

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -53,12 +53,10 @@ import static java.time.Duration.between;
 import static java.util.Comparator.comparing;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-public class GraphPlanner implements Planner {
+public class GraphPlanner implements ConnectedPlanner {
 
     private static final Logger LOG = LoggerFactory.getLogger(GraphPlanner.class);
 
-    static final long DEFAULT_TIME_LIMIT_MILLIS = 100;
-    static final long HIGHER_TIME_LIMIT_MILLIS = 200;
     static final double OBJECTIVE_PLANNER_COST_MAX_CHANGE = 0.2;
     static final double OBJECTIVE_VARIABLE_COST_MAX_CHANGE = 2.0;
     static final double OBJECTIVE_VARIABLE_TO_PLANNER_COST_MIN_CHANGE = 0.02;
@@ -90,13 +88,11 @@ public class GraphPlanner implements Planner {
         snapshot = -1L;
     }
 
-    static GraphPlanner create(List<Structure> structures) {
+    static GraphPlanner create(Structure structure) {
         GraphPlanner planner = new GraphPlanner();
         Set<StructureVertex<?>> registeredVertices = new HashSet<>();
         Set<StructureEdge<?, ?>> registeredEdges = new HashSet<>();
-        structures.forEach(s ->
-                s.vertices().forEach(vertex -> planner.registerVertex(vertex, registeredVertices, registeredEdges))
-        );
+        structure.vertices().forEach(vertex -> planner.registerVertex(vertex, registeredVertices, registeredEdges));
         assert planner.vertices().size() > 1;
         planner.initialiseOptimiserModel();
         return planner;
@@ -229,7 +225,8 @@ public class GraphPlanner implements Planner {
         return optimiser;
     }
 
-    void mayOptimise(GraphManager graphMgr, boolean singleUse) {
+    @Override
+    public void tryOptimise(GraphManager graphMgr, boolean singleUse) {
         long timeLimitMillis = singleUse ? HIGHER_TIME_LIMIT_MILLIS : DEFAULT_TIME_LIMIT_MILLIS;
         if (backgroundOptimisation == null) startFirstOptimise(graphMgr, timeLimitMillis);
         else if (isOptimising.compareAndSet(false, true)) startReOptimise(graphMgr, timeLimitMillis);

--- a/traversal/planner/MultiPlanner.java
+++ b/traversal/planner/MultiPlanner.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNEXPECTED_INTERRUPTION;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
+import static com.vaticle.typedb.core.concurrent.executor.Executors.async1;
 
 public class MultiPlanner implements Planner {
 
@@ -69,7 +70,7 @@ public class MultiPlanner implements Planner {
     private void mayOptimise(GraphManager graphMgr, boolean singleUse) {
         if (isOptimal()) return;
         List<CompletableFuture<Void>> futures = new ArrayList<>(planners.size());
-        planners.forEach(planner -> futures.add(CompletableFuture.runAsync(() -> planner.tryOptimise(graphMgr, singleUse))));
+        planners.forEach(planner -> futures.add(CompletableFuture.runAsync(() -> planner.tryOptimise(graphMgr, singleUse), async1())));
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
         createProcedure();
     }

--- a/traversal/planner/MultiPlanner.java
+++ b/traversal/planner/MultiPlanner.java
@@ -1,5 +1,6 @@
 package com.vaticle.typedb.core.traversal.planner;
 
+import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.traversal.procedure.GraphProcedure;
 import com.vaticle.typedb.core.traversal.procedure.PermutationProcedure;
@@ -12,6 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
 
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 
 public class MultiPlanner implements Planner {
@@ -42,7 +44,7 @@ public class MultiPlanner implements Planner {
                 optimisationLock.acquire();
                 optimisationLock.release();
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                throw TypeDBException.of(ILLEGAL_STATE);
             }
         }
     }

--- a/traversal/planner/MultiPlanner.java
+++ b/traversal/planner/MultiPlanner.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package com.vaticle.typedb.core.traversal.planner;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;

--- a/traversal/planner/MultiPlanner.java
+++ b/traversal/planner/MultiPlanner.java
@@ -47,9 +47,7 @@ public class MultiPlanner implements Planner {
     }
 
     static MultiPlanner create(List<Structure> structures) {
-        List<ConnectedPlanner> planners = new ArrayList<>(structures.size());
-        structures.forEach(s -> planners.add(ConnectedPlanner.create(s)));
-        return new MultiPlanner(planners);
+        return new MultiPlanner(iterate(structures).map(ConnectedPlanner::create).toList());
     }
 
     @Override

--- a/traversal/planner/MultiPlanner.java
+++ b/traversal/planner/MultiPlanner.java
@@ -31,7 +31,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
 
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNEXPECTED_INTERRUPTION;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 
 public class MultiPlanner implements Planner {
@@ -40,9 +40,10 @@ public class MultiPlanner implements Planner {
     private final Semaphore optimisationLock;
     private GraphProcedure procedure;
 
-    public MultiPlanner(List<ConnectedPlanner> planners) {
+    private MultiPlanner(List<ConnectedPlanner> planners) {
         this.planners = planners;
         this.optimisationLock = new Semaphore(1);
+        if (iterate(planners).allMatch(Planner::isOptimal)) createProcedure();
     }
 
     static MultiPlanner create(List<Structure> structures) {
@@ -62,16 +63,13 @@ public class MultiPlanner implements Planner {
                 optimisationLock.acquire();
                 optimisationLock.release();
             } catch (InterruptedException e) {
-                throw TypeDBException.of(ILLEGAL_STATE);
+                throw TypeDBException.of(UNEXPECTED_INTERRUPTION);
             }
         }
     }
 
     private void mayOptimise(GraphManager graphMgr, boolean singleUse) {
-        if (isOptimal()) {
-            if (procedure == null) createProcedure();
-            return;
-        }
+        if (isOptimal()) return;
         List<CompletableFuture<Void>> futures = new ArrayList<>(planners.size());
         planners.forEach(planner -> futures.add(CompletableFuture.runAsync(() -> planner.tryOptimise(graphMgr, singleUse))));
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
@@ -79,8 +77,9 @@ public class MultiPlanner implements Planner {
     }
 
     private void createProcedure() {
-        // create procedure based on optimal ordering of all the planners, heuristically estimated
-        Comparator<Planner> comparator = Comparator.<Planner, Integer>comparing(planner ->
+        // create procedure based on optimal ordering of all the planners
+        // rather than solving the optimisation, we estimate the most expensive traversals are the largest ones
+        Comparator<ConnectedPlanner> comparator = Comparator.<ConnectedPlanner, Integer>comparing(planner ->
                 planner.isVertex() ? 1 : planner.asGraph().vertices().size()
         ).reversed();
         procedure = GraphProcedure.create(planners.stream().sorted(comparator).collect(Collectors.toList()));

--- a/traversal/planner/MultiPlanner.java
+++ b/traversal/planner/MultiPlanner.java
@@ -1,0 +1,65 @@
+package com.vaticle.typedb.core.traversal.planner;
+
+import com.vaticle.typedb.core.graph.GraphManager;
+import com.vaticle.typedb.core.traversal.procedure.GraphProcedure;
+import com.vaticle.typedb.core.traversal.procedure.PermutationProcedure;
+import com.vaticle.typedb.core.traversal.structure.Structure;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
+
+public class MultiPlanner implements Planner {
+
+    private final List<ConnectedPlanner> planners;
+    private final AtomicBoolean isOptimising;
+    private CompletableFuture<Void> optimisation;
+    private GraphProcedure procedure;
+
+    public MultiPlanner(List<ConnectedPlanner> planners) {
+        this.planners = planners;
+        this.isOptimising = new AtomicBoolean(false);
+    }
+
+    static MultiPlanner create(List<Structure> structures) {
+        List<ConnectedPlanner> planners = new ArrayList<>(structures.size());
+        structures.forEach(s -> planners.add(ConnectedPlanner.create(s)));
+        return new MultiPlanner(planners);
+    }
+
+    @Override
+    public void tryOptimise(GraphManager graphMgr, boolean singleUse) {
+        if (isOptimising.compareAndSet(false, true)) mayOptimise(graphMgr, singleUse);
+        optimisation.join();
+    }
+
+    private synchronized void mayOptimise(GraphManager graphMgr, boolean singleUse) {
+        if (isOptimal()) return;
+        List<CompletableFuture<Void>> futures = new ArrayList<>(planners.size());
+        planners.forEach(planner -> futures.add(CompletableFuture.runAsync(() -> planner.tryOptimise(graphMgr, singleUse))));
+        optimisation = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).thenRun(this::createProcedure);
+    }
+
+    private void createProcedure() {
+        // create procedure based on optimal ordering of all the planners, heuristically estimated
+        Comparator<Planner> comparator = Comparator.<Planner, Integer>comparing(planner ->
+                planner.isVertex() ? 1 : planner.asGraph().vertices().size()
+        ).reversed();
+        procedure = GraphProcedure.create(planners.stream().sorted(comparator).collect(Collectors.toList()));
+    }
+
+    @Override
+    public PermutationProcedure procedure() {
+        return procedure;
+    }
+
+    @Override
+    public boolean isOptimal() {
+        return iterate(planners).allMatch(Planner::isOptimal);
+    }
+}

--- a/traversal/planner/Planner.java
+++ b/traversal/planner/Planner.java
@@ -18,24 +18,15 @@
 
 package com.vaticle.typedb.core.traversal.planner;
 
-import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.traversal.procedure.PermutationProcedure;
 import com.vaticle.typedb.core.traversal.structure.Structure;
 
 import java.util.List;
 
-import static com.vaticle.typedb.common.util.Objects.className;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 
 public interface Planner {
-
-    PermutationProcedure procedure();
-
-    boolean isOptimal();
-
-    void tryOptimise(GraphManager graphMgr, boolean singleUse);
 
     static Planner create(Structure structure) {
         List<Structure> retrievedStructures = retrievedStructures(structure.asGraphs());
@@ -49,23 +40,13 @@ public interface Planner {
      */
     static List<Structure> retrievedStructures(List<Structure> structures) {
         return iterate(structures).filter(s ->
-                        iterate(s.vertices()).anyMatch(v -> v.id().isRetrievable())
+                iterate(s.vertices()).anyMatch(v -> v.id().isRetrievable())
         ).toList();
     }
 
-    default boolean isVertex() {
-        return false;
-    }
+    PermutationProcedure procedure();
 
-    default boolean isGraph() {
-        return false;
-    }
+    boolean isOptimal();
 
-    default VertexPlanner asVertex() {
-        throw TypeDBException.of(ILLEGAL_CAST, className(this.getClass()), className(VertexPlanner.class));
-    }
-
-    default GraphPlanner asGraph() {
-        throw TypeDBException.of(ILLEGAL_CAST, className(this.getClass()), className(GraphPlanner.class));
-    }
+    void tryOptimise(GraphManager graphMgr, boolean singleUse);
 }

--- a/traversal/planner/Planner.java
+++ b/traversal/planner/Planner.java
@@ -31,23 +31,24 @@ import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 
 public interface Planner {
 
+    long DEFAULT_TIME_LIMIT_MILLIS = 100;
+    long HIGHER_TIME_LIMIT_MILLIS = 200;
+
     PermutationProcedure procedure();
 
     boolean isOptimal();
 
-    default void tryOptimise(GraphManager graphMgr, boolean singleUse) {
-        if (isGraph()) this.asGraph().mayOptimise(graphMgr, singleUse);
-    }
+    void tryOptimise(GraphManager graphMgr, boolean singleUse);
 
     static Planner create(Structure structure) {
-        List<Structure> retrievedGraphs = iterate(structure.asGraphs()).filter(s ->
-            // we can eliminate subgraphs that are not retrievable
-            // TODO elimination can further be improved if the planning includes the traversal filter
-            iterate(s.vertices()).anyMatch(v -> v.id().isRetrievable())
-        ).toList();
-        if (retrievedGraphs.size() == 1 && retrievedGraphs.get(0).vertices().size() == 1) {
-            return VertexPlanner.create(retrievedGraphs.get(0).vertices().iterator().next());
-        } else return GraphPlanner.create(retrievedGraphs);
+//        List<Structure> retrievedStructures = iterate(structure.asGraphs()).filter(s ->
+////             we can eliminate subgraphs that are not retrievable
+////             TODO elimination can further be improved if the planning includes the traversal filter
+//            iterate(s.vertices()).anyMatch(v -> v.id().isRetrievable())
+//        ).toList();
+        List<Structure> retrievedStructures = structure.asGraphs();
+        if (retrievedStructures.size() == 1) return ConnectedPlanner.create(retrievedStructures.get(0));
+        else return MultiPlanner.create(retrievedStructures);
     }
 
     default boolean isVertex() {

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -130,8 +130,8 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
         }
 
         int numIns = ins().size();
-        OptimiserConstraint conIsStartingVertex = planner.optimiser().constraint(1, numIns, conPrefix + "is_starting_vertex");
-        conIsStartingVertex.setCoefficient(varIsStartingVertex, numIns);
+        OptimiserConstraint conIsStartingVertex = planner.optimiser().constraint(1, numIns + 1, conPrefix + "is_starting_vertex");
+        conIsStartingVertex.setCoefficient(varIsStartingVertex, numIns + 1);
         for (PlannerEdge.Directional<?, ?> edge : ins()) conIsStartingVertex.setCoefficient(edge.varIsSelected, 1);
     }
 

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -145,8 +145,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
     }
 
     boolean validResults() {
-        return !(isStartingVertex() && isEndingVertex()) && (isStartingVertex() ^ hasIncomingEdges())
-                && (isEndingVertex() ^ hasOutgoingEdges());
+        return (isStartingVertex() ^ hasIncomingEdges()) && (isEndingVertex() ^ hasOutgoingEdges());
     }
 
     void setOrder(int order) {

--- a/traversal/planner/VertexPlanner.java
+++ b/traversal/planner/VertexPlanner.java
@@ -20,7 +20,6 @@ package com.vaticle.typedb.core.traversal.planner;
 
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.traversal.procedure.VertexProcedure;
-import com.vaticle.typedb.core.traversal.structure.Structure;
 import com.vaticle.typedb.core.traversal.structure.StructureVertex;
 
 public class VertexPlanner implements ConnectedPlanner {
@@ -28,13 +27,13 @@ public class VertexPlanner implements ConnectedPlanner {
     private final StructureVertex<?> structureVertex;
     private final VertexProcedure procedure;
 
-    private VertexPlanner(StructureVertex<?> structureVertex, VertexProcedure procedure) {
+    private VertexPlanner(StructureVertex<?> structureVertex) {
         this.structureVertex = structureVertex;
-        this.procedure = procedure;
+        this.procedure = VertexProcedure.create(structureVertex);
     }
 
     static VertexPlanner create(StructureVertex<?> structureVertex) {
-        return new VertexPlanner(structureVertex, VertexProcedure.create(structureVertex));
+        return new VertexPlanner(structureVertex);
     }
 
     @Override

--- a/traversal/planner/VertexPlanner.java
+++ b/traversal/planner/VertexPlanner.java
@@ -20,6 +20,7 @@ package com.vaticle.typedb.core.traversal.planner;
 
 import com.vaticle.typedb.core.traversal.procedure.VertexProcedure;
 import com.vaticle.typedb.core.traversal.structure.Structure;
+import com.vaticle.typedb.core.traversal.structure.StructureVertex;
 
 public class VertexPlanner implements Planner {
 
@@ -29,9 +30,8 @@ public class VertexPlanner implements Planner {
         this.procedure = procedure;
     }
 
-    static VertexPlanner create(Structure structure) {
-        assert structure.vertices().size() == 1;
-        return new VertexPlanner(VertexProcedure.create(structure.vertices().iterator().next()));
+    static VertexPlanner create(StructureVertex<?> structureVertex) {
+        return new VertexPlanner(VertexProcedure.create(structureVertex));
     }
 
     @Override

--- a/traversal/planner/VertexPlanner.java
+++ b/traversal/planner/VertexPlanner.java
@@ -18,25 +18,37 @@
 
 package com.vaticle.typedb.core.traversal.planner;
 
+import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.traversal.procedure.VertexProcedure;
 import com.vaticle.typedb.core.traversal.structure.Structure;
 import com.vaticle.typedb.core.traversal.structure.StructureVertex;
 
-public class VertexPlanner implements Planner {
+public class VertexPlanner implements ConnectedPlanner {
 
+    private final StructureVertex<?> structureVertex;
     private final VertexProcedure procedure;
 
-    private VertexPlanner(VertexProcedure procedure) {
+    private VertexPlanner(StructureVertex<?> structureVertex, VertexProcedure procedure) {
+        this.structureVertex = structureVertex;
         this.procedure = procedure;
     }
 
     static VertexPlanner create(StructureVertex<?> structureVertex) {
-        return new VertexPlanner(VertexProcedure.create(structureVertex));
+        return new VertexPlanner(structureVertex, VertexProcedure.create(structureVertex));
     }
 
     @Override
     public VertexProcedure procedure() {
         return procedure;
+    }
+
+    public StructureVertex<?> structureVertex() {
+        return structureVertex;
+    }
+
+    @Override
+    public void tryOptimise(GraphManager graphMgr, boolean singleUse) {
+        assert this.procedure != null;
     }
 
     @Override

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -213,7 +213,7 @@ public class GraphProcedure implements PermutationProcedure {
 
         private void register(Structure structure, Map<Identifier, Integer> orders) {
             assert iterate(structure.vertices()).allMatch(v -> orders.containsKey(v.id())) &&
-                    iterate(structure.vertices()).noneMatch(v ->
+                    iterate(structure.vertices()).allMatch(v ->
                             !vertices.containsKey(v.id()) || vertices.get(v.id()).order() == orders.get(v.id())
                     );
             structure.vertices().forEach(vertex -> vertex(vertex).setOrder(orders.get(vertex.id())));

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -219,7 +219,7 @@ public class GraphProcedure implements PermutationProcedure {
             ProcedureVertex<?, ?> from = vertex(plannerEdge.from());
             ProcedureVertex<?, ?> to = vertex(plannerEdge.to());
             ProcedureEdge<?, ?> edge = ProcedureEdge.of(from, to, plannerEdge);
-            attachEdge(edge);
+            attachEdge(from, to, edge);
         }
 
         private void register(Structure structure, Map<Identifier, Integer> orders) {
@@ -248,15 +248,16 @@ public class GraphProcedure implements PermutationProcedure {
             }
             if (from.order() > to.order()) return;
             ProcedureEdge<?, ?> edge = ProcedureEdge.of(from, to, structureEdge, isForward);
-            attachEdge(edge);
+            attachEdge(from, to, edge);
         }
 
-        public void attachEdge(ProcedureEdge<?, ?> edge) {
-            if (edge.from().equals(edge.to())) {
-                edge.from().loop(edge);
+        public void attachEdge(ProcedureVertex<?, ?> from, ProcedureVertex<?, ?> to, ProcedureEdge<?, ?> edge) {
+            assert from.equals(edge.from()) && to.equals(edge.to());
+            if (from.equals(to)) {
+                from.loop(edge);
             } else {
-                edge.from().out(edge);
-                edge.to().in(edge);
+                from.out(edge);
+                to.in(edge);
             }
         }
 
@@ -342,7 +343,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Type child, ProcedureVertex.Type parent, boolean isTransitive) {
             ProcedureEdge.Native.Type.Sub.Forward edge =
                     new ProcedureEdge.Native.Type.Sub.Forward(child, parent, isTransitive);
-            attachEdge(edge);
+            attachEdge(child, parent, edge);
             return edge;
         }
 
@@ -350,7 +351,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Type parent, ProcedureVertex.Type child, boolean isTransitive) {
             ProcedureEdge.Native.Type.Sub.Backward edge =
                     new ProcedureEdge.Native.Type.Sub.Backward(parent, child, isTransitive);
-            attachEdge(edge);
+            attachEdge(parent, child, edge);
             return edge;
         }
 
@@ -358,7 +359,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Type player, ProcedureVertex.Type roleType) {
             ProcedureEdge.Native.Type.Plays.Forward edge =
                     new ProcedureEdge.Native.Type.Plays.Forward(player, roleType);
-            attachEdge(edge);
+            attachEdge(player, roleType, edge);
             return edge;
         }
 
@@ -366,7 +367,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Type roleType, ProcedureVertex.Type player) {
             ProcedureEdge.Native.Type.Plays.Backward edge =
                     new ProcedureEdge.Native.Type.Plays.Backward(roleType, player);
-            attachEdge(edge);
+            attachEdge(roleType, player, edge);
             return edge;
         }
 
@@ -374,7 +375,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Type owner, ProcedureVertex.Type att, boolean isKey) {
             ProcedureEdge.Native.Type.Owns.Forward edge =
                     new ProcedureEdge.Native.Type.Owns.Forward(owner, att, isKey);
-            attachEdge(edge);
+            attachEdge(owner, att, edge);
             return edge;
         }
 
@@ -382,31 +383,31 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Type att, ProcedureVertex.Type owner, boolean isKey) {
             ProcedureEdge.Native.Type.Owns.Backward edge =
                     new ProcedureEdge.Native.Type.Owns.Backward(att, owner, isKey);
-            attachEdge(edge);
+            attachEdge(att, owner, edge);
             return edge;
         }
 
         public ProcedureEdge.Equal forwardEqual(ProcedureVertex.Type from, ProcedureVertex.Type to) {
             ProcedureEdge.Equal edge = new ProcedureEdge.Equal(from, to, Encoding.Direction.Edge.FORWARD);
-            attachEdge(edge);
+            attachEdge(from, to, edge);
             return edge;
         }
 
         public ProcedureEdge.Equal backwardEqual(ProcedureVertex.Type from, ProcedureVertex.Type to) {
             ProcedureEdge.Equal edge = new ProcedureEdge.Equal(from, to, Encoding.Direction.Edge.BACKWARD);
-            attachEdge(edge);
+            attachEdge(from, to, edge);
             return edge;
         }
 
         public ProcedureEdge.Predicate forwardPredicate(ProcedureVertex.Thing from, ProcedureVertex.Thing to, Predicate.Variable predicate) {
             ProcedureEdge.Predicate edge = new ProcedureEdge.Predicate(from, to, Encoding.Direction.Edge.FORWARD, predicate);
-            attachEdge(edge);
+            attachEdge(from, to, edge);
             return edge;
         }
 
         public ProcedureEdge.Predicate backwardPredicate(ProcedureVertex.Thing from, ProcedureVertex.Thing to, Predicate.Variable predicate) {
             ProcedureEdge.Predicate edge = new ProcedureEdge.Predicate(from, to, Encoding.Direction.Edge.BACKWARD, predicate);
-            attachEdge(edge);
+            attachEdge(from, to, edge);
             return edge;
         }
 
@@ -414,7 +415,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Thing thing, ProcedureVertex.Type type, boolean isTransitive) {
             ProcedureEdge.Native.Isa.Forward edge =
                     new ProcedureEdge.Native.Isa.Forward(thing, type, isTransitive);
-            attachEdge(edge);
+            attachEdge(thing, type, edge);
             return edge;
         }
 
@@ -422,7 +423,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Type type, ProcedureVertex.Thing thing, boolean isTransitive) {
             ProcedureEdge.Native.Isa.Backward edge =
                     new ProcedureEdge.Native.Isa.Backward(type, thing, isTransitive);
-            attachEdge(edge);
+            attachEdge(type, thing, edge);
             return edge;
         }
 
@@ -430,7 +431,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Type relationType, ProcedureVertex.Type roleType) {
             ProcedureEdge.Native.Type.Relates.Forward edge =
                     new ProcedureEdge.Native.Type.Relates.Forward(relationType, roleType);
-            attachEdge(edge);
+            attachEdge(relationType, roleType, edge);
             return edge;
         }
 
@@ -438,7 +439,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Type roleType, ProcedureVertex.Type relationType) {
             ProcedureEdge.Native.Type.Relates.Backward edge =
                     new ProcedureEdge.Native.Type.Relates.Backward(roleType, relationType);
-            attachEdge(edge);
+            attachEdge(roleType, relationType, edge);
             return edge;
         }
 
@@ -446,7 +447,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Thing owner, ProcedureVertex.Thing attribute) {
             ProcedureEdge.Native.Thing.Has.Forward edge =
                     new ProcedureEdge.Native.Thing.Has.Forward(owner, attribute);
-            attachEdge(edge);
+            attachEdge(owner, attribute, edge);
             return edge;
         }
 
@@ -454,7 +455,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Thing attribute, ProcedureVertex.Thing owner) {
             ProcedureEdge.Native.Thing.Has.Backward edge =
                     new ProcedureEdge.Native.Thing.Has.Backward(attribute, owner);
-            attachEdge(edge);
+            attachEdge(attribute, owner, edge);
             return edge;
         }
 
@@ -462,7 +463,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Thing relation, ProcedureVertex.Thing role) {
             ProcedureEdge.Native.Thing.Relating.Forward edge =
                     new ProcedureEdge.Native.Thing.Relating.Forward(relation, role);
-            attachEdge(edge);
+            attachEdge(relation, role, edge);
             return edge;
         }
 
@@ -470,7 +471,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Thing role, ProcedureVertex.Thing relation) {
             ProcedureEdge.Native.Thing.Relating.Backward edge =
                     new ProcedureEdge.Native.Thing.Relating.Backward(role, relation);
-            attachEdge(edge);
+            attachEdge(role, relation, edge);
             return edge;
         }
 
@@ -478,7 +479,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Thing player, ProcedureVertex.Thing role) {
             ProcedureEdge.Native.Thing.Playing.Forward edge =
                     new ProcedureEdge.Native.Thing.Playing.Forward(player, role);
-            attachEdge(edge);
+            attachEdge(player, role, edge);
             return edge;
         }
 
@@ -486,7 +487,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Thing role, ProcedureVertex.Thing player) {
             ProcedureEdge.Native.Thing.Playing.Backward edge =
                     new ProcedureEdge.Native.Thing.Playing.Backward(role, player);
-            attachEdge(edge);
+            attachEdge(role, player, edge);
             return edge;
         }
 
@@ -494,7 +495,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Thing relation, ProcedureVertex.Thing player, int repetition, Set<Label> roleTypes) {
             ProcedureEdge.Native.Thing.RolePlayer.Forward edge =
                     new ProcedureEdge.Native.Thing.RolePlayer.Forward(relation, player, repetition, roleTypes);
-            attachEdge(edge);
+            attachEdge(relation, player, edge);
             return edge;
         }
 
@@ -502,7 +503,7 @@ public class GraphProcedure implements PermutationProcedure {
                 ProcedureVertex.Thing player, ProcedureVertex.Thing relation, int repetition, Set<Label> roleTypes) {
             ProcedureEdge.Native.Thing.RolePlayer.Backward edge =
                     new ProcedureEdge.Native.Thing.RolePlayer.Backward(player, relation, repetition, roleTypes);
-            attachEdge(edge);
+            attachEdge(player, relation, edge);
             return edge;
         }
     }

--- a/traversal/scanner/CombinationFinder.java
+++ b/traversal/scanner/CombinationFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Vaticle
+ * Copyright (C) 2022 Vaticle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/traversal/scanner/GraphIterator.java
+++ b/traversal/scanner/GraphIterator.java
@@ -54,6 +54,10 @@ import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.ASC;
 import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterators.Forwardable.intersect;
 import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterators.Forwardable.iterateSorted;
 
+/**
+ * We have to include the optimisation to only find an answer if a connected predecessor or successor is retrieved
+ *  and we only have to find 1 answer if all successors are not filtered in
+ */
 public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
 
     private static final Logger LOG = LoggerFactory.getLogger(GraphIterator.class);

--- a/traversal/scanner/GraphIterator.java
+++ b/traversal/scanner/GraphIterator.java
@@ -56,7 +56,7 @@ import static com.vaticle.typedb.core.common.iterator.sorted.SortedIterators.For
 
 /**
  * We have to include the optimisation to only find an answer if a connected predecessor or successor is retrieved
- *  and we only have to find 1 answer if all successors are not filtered in
+ * and we only have to find 1 answer if all successors are not filtered in
  */
 public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
 
@@ -80,7 +80,6 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
 
     public GraphIterator(GraphManager graphMgr, Vertex<?, ?> initial, GraphProcedure procedure,
                          Traversal.Parameters params, Set<Identifier.Variable.Retrievable> filter) {
-        assert procedure.vertexCount() > 1;
         this.graphMgr = graphMgr;
         this.procedure = procedure;
         this.params = params;
@@ -96,13 +95,17 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
 
     private void setup() {
         // set up scopes
-        iterate(procedure.vertices()).filter(v -> v.isThing() && v.asThing().isScope())
-                .forEachRemaining(v -> scopes.put(v.id().asVariable(), new Scope()));
+        for (ProcedureVertex<?, ?> v : procedure.vertices()) {
+            if (v.isThing() && v.asThing().isScope()) scopes.put(v.id().asVariable(), new Scope());
+        }
         // set up traversers
-        iterate(procedure.vertices()).forEachRemaining(v -> vertexTraversers.put(v, new VertexTraverser(v)));
+        for (ProcedureVertex<?, ?> v : procedure.vertices()) {
+            vertexTraversers.put(v, new VertexTraverser(v));
+        }
         // add implicit dependencies between traversers
-        iterate(procedure.vertices()).filter(v -> v.isThing() && v.asThing().isScope())
-                .forEachRemaining(this::setupImplicitDependencies);
+        for (ProcedureVertex<?, ?> v : procedure.vertices()) {
+            if (v.isThing() && v.asThing().isScope()) setupImplicitDependencies(v);
+        }
     }
 
     /**
@@ -115,19 +118,19 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
      */
     private void setupImplicitDependencies(ProcedureVertex<?, ?> vertex) {
         Set<ProcedureEdge<?, ?>> rpEdges = iterate(vertex.outs()).filter(e -> e.isRolePlayer() && e.direction().isForward()).toSet();
-        iterate(rpEdges).forEachRemaining(rp1 -> iterate(rpEdges).forEachRemaining(rp2 -> {
+        rpEdges.forEach(rp1 -> rpEdges.forEach(rp2 -> {
             if (rp1.to().order() < rp2.to().order() && rp1.asRolePlayer().overlaps(rp2.asRolePlayer(), params)) {
                 setupImplicitDependency(rp1.to(), rp2.to());
             }
         }));
         Set<ProcedureVertex.Thing> roleVerticesOut = iterate(vertex.outs()).filter(e -> e.isRelating() && e.direction().isForward())
                 .map(e -> e.asRelating().to()).toSet();
-        iterate(roleVerticesOut).forEachRemaining(v1 -> iterate(roleVerticesOut).forEachRemaining(v2 -> {
+        roleVerticesOut.forEach(v1 -> roleVerticesOut.forEach(v2 -> {
             if (v1.order() < v2.order() && v1.overlaps(v2, params)) setupImplicitDependency(v1, v2);
         }));
         Set<ProcedureVertex.Thing> roleVerticesIn = iterate(vertex.ins()).filter(e -> e.isRelating() && e.direction().isBackward())
                 .map(e -> e.asRelating().from()).toSet();
-        iterate(roleVerticesIn).forEachRemaining(v1 -> iterate(roleVerticesIn).forEachRemaining(v2 -> {
+        roleVerticesIn.forEach(v1 -> roleVerticesIn.forEach(v2 -> {
             if (v1.order() < v2.order() && v1.overlaps(v2, params)) setupImplicitDependency(v1, v2);
         }));
     }

--- a/traversal/structure/Structure.java
+++ b/traversal/structure/Structure.java
@@ -41,7 +41,6 @@ public class Structure {
     final Map<Identifier.Variable, TraversalVertex.Properties> properties;
     private final Map<Identifier, StructureVertex<?>> vertices;
     private final Set<StructureEdge<?, ?>> edges;
-    private List<Structure> structures;
 
     public Structure() {
         vertices = new HashMap<>();
@@ -106,56 +105,6 @@ public class Structure {
             edge.from().out(edge);
             edge.to().in(edge);
         }
-    }
-
-    public List<Structure> asGraphs() {
-        if (structures == null) {
-            structures = new ArrayList<>();
-            Set<StructureVertex<?>> verticesToVisit = new HashSet<>(this.vertices.values());
-            Set<StructureEdge<?, ?>> edgesToVisit = new HashSet<>(this.edges);
-            while (!verticesToVisit.isEmpty()) {
-                Structure newStructure = new Structure();
-                splitGraph(verticesToVisit.iterator().next(), newStructure, verticesToVisit, edgesToVisit);
-                if (newStructure.vertices().size() > 1 || newStructure.vertices().iterator().next().id().isRetrievable()) {
-                    structures.add(newStructure);
-                }
-            }
-        }
-        return structures;
-    }
-
-    private void splitGraph(StructureVertex<?> vertex, Structure newStructure,
-                            Set<StructureVertex<?>> verticesToVisit, Set<StructureEdge<?, ?>> edgesToVisit) {
-        if (!verticesToVisit.contains(vertex)) return;
-
-        verticesToVisit.remove(vertex);
-        newStructure.vertices.put(vertex.id(), vertex);
-        TraversalVertex.Properties props;
-        if (vertex.id().isVariable() && (props = this.properties.get(vertex.id().asVariable())) != null) {
-            newStructure.properties.put(vertex.id().asVariable(), props);
-        }
-        List<StructureVertex<?>> adjacents = new ArrayList<>();
-        vertex.outs().forEach(outgoing -> {
-            if (edgesToVisit.contains(outgoing)) {
-                edgesToVisit.remove(outgoing);
-                newStructure.edges.add(outgoing);
-                adjacents.add(outgoing.to());
-            }
-        });
-        vertex.ins().forEach(incoming -> {
-            if (edgesToVisit.contains(incoming)) {
-                edgesToVisit.remove(incoming);
-                newStructure.edges.add(incoming);
-                adjacents.add(incoming.from());
-            }
-        });
-        vertex.loops().forEach(loop -> {
-            if (edgesToVisit.contains(loop)) {
-                edgesToVisit.remove(loop);
-                newStructure.edges.add(loop);
-            }
-        });
-        adjacents.forEach(v -> splitGraph(v, newStructure, verticesToVisit, edgesToVisit));
     }
 
     @Override

--- a/traversal/structure/Structure.java
+++ b/traversal/structure/Structure.java
@@ -41,6 +41,7 @@ public class Structure {
     final Map<Identifier.Variable, TraversalVertex.Properties> properties;
     private final Map<Identifier, StructureVertex<?>> vertices;
     private final Set<StructureEdge<?, ?>> edges;
+    private List<Structure> structures;
 
     public Structure() {
         vertices = new HashMap<>();
@@ -105,6 +106,55 @@ public class Structure {
             edge.from().out(edge);
             edge.to().in(edge);
         }
+    }
+    public List<Structure> asGraphs() {
+        if (structures == null) {
+            structures = new ArrayList<>();
+            Set<StructureVertex<?>> verticesToVisit = new HashSet<>(this.vertices.values());
+            Set<StructureEdge<?, ?>> edgesToVisit = new HashSet<>(this.edges);
+            while (!verticesToVisit.isEmpty()) {
+                Structure newStructure = new Structure();
+                splitGraph(verticesToVisit.iterator().next(), newStructure, verticesToVisit, edgesToVisit);
+                if (newStructure.vertices().size() > 1 || newStructure.vertices().iterator().next().id().isRetrievable()) {
+                    structures.add(newStructure);
+                }
+            }
+        }
+        return structures;
+    }
+
+    private void splitGraph(StructureVertex<?> vertex, Structure newStructure,
+                            Set<StructureVertex<?>> verticesToVisit, Set<StructureEdge<?, ?>> edgesToVisit) {
+        if (!verticesToVisit.contains(vertex)) return;
+
+        verticesToVisit.remove(vertex);
+        newStructure.vertices.put(vertex.id(), vertex);
+        TraversalVertex.Properties props;
+        if (vertex.id().isVariable() && (props = this.properties.get(vertex.id().asVariable())) != null) {
+            newStructure.properties.put(vertex.id().asVariable(), props);
+        }
+        List<StructureVertex<?>> adjacents = new ArrayList<>();
+        vertex.outs().forEach(outgoing -> {
+            if (edgesToVisit.contains(outgoing)) {
+                edgesToVisit.remove(outgoing);
+                newStructure.edges.add(outgoing);
+                adjacents.add(outgoing.to());
+            }
+        });
+        vertex.ins().forEach(incoming -> {
+            if (edgesToVisit.contains(incoming)) {
+                edgesToVisit.remove(incoming);
+                newStructure.edges.add(incoming);
+                adjacents.add(incoming.from());
+            }
+        });
+        vertex.loops().forEach(loop -> {
+            if (edgesToVisit.contains(loop)) {
+                edgesToVisit.remove(loop);
+                newStructure.edges.add(loop);
+            }
+        });
+        adjacents.forEach(v -> splitGraph(v, newStructure, verticesToVisit, edgesToVisit));
     }
 
     @Override

--- a/traversal/test/ProcedurePermutator.java
+++ b/traversal/test/ProcedurePermutator.java
@@ -18,7 +18,6 @@
 
 package com.vaticle.typedb.core.traversal.test;
 
-import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typedb.core.traversal.graph.TraversalVertex;
 import com.vaticle.typedb.core.traversal.procedure.GraphProcedure;
@@ -30,14 +29,11 @@ import java.util.List;
 import java.util.Map;
 
 import static com.vaticle.typedb.common.collection.Collections.permutations;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 
 public class ProcedurePermutator {
 
-    // TODO: receive a Traversal object once the asGraphs call disappears
     public static List<GraphProcedure> generate(Structure structure) {
-        if (structure.asGraphs().size() != 1) throw TypeDBException.of(ILLEGAL_ARGUMENT);
         List<GraphProcedure> procedures = new ArrayList<>();
         for (List<Identifier> ordering : permutations(iterate(structure.vertices()).map(TraversalVertex::id).toList())) {
             Map<Identifier, Integer> orderingMap = new HashMap<>();

--- a/traversal/test/ProcedurePermutator.java
+++ b/traversal/test/ProcedurePermutator.java
@@ -18,14 +18,13 @@
 
 package com.vaticle.typedb.core.traversal.test;
 
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typedb.core.traversal.graph.TraversalVertex;
 import com.vaticle.typedb.core.traversal.procedure.GraphProcedure;
 import com.vaticle.typedb.core.traversal.structure.Structure;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static com.vaticle.typedb.common.collection.Collections.permutations;
@@ -33,15 +32,14 @@ import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 
 public class ProcedurePermutator {
 
-    public static List<GraphProcedure> generate(Structure structure) {
-        List<GraphProcedure> procedures = new ArrayList<>();
-        for (List<Identifier> ordering : permutations(iterate(structure.vertices()).map(TraversalVertex::id).toList())) {
-            Map<Identifier, Integer> orderingMap = new HashMap<>();
-            for (int index = 0; index < ordering.size(); index++) {
-                orderingMap.put(ordering.get(index), index);
-            }
-            procedures.add(GraphProcedure.create(structure, orderingMap));
-        }
-        return procedures;
+    public static FunctionalIterator<GraphProcedure> generate(Structure structure) {
+        return iterate(permutations(iterate(structure.vertices()).map(TraversalVertex::id).toSet()))
+                .map(idPermutation -> {
+                    Map<Identifier, Integer> orderingMap = new HashMap<>();
+                    for (int index = 0; index < idPermutation.size(); index++) {
+                        orderingMap.put(idPermutation.get(index), index);
+                    }
+                    return GraphProcedure.create(structure, orderingMap);
+                });
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

TypeDB traversal engine now traverses disconnected parts of a query using the standard backtracking traversal algorithm. This avoids potential memory issues compared to a caching + cartesian product approach. It also enables future work on native sorting across multiple variables, which must all be part of the graph planning problem.

## What are the changes implemented in this PR?

**Traversal**
* Do not split traversal `Structure`s into its connected subgraphs before entering planning
* Introduce a `ConnectedPlanner` parent type that encompasses both `GraphPlanner` and `VertexPlanner`
* Introduce a `MultiPlanner` that splits and plans multiple sub-plans (`ConnectedPlanner`s) independently, then assembles the outputs of each into a single `Procedure` object
  * Relies on a refactored `GraphProcedure.Builder` to allow constructing a `GraphProcedure` from a list of `ConnectedPlanner`s
  * We heuristically choose the order of the planners to reassemble by just using the ones with the most vertices first, assuming that these are the most expensive
* Update `PlannerVertex` constraints to correctly compute allow for a vertex that has no in or out edges - this vertex must be allowed to be both a start and and end vertex
* Update `Combination` execution procedure generation to handle disconnected subgraphs within a single `Combination`

**Testing**
* The testing of all plan permutations within one structure that includes disconnected subgraphs can blow up in size extremely quickly - we now rely on lazy plan permutation generation and cap the testing at 5000 plans

**Misc**
* Update `GraphIterator` to remove unnecessary use of iterators