### PR TITLE
Reasoner planner treats IID and value-equality constraints as bounds

### DIFF
--- a/reasoner/common/Planner.java
+++ b/reasoner/common/Planner.java
@@ -116,7 +116,6 @@ public class Planner {
                     }
                 }
 
-
                 // Retrievable where:
                 // it can be disconnected
                 // all of it's dependencies are already satisfied (should be moot),

--- a/reasoner/common/Planner.java
+++ b/reasoner/common/Planner.java
@@ -74,6 +74,7 @@ public class Planner {
         }
 
         private void computePlan() {
+            boolean boundsExtended = false;
             while (!unplanned.isEmpty()) {
                 Optional<Concludable> concludable;
                 Optional<com.vaticle.typedb.core.logic.resolvable.Retrievable> retrievable;
@@ -97,6 +98,24 @@ public class Planner {
                     add(concludable.get());
                     continue;
                 }
+
+                // If nothing is connected, see if a variable is bound to an IID or to a value. If yes, add it to the bounds.
+                if (!boundsExtended) {
+                    boundsExtended = true;
+                    Set<Retrievable> extendedBounds = iterate(unplanned).filter(Resolvable::isRetrievable).flatMap(resolvable -> iterate(resolvable.asRetrievable().pattern().variables()))
+                            .flatMap(variable -> iterate(variable.constraints()))
+                            .filter(constraint -> constraint.isThing()).map(constraint -> constraint.asThing())
+                            .filter(thingConstraint -> (thingConstraint.isIID() || (thingConstraint.isValue() && thingConstraint.asValue().isValueIdentity())))
+                            .map(thingConstraint -> thingConstraint.owner().id())
+                            .filter(var -> !boundVariables.contains(var))
+                            .toSet();
+
+                    if (!extendedBounds.isEmpty()) {
+                        boundVariables.addAll(extendedBounds);
+                        continue;
+                    }
+                }
+
 
                 // Retrievable where:
                 // it can be disconnected


### PR DESCRIPTION
## What is the goal of this PR?
The reasoner planner must treat constraints binding a variable to a specific value (or IID) similar to how it treats the variable being bound to a specific thing.
 
When planning the order of resolvables constituting a conjunction, the current reasoner-planner prioritises a connected resolvable over a disconnected one.
A variable which is bound to an IID (or a specific value) has a similarly strong restricting effect. With this PR, the reasoner planner treats these variables as being bound (and hence, all resolvables featuring them as connected) AFTER it runs out of connected resolvables. (Note: for the top-level query, this is always the case).  

## What are the changes implemented in this PR?
- Reasoner planner: When all resolvables left to schedule are disconnected, the boundVariables are extended to include the variables bound to an IID or a specific value.
