### PR TITLE
Fix tar.gz assembly having incorrect folder structure

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -114,9 +114,9 @@ build:
         bazel test //test/assembly:assembly --test_output=streamed
     test-assembly-docker:
       image: vaticle-ubuntu-21.04
-      #filter:
-      #  owner: vaticle
-      #  branch: master
+      filter:
+        owner: vaticle
+        branch: master
       dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-match, test-behaviour-writable, test-behaviour-definable, test-behaviour-reasoner]
       command: |
         bazel test //test/assembly:docker --test_output=streamed

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -122,9 +122,9 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-21.04
-      #filter:
-      #  owner: vaticle
-      #  branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -122,9 +122,9 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-21.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
+      #filter:
+      #  owner: vaticle
+      #  branch: [master, development]
       dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -114,9 +114,9 @@ build:
         bazel test //test/assembly:assembly --test_output=streamed
     test-assembly-docker:
       image: vaticle-ubuntu-21.04
-      filter:
-        owner: vaticle
-        branch: master
+      #filter:
+      #  owner: vaticle
+      #  branch: master
       dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-match, test-behaviour-writable, test-behaviour-definable, test-behaviour-reasoner]
       command: |
         bazel test //test/assembly:docker --test_output=streamed

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,6 +89,18 @@ rules_pkg()
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 
+# Load //github
+load("@vaticle_bazel_distribution//github:deps.bzl", github_deps = "deps")
+github_deps()
+
+# Load //pip
+load("@vaticle_bazel_distribution//pip:deps.bzl", pip_deps = "deps")
+pip_deps()
+
+######################################
+# Load @vaticle_dependencies//distribution docker #
+######################################
+
 # Load //distribution/docker
 load("@vaticle_dependencies//distribution/docker:deps.bzl", docker_deps = "deps")
 docker_deps()
@@ -106,14 +118,6 @@ container_pull(
   repository = "vaticle/ubuntu",
   tag = "4ee548cea883c716055566847c4736a7ef791c38"
 )
-
-# Load //github
-load("@vaticle_bazel_distribution//github:deps.bzl", github_deps = "deps")
-github_deps()
-
-# Load //pip
-load("@vaticle_bazel_distribution//pip:deps.bzl", pip_deps = "deps")
-pip_deps()
 
 #####################################
 # Load @vaticle/typedb dependencies #

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -76,6 +76,19 @@ sonarcloud_dependencies()
 load("@vaticle_dependencies//tool/unuseddeps:deps.bzl", unuseddeps_deps = "deps")
 unuseddeps_deps()
 
+######################################
+# Load @vaticle_bazel_distribution #
+######################################
+
+load("@vaticle_dependencies//distribution:deps.bzl", "vaticle_bazel_distribution")
+vaticle_bazel_distribution()
+
+# Load //common
+load("@vaticle_bazel_distribution//common:deps.bzl", "rules_pkg")
+rules_pkg()
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()
+
 # Load //distribution/docker
 load("@vaticle_dependencies//distribution/docker:deps.bzl", docker_deps = "deps")
 docker_deps()
@@ -93,19 +106,6 @@ container_pull(
   repository = "vaticle/ubuntu",
   tag = "4ee548cea883c716055566847c4736a7ef791c38"
 )
-
-######################################
-# Load @vaticle_bazel_distribution #
-######################################
-
-load("@vaticle_dependencies//distribution:deps.bzl", "vaticle_bazel_distribution")
-vaticle_bazel_distribution()
-
-# Load //common
-load("@vaticle_bazel_distribution//common:deps.bzl", "rules_pkg")
-rules_pkg()
-load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
-rules_pkg_dependencies()
 
 # Load //github
 load("@vaticle_bazel_distribution//github:deps.bzl", github_deps = "deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -98,7 +98,7 @@ load("@vaticle_bazel_distribution//pip:deps.bzl", pip_deps = "deps")
 pip_deps()
 
 ######################################
-# Load @vaticle_dependencies//distribution docker #
+# Load @vaticle_dependencies//distribution/docker #
 ######################################
 
 # Load //distribution/docker

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -101,6 +101,9 @@ pip_deps()
 # Load @vaticle_dependencies//distribution/docker #
 ######################################
 
+# must be loaded after `vaticle_bazel_distribution` to ensure
+# `rules_pkg` is correctly patched (bazel-distribution #issue_no)
+
 # Load //distribution/docker
 load("@vaticle_dependencies//distribution/docker:deps.bzl", docker_deps = "deps")
 docker_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -102,7 +102,7 @@ pip_deps()
 ######################################
 
 # must be loaded after `vaticle_bazel_distribution` to ensure
-# `rules_pkg` is correctly patched (bazel-distribution #issue_no)
+# `rules_pkg` is correctly patched (bazel-distribution #251)
 
 # Load //distribution/docker
 load("@vaticle_dependencies//distribution/docker:deps.bzl", docker_deps = "deps")


### PR DESCRIPTION
## What is the goal of this PR?

Fix the issues in tar.gz assembly that were caused by #6642.

## What are the changes implemented in this PR?

PR #6642 has changed the upstream repository of `rules_docker` to be from `bazelbuild`. Previously, the upstream repository was the Vaticle's fork of `rules_docker`. That fork contained a patch that fixed a bug in `rules_pkg` that stopped `pkg_tar` rule from working with long paths (the bug caused targz assembly of TypeDB to be incorrect) . Incidentally, an identical patch was applied in Vaticle's `bazel-distribution`. By loading, `rules_docker` from `vaticle_dependencies` before `bazel-distribution`, we ended up using the unpatched `rules_pkg` in the assembly targets that were depending on `rules_pkg` (we can't have multiple versions of a workspace dependency at the same time). This caused the targz assembly of TypeDB to contain invalid paths.

The solution in this PR simply swaps the order of loading, so that `typedb` ends up depending on the patched `rules_pkg` that is provided by `bazel-distribution`.

The ideal solution for this problem would be to bump the `rules_pkg` dependency in `bazel-distribution`, however, the newer versions of `rules_pkg` changed their subpackage visibility modifiers. More precisely, in the newer versions, `pkg_tar` depends on private subpackages. Unfortunately, `stardoc`, the tool that we use to generate documentation, does not work with rules that depend on rules that are invisible to our project (https://github.com/bazelbuild/stardoc/issues/93, https://github.com/bazelbuild/stardoc/issues/128). Therefore, in order to continue using `stardoc`, we must continue using the older version of `rules_pkg`.
