### PR TITLE
Simplify and fix traversal forward and back-tracking

### DIFF
--- a/test/behaviour/typeql/TypeQLSteps.java
+++ b/test/behaviour/typeql/TypeQLSteps.java
@@ -182,7 +182,7 @@ public class TypeQLSteps {
         for (Conjunction conjunction : disjunction.conjunctions()) {
             GraphTraversal.Thing traversal = conjunction.traversal(filter);
             // limited permutation space to avoid timeouts
-            FunctionalIterator<GraphProcedure> procedurePermutations = ProcedurePermutator.generate(traversal.structure()).limit(20000);
+            FunctionalIterator<GraphProcedure> procedurePermutations = ProcedurePermutator.generate(traversal.structure()).limit(40320);
             GraphProcedure procedure = procedurePermutations.next();
             Set<VertexMap> answers = procedure.iterator(tx().concepts().graph(),
                     traversal.parameters(), filter).toSet();

--- a/test/behaviour/typeql/TypeQLSteps.java
+++ b/test/behaviour/typeql/TypeQLSteps.java
@@ -181,12 +181,14 @@ public class TypeQLSteps {
                 .toSet();
         for (Conjunction conjunction : disjunction.conjunctions()) {
             GraphTraversal.Thing traversal = conjunction.traversal(filter);
-            // limited permutation space to avoid OOMs and timeouts
-            FunctionalIterator<GraphProcedure> procedurePermutations = ProcedurePermutator.generate(traversal.structure()).limit(5000);
-            Set<VertexMap> answers = procedurePermutations.next().iterator(tx().concepts().graph(),
+            // limited permutation space to avoid timeouts
+            FunctionalIterator<GraphProcedure> procedurePermutations = ProcedurePermutator.generate(traversal.structure()).limit(20000);
+            GraphProcedure procedure = procedurePermutations.next();
+            Set<VertexMap> answers = procedure.iterator(tx().concepts().graph(),
                     traversal.parameters(), filter).toSet();
             for (int i = 0; procedurePermutations.hasNext(); i++) {
-                Set<VertexMap> permutationAnswers = procedurePermutations.next().iterator(tx().concepts().graph(),
+                procedure = procedurePermutations.next();
+                Set<VertexMap> permutationAnswers = procedure.iterator(tx().concepts().graph(),
                         traversal.parameters(), filter).toSet();
                 assertEquals(answers, permutationAnswers);
             }

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -88,7 +88,7 @@ public class GraphProcedure implements PermutationProcedure {
 
     public Set<ProcedureVertex<?, ?>> startVertices() {
         if (startVertices == null) {
-            startVertices = iterate(vertices()).filter(ProcedureVertex::isStartingVertex).toSet();
+            startVertices = iterate(vertices()).filter(ProcedureVertex::isStartVertex).toSet();
         }
         return startVertices;
     }

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -86,11 +86,8 @@ public class GraphProcedure implements PermutationProcedure {
         return vertices[0];
     }
 
-    public Set<ProcedureVertex<?, ?>> startVertices() {
-        if (startVertices == null) {
-            startVertices = iterate(vertices()).filter(ProcedureVertex::isStartVertex).toSet();
-        }
-        return startVertices;
+    public ProcedureVertex<?, ?> lastVertex() {
+        return vertices[vertices.length - 1];
     }
 
     public Set<ProcedureVertex<?, ?>> endVertices() {

--- a/traversal/procedure/ProcedureVertex.java
+++ b/traversal/procedure/ProcedureVertex.java
@@ -71,8 +71,12 @@ public abstract class ProcedureVertex<
 
     public abstract Forwardable<? extends VERTEX, Order.Asc> iterator(GraphManager graphMgr, Traversal.Parameters parameters);
 
-    public boolean isStartingVertex() {
-        return ins().size() == 0;
+    public boolean isStartVertex() {
+        return ins().isEmpty();
+    }
+
+    public boolean isEndVertex() {
+        return outs().isEmpty();
     }
 
     public Thing asThing() {
@@ -112,7 +116,7 @@ public abstract class ProcedureVertex<
     @Override
     public String toString() {
         String str = order() + ": " + super.toString();
-        if (isStartingVertex()) str += " (start)";
+        if (isStartVertex()) str += " (start)";
         if (outs().isEmpty()) str += " (end)";
         return str;
     }

--- a/traversal/procedure/ProcedureVertex.java
+++ b/traversal/procedure/ProcedureVertex.java
@@ -75,10 +75,6 @@ public abstract class ProcedureVertex<
         return ins().isEmpty();
     }
 
-    public boolean isEndVertex() {
-        return outs().isEmpty();
-    }
-
     public Thing asThing() {
         throw TypeDBException.of(ILLEGAL_CAST, className(this.getClass()), className(Thing.class));
     }

--- a/traversal/scanner/GraphIterator.java
+++ b/traversal/scanner/GraphIterator.java
@@ -225,7 +225,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
     }
 
     private void success(VertexTraverser vertexTraverser) {
-        if (vertexTraverser.procedureVertex.order() + 1 == procedure.vertexCount()) return;
+        if (vertexTraverser.procedureVertex.isEndVertex()) return;
         ProcedureVertex<?, ?> next = procedure.vertex(vertexTraverser.procedureVertex.order() + 1);
         toTraverse.add(next);
         vertexTraversers.get(next).clear();
@@ -234,7 +234,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
     private void failed(VertexTraverser vertexTraverser) {
         toRevisit.addAll(vertexTraverser.procedureVertex.dependees());
         toRevisit.addAll(vertexTraverser.implicitDependees);
-        if (!vertexTraverser.anyAnswerFound() && !vertexTraverser.procedureVertex.ins().isEmpty()) {
+        if (!vertexTraverser.anyAnswerFound() && !vertexTraverser.procedureVertex.isStartVertex()) {
             // short circuit everything not required to be re-visited
             for (int i = vertexTraverser.lastDependee.order() + 1; i < vertexTraverser.procedureVertex.order(); i++) {
                 ProcedureVertex<?, ?> skip = procedure.vertex(i);
@@ -345,7 +345,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
         private Forwardable<Vertex<?, ?>, Order.Asc> getIterator() {
             if (iterator == null) {
                 if (procedureVertex.equals(procedure.initialVertex())) iterator = createIteratorFromInitial();
-                else if (procedureVertex.isStartingVertex()) iterator = createIteratorFromStart();
+                else if (procedureVertex.isStartVertex()) iterator = createIteratorFromStart();
                 else iterator = createIteratorFromEdges();
                 // TODO: we may only need to find one valid answer if all dependents are not included in the filter and also find an answer
             }
@@ -358,7 +358,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
         }
 
         private Forwardable<Vertex<?, ?>, Order.Asc> createIteratorFromStart() {
-            assert procedureVertex.isStartingVertex();
+            assert procedureVertex.isStartVertex();
             if (procedureVertex.id().isScoped()) {
                 return applyLocalScope((Forwardable<Vertex<?, ?>, Order.Asc>) procedureVertex.iterator(graphMgr, params));
             } else {

--- a/traversal/scanner/GraphIterator.java
+++ b/traversal/scanner/GraphIterator.java
@@ -248,9 +248,6 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
 
     private void revisit(ProcedureVertex<?, ?> procedureVertex) {
         toTraverse.add(procedureVertex);
-        for (int i = procedureVertex.order() + 1; i < procedure.vertexCount(); i++) {
-            vertexTraversers.get(procedure.vertex(i)).clear();
-        }
         direction = Direction.TRAVERSE;
     }
 

--- a/traversal/scanner/GraphIterator.java
+++ b/traversal/scanner/GraphIterator.java
@@ -163,7 +163,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
             if (iteratorState == IteratorState.COMPLETED) return false;
             else if (iteratorState == IteratorState.FETCHED) return true;
             else if (iteratorState == IteratorState.INIT) {
-                initialiseStarts();
+                initialiseStart();
                 if (computeAnswer()) iteratorState = IteratorState.FETCHED;
                 else setCompleted();
             } else if (iteratorState == IteratorState.EMPTY) {
@@ -192,7 +192,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
         recycle();
     }
 
-    private void initialiseStarts() {
+    private void initialiseStart() {
         toTraverse.add(procedure.vertex(0));
         direction = Direction.TRAVERSE;
     }

--- a/traversal/scanner/GraphIterator.java
+++ b/traversal/scanner/GraphIterator.java
@@ -225,7 +225,7 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
     }
 
     private void success(VertexTraverser vertexTraverser) {
-        if (vertexTraverser.procedureVertex.isEndVertex()) return;
+        if (vertexTraverser.procedureVertex.equals(procedure.lastVertex())) return;
         ProcedureVertex<?, ?> next = procedure.vertex(vertexTraverser.procedureVertex.order() + 1);
         toTraverse.add(next);
         vertexTraversers.get(next).clear();

--- a/traversal/scanner/GraphIterator.java
+++ b/traversal/scanner/GraphIterator.java
@@ -234,8 +234,8 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
     private void failed(VertexTraverser vertexTraverser) {
         toRevisit.addAll(vertexTraverser.procedureVertex.dependees());
         toRevisit.addAll(vertexTraverser.implicitDependees);
-        if (!vertexTraverser.anyAnswerFound() && vertexTraverser.lastDependee != null) {
-            // short circuit everything not required to be visited
+        if (!vertexTraverser.anyAnswerFound() && !vertexTraverser.procedureVertex.ins().isEmpty()) {
+            // short circuit everything not required to be re-visited
             for (int i = vertexTraverser.lastDependee.order() + 1; i < vertexTraverser.procedureVertex.order(); i++) {
                 ProcedureVertex<?, ?> skip = procedure.vertex(i);
                 toRevisit.remove(skip);

--- a/traversal/test/ProcedurePermutator.java
+++ b/traversal/test/ProcedurePermutator.java
@@ -20,12 +20,16 @@ package com.vaticle.typedb.core.traversal.test;
 
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.traversal.common.Identifier;
-import com.vaticle.typedb.core.traversal.graph.TraversalVertex;
 import com.vaticle.typedb.core.traversal.procedure.GraphProcedure;
 import com.vaticle.typedb.core.traversal.structure.Structure;
+import com.vaticle.typedb.core.traversal.structure.StructureVertex;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.vaticle.typedb.common.collection.Permutations.permutations;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
@@ -33,13 +37,19 @@ import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 public class ProcedurePermutator {
 
     public static FunctionalIterator<GraphProcedure> generate(Structure structure) {
-        return iterate(permutations(iterate(structure.vertices()).map(TraversalVertex::id).toSet()))
-                .map(idPermutation -> {
-                    Map<Identifier, Integer> orderingMap = new HashMap<>();
-                    for (int index = 0; index < idPermutation.size(); index++) {
-                        orderingMap.put(idPermutation.get(index), index);
-                    }
-                    return GraphProcedure.create(structure, orderingMap);
-                });
+        // to reduce the permutation space, we always will put the type vertices at the start
+        Set<Identifier> retrievables = new HashSet<>();
+        List<Identifier.Variable.Label> labels = new ArrayList<>();
+        for (StructureVertex<?> vertex : structure.vertices()) {
+            if (vertex.id().isLabel()) labels.add(vertex.id().asVariable().asLabel());
+            else retrievables.add(vertex.id());
+        }
+
+        return iterate(permutations(retrievables)).map(idPermutation -> {
+            Map<Identifier, Integer> orderingMap = new HashMap<>();
+            labels.forEach(labelled -> orderingMap.put(labelled, orderingMap.size()));
+            idPermutation.forEach(retrievable -> orderingMap.put(retrievable, orderingMap.size()));
+            return GraphProcedure.create(structure, orderingMap);
+        });
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

We identify an issue where the forward and back-tracking will lead to an incorrect state. To fix this, we simplify the traversal's progression through the query plan, and only optimise the back-tracking mechanism.

## What are the changes implemented in this PR?

* traversal forward progression simplified to progress to the next vertex in the plan
* follow query plan traversal edges only for backtracking, rather than the forward-stepping
* backtracking in the traversal can skip backward (short circuit) whenever a query vertex failed to find a single answer

* reduce the permutation space of the traversal plan permutator

### Problematic case

Imagine the following query plan:

```
    0
 /     \
1        2
|        |
4        3
```
Let's say the first answer was already found, so every vertex above has a valid solution. 
1. We try to find the next answer, by bumping `4` to the next answer, and it has nothing. 
2. Backtracking will proceed to `3`, because that is another leaf in the `revisit` set, and we add `1` to the `revisit` set as well.
3. Let's say `3` and `2` fail to find an answer, adding `0` to the `revisit` set. 
4. Next, we revisit `1`, which was recorded before, and it finds the next vertex.
5. `2` and `3` will find the same vertices they found for the first answer
6. `4` fails to find a vertex! Here, backtracking would have skipped to `1`. However, this breaks our invariants that everything after the currently explored vertex is cleared/empty.

In the new solution, skipping backward from `4` to `1` will clear everything between them, restoring our invariant. The forward step will then re-visit `2` and `3` by proceeding through the ordered vertices in the query plan.
