### PR TITLE
Deploy artifact snapshots only from 'vaticle' org's 'development' and 'master' branches

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -122,6 +122,9 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-21.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME


### PR DESCRIPTION
## What is the goal of this PR?

Artifact snapshots will no longer be deployed from repo forks, or branches that are not 'development' or 'master'.

## What are the changes implemented in this PR?

Previously, we were deploying artifact snapshots on every push to `vaticle/typedb` and its forks. This quickly resulted in filling up the whole disk of `repo.vaticle.com`.

Now, we only deploy artifact snapshots from the `development` and `master` branches.