### PR TITLE
Rename Order API

### DIFF
--- a/common/iterator/sorted/BaseForwardableIterator.java
+++ b/common/iterator/sorted/BaseForwardableIterator.java
@@ -74,8 +74,8 @@ public class BaseForwardableIterator<T extends Comparable<? super T>, ORDER exte
 
     @Override
     public void forward(T target) {
-        if (last != null && !order.isValidNext(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
-        if (next != null && order.isValidNext(target, next)) return;
+        if (last != null && !order.inOrder(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
+        if (next != null && order.inOrder(target, next)) return;
         this.iterator = order.orderer().iterate(source, target);
         this.next = null;
     }

--- a/common/iterator/sorted/BaseSortedIterator.java
+++ b/common/iterator/sorted/BaseSortedIterator.java
@@ -41,7 +41,7 @@ public class BaseSortedIterator<T extends Comparable<? super T>, ORDER extends O
         T last = source.get(0);
         for (int i = 1; i < source.size(); i++) {
             T next = source.get(i);
-            if (!order.isValidNext(last, next)) return false;
+            if (!order.inOrder(last, next)) return false;
             last = next;
         }
         return true;

--- a/common/iterator/sorted/ConsumeHandledSortedIterator.java
+++ b/common/iterator/sorted/ConsumeHandledSortedIterator.java
@@ -87,7 +87,7 @@ public class ConsumeHandledSortedIterator<T extends Comparable<? super T>, ORDER
 
         @Override
         public void forward(T target) {
-            if (last != null && !order.isValidNext(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
+            if (last != null && !order.inOrder(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
             iterator.forward(target);
         }
 

--- a/common/iterator/sorted/DistinctSortedIterator.java
+++ b/common/iterator/sorted/DistinctSortedIterator.java
@@ -127,7 +127,7 @@ public class DistinctSortedIterator<T extends Comparable<? super T>, ORDER exten
 
         @Override
         public void forward(T target) {
-            if (last != null && !order.isValidNext(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
+            if (last != null && !order.inOrder(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
             iterator.forward(target);
             if (last == null) state = State.INIT;
             else if (state == State.FETCHED) state = State.EMPTY;

--- a/common/iterator/sorted/FilteredSortedIterator.java
+++ b/common/iterator/sorted/FilteredSortedIterator.java
@@ -80,9 +80,9 @@ public class FilteredSortedIterator<T extends Comparable<? super T>, ORDER exten
 
         @Override
         public void forward(T target) {
-            if (last != null && !order.isValidNext(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
+            if (last != null && !order.inOrder(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
             if (next != null) {
-                if (order.isValidNext(target, next)) return;
+                if (order.inOrder(target, next)) return;
                 last = next;
                 next = null;
             }

--- a/common/iterator/sorted/FinaliseSortedIterator.java
+++ b/common/iterator/sorted/FinaliseSortedIterator.java
@@ -76,7 +76,7 @@ public class FinaliseSortedIterator<T extends Comparable<? super T>, ORDER exten
 
         @Override
         public void forward(T target) {
-            if (last != null && !order.isValidNext(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
+            if (last != null && !order.inOrder(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
             iterator.forward(target);
         }
 

--- a/common/iterator/sorted/IntersectForwardableIterator.java
+++ b/common/iterator/sorted/IntersectForwardableIterator.java
@@ -126,12 +126,12 @@ public class IntersectForwardableIterator<T extends Comparable<? super T>, ORDER
         boolean newCandidate = false;
         for (Forwardable<T, ORDER> iterator : iterators) {
             if (iterator == candidateSource) continue;
-            if (iterator.hasNext() && !order.isValidNext(candidate, iterator.peek())) iterator.forward(candidate);
+            if (iterator.hasNext() && !order.inOrder(candidate, iterator.peek())) iterator.forward(candidate);
             if (!iterator.hasNext()) {
                 state = State.COMPLETED;
                 return;
             } else if (!isIntersection(candidate, iterator.peek())) {
-                assert order.isValidNext(candidate, iterator.peek());
+                assert order.inOrder(candidate, iterator.peek());
                 candidate = iterator.peek();
                 candidateSource = iterator;
                 newCandidate = true;

--- a/common/iterator/sorted/LimitedSortedIterator.java
+++ b/common/iterator/sorted/LimitedSortedIterator.java
@@ -82,7 +82,7 @@ public class LimitedSortedIterator<T extends Comparable<? super T>, ORDER extend
 
         @Override
         public void forward(T target) {
-            if (last != null && !order.isValidNext(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
+            if (last != null && !order.inOrder(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
             iterator.forward(target);
         }
 

--- a/common/iterator/sorted/MappedSortedIterator.java
+++ b/common/iterator/sorted/MappedSortedIterator.java
@@ -88,7 +88,7 @@ public class MappedSortedIterator<
     @Override
     public U next() {
         if (!hasNext()) throw new NoSuchElementException();
-        assert last == null || order.isValidNext(last, next) : "Sorted mapped iterator produces out of order values";
+        assert last == null || order.inOrder(last, next) : "Sorted mapped iterator produces out of order values";
         last = next;
         next = null;
         state = State.EMPTY;
@@ -123,12 +123,12 @@ public class MappedSortedIterator<
 
         @Override
         public void forward(U target) {
-            if (last != null && !order.isValidNext(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
+            if (last != null && !order.inOrder(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
             T reverseMapped = reverseMappingFn.apply(target);
             if (state == State.EMPTY) {
                 source.forward(reverseMapped);
             } else if (state == State.FETCHED) {
-                if (order.isValidNext(target, next)) return;
+                if (order.inOrder(target, next)) return;
                 source.forward(reverseMapped);
                 last = next;
                 state = State.EMPTY;

--- a/common/iterator/sorted/MergeMappedSortedIterator.java
+++ b/common/iterator/sorted/MergeMappedSortedIterator.java
@@ -158,11 +158,11 @@ public class MergeMappedSortedIterator<T, U extends Comparable<? super U>, ORDER
 
         @Override
         public void forward(U target) {
-            if (last != null && !order.isValidNext(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
+            if (last != null && !order.inOrder(last, target)) throw TypeDBException.of(ILLEGAL_ARGUMENT);
             if (state == State.INIT) {
                 initialForward = target;
             } else if (state == State.FETCHED) {
-                if (order.isValidNext(target, peek())) return;
+                if (order.inOrder(target, peek())) return;
                 forwardFetched(target);
                 state = State.NOT_READY;
             } else if (state == State.NOT_READY) {

--- a/common/iterator/sorted/SortedIterator.java
+++ b/common/iterator/sorted/SortedIterator.java
@@ -67,7 +67,7 @@ public interface SortedIterator<T extends Comparable<? super T>, ORDER extends O
         Forwardable<T, ORDER> limit(long limit);
 
         default Optional<T> findFirst(T value) {
-            if (!hasNext() || !order().isValidNext(peek(), value)) return Optional.empty();
+            if (!hasNext() || !order().inOrder(peek(), value)) return Optional.empty();
             forward(value);
             Optional<T> found;
             if (hasNext() && peek().equals(value)) found = Optional.of(next());

--- a/common/parameters/Order.java
+++ b/common/parameters/Order.java
@@ -25,8 +25,8 @@ public abstract class Order {
 
     public abstract Orderer orderer();
 
-    public <T extends Comparable<? super T>> boolean isValidNext(T last, T next) {
-        return orderer().compare(last, next) <= 0;
+    public <T extends Comparable<? super T>> boolean inOrder(T first, T second) {
+        return orderer().compare(first, second) <= 0;
     }
 
     public boolean isAscending() {

--- a/database/RocksIterator.java
+++ b/database/RocksIterator.java
@@ -217,7 +217,7 @@ public abstract class RocksIterator<T extends Key, ORDER extends Order>
 
         @Override
         public synchronized void forward(KeyValue<T, ByteArray> target) {
-            if (state == State.COMPLETED || !ASC.isValidNext(prefix.bytes(), target.key().bytes())) return;
+            if (state == State.COMPLETED || !ASC.inOrder(prefix.bytes(), target.key().bytes())) return;
             if (state == State.INIT) initialiseInternalIterator();
             internalRocksIterator.seek(target.key().bytes().getBytes());
             state = State.FORWARDED;
@@ -249,7 +249,7 @@ public abstract class RocksIterator<T extends Key, ORDER extends Order>
 
         @Override
         public synchronized void forward(KeyValue<T, ByteArray> target) {
-            if (state == State.COMPLETED || !DESC.isValidNext(prefix.bytes(), target.key().bytes())) return;
+            if (state == State.COMPLETED || !DESC.inOrder(prefix.bytes(), target.key().bytes())) return;
             if (state == State.INIT) initialiseInternalIterator();
             internalRocksIterator.seekForPrev(target.key().bytes().getBytes());
             state = State.FORWARDED;


### PR DESCRIPTION
## What is the goal of this PR?

We improve the naming of the API `Order` class, which is a parameter used to indicate ascending or descending orders of sequences.

## What are the changes implemented in this PR?
* rename `isValidNext(prev, next)` to `inOrder(first, second)` to reflect that it validates the order, according to its own definition, of two elements from a sequence