### PR TITLE
Refine estimated costs of traversing intersections

### DIFF
--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -292,7 +292,7 @@ public class GraphPlanner implements ComponentPlanner {
     }
 
     private void updateOptimiser() {
-        updateOptimiserCoefficents();
+        updateOptimiserCoefficients();
         updateOptimiserConstraints();
         if (!isVertexOrderInitialised) initialiseVertexOrderGreedy();
         setOptimiserValues();
@@ -308,7 +308,7 @@ public class GraphPlanner implements ComponentPlanner {
         edges.forEach(PlannerEdge::updateOptimiserConstraints);
     }
 
-    private void updateOptimiserCoefficents() {
+    private void updateOptimiserCoefficients() {
         vertices.values().forEach(PlannerVertex::updateOptimiserCoefficients);
         edges.forEach(PlannerEdge::updateOptimiserCoefficients);
     }

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -198,7 +198,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
             for (int i = 0; i < numAdjacent; i++) {
                 OptimiserConstraint conMinimalWithMultiplicity = planner.optimiser().constraint(0, 1, conPrefix + "minimal_with_multiplicity[" + i + "]");
                 conMinimalWithMultiplicity.setCoefficient(varIsMinimal, 1);
-                conMinimalWithMultiplicity.setCoefficient(to.varNumInsEncoding[i + 1], 1);
+                conMinimalWithMultiplicity.setCoefficient(to.varNumInsSelectedOneHot[i + 1], 1);
                 conMinimalWithMultiplicity.setCoefficient(varIsMinimalWithMultiplicity[i], -2);
             }
 
@@ -281,7 +281,7 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                                     noneMatch(e -> e.cheaperThan(this))
             );
             for (int i = 0; i < to.ins().size(); i++) {
-                varIsMinimalWithMultiplicity[i].setValue(varIsMinimal.value() && to.varNumIns.value() == i+1);
+                varIsMinimalWithMultiplicity[i].setValue(varIsMinimal.value() && to.varNumInsSelected.value() == i+1);
             }
         }
 

--- a/traversal/planner/PlannerEdge.java
+++ b/traversal/planner/PlannerEdge.java
@@ -264,9 +264,6 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
         public void setOptimiserValues() {
             setSelected();
             setMinimal();
-            for (int i = 0; i < to.ins().size(); i++) {
-                varIsMinimalWithMultiplicity[i].setValue(varIsMinimal.value() && to.varNumIns.value() == i+1);
-            }
             isInitialised = true;
         }
 
@@ -283,6 +280,9 @@ public abstract class PlannerEdge<VERTEX_FROM extends PlannerVertex<?>, VERTEX_T
                                     filter(e -> e.from().getOrder() < e.to().getOrder()).
                                     noneMatch(e -> e.cheaperThan(this))
             );
+            for (int i = 0; i < to.ins().size(); i++) {
+                varIsMinimalWithMultiplicity[i].setValue(varIsMinimal.value() && to.varNumIns.value() == i+1);
+            }
         }
 
         public boolean isEqual() {

--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -151,6 +151,7 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
     protected void updateOptimiserCoefficients() {
         assert costLastRecorded == safeCost();
         planner.optimiser().setObjectiveCoefficient(varIsStartingVertex, log(1 + safeCost()));
+        for (int i = 1; i < ins().size() + 1; i++) planner.optimiser().setObjectiveCoefficient(varNumInsEncoding[i], log(i));
     }
 
     void recordCost() {


### PR DESCRIPTION
## What is the goal of this PR?

We refine the estimate of the costs of an intersection of multiple edges incoming into a vertex to better reflect the number of operations performed during traversal. Because the cost of traversing to a vertex increases with the number of edges intersecting at the vertex, penalties may be incurred when intersecting many cheap edges. The query planner model is made aware of these penalties. 

## What are the changes implemented in this PR?

Consider the following query structure:

```
A  -  B
 \   /
   C
```

Suppose:
- we always begin traversal from A,
- the cost of traversal of edges AC and BC is 1, that is, for each concept match by A or B we will match exactly one C concept,
- the cost of AB is cheaper than that of CB.

The two possible plans are as follows, traversed top-to-bottom:

```
A            A
|\          /|
| B   or   C |
|/          \|
C            B
```

The cost of the plan is estimated as the product of the costs of querying each vertex. The cost of starting at a vertex is that vertex's cardinality, i.e. the number of concepts that vertex would match in isolation. The cost of traversing to a vertex via edges is estimated as the minimum of the costs of each incoming edge. The cost of an edge, in turn, is an estimate of the average number of concepts that would be matched by traversing this vertex given a fixed value at the edge's source, plus one to account for verifying that there are no further answers.

Given all that, the estimated costs of the plans in question are estimated as:

```
|A| * (1 + |AB|) * (1 + min(|AC|, |BC|)) = |A| * (1 + |AB|) * 2

|A| * (1 + |AC|) * (1 + min(|AB|, |CB|)) = |A| * 2 * (1 + |AB|)
```

which are equivalent. In other words, the planner cannot tell the difference between the two plans.

It turns out that for most sets of data the first plan will perform significantly worse. A more correct estimate of the work done to traverse to a vertex via some set of edges is `N * (1 + |V| * Π |E|/|V|)`, where N is the number of edges intersecting at the vertex. `|E|/|V|` is the "filtering power" of an edge, which is to say, it's the portion of the concepts at its destination that traversing the edge would match, on average. `1 + |V| * Π |E|/|V|` therefore represents the total expected number of matches produced by the intersection as a whole, once again accounting for verifying that there are no more answers by adding one. Finally, the factor of `N` represents the fact that each of the `N` edges must be queried at least once to produce each answer.

With that in mind, the estimated costs of the two plans from before would instead be:

```
|A| * (1 + |AB|) * 2 * (1 + |AC| * |BC| / |C|) = 
    |A| * (1 + |AB|) * 2 * (1 + 1 / |C|) ≈
    2 * |A| * (1 + |E|) * (1 + 1/|V|) ≈
    2 * |A| * (1 + |E|)

|A| * (1 + |AC|) * 2 * (1 + |AB| * |CB| / |B|) =
    |A| * 2 * 2 * (1 + |AB| * |CB| / |B|) ≈
    4 * |A| * (1 + |E|² / |V|) ≈
    4 * |A|
```

Assuming `|AB| ≈ |CB| ≈ |E|`, `|B| ≈ |C| ≈ |V|`, `|E| << |V|`.

Because the cost of traversing to a vertex via an edge is capped at N from below by the need to verify that the iterator has no more matches, intersecting many cheap edges is not as powerful as intersecting few expensive ones. This change is now reflected in the planner model. The additional complexity slows down the convergence quite a bit, but intermediate solutions are generally better due to more accurate estimation.