### PR TITLE
Linearise query traversal

### DIFF
--- a/common/iterator/AbstractFunctionalIterator.java
+++ b/common/iterator/AbstractFunctionalIterator.java
@@ -26,6 +26,7 @@ import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Forwardable
 import com.vaticle.typedb.core.common.parameters.Order;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -35,6 +36,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -216,6 +218,13 @@ public abstract class AbstractFunctionalIterator<T> implements FunctionalIterato
     public void toSet(Set<T> set) {
         this.forEachRemaining(set::add);
         recycle();
+    }
+
+    @Override
+    public <U extends Collection<? super T>> U collect(Supplier<U> constructor) {
+        U collection = constructor.get();
+        this.forEachRemaining(collection::add);
+        return collection;
     }
 
     @Override

--- a/common/iterator/FunctionalIterator.java
+++ b/common/iterator/FunctionalIterator.java
@@ -22,6 +22,7 @@ import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
 import com.vaticle.typedb.core.common.parameters.Order;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -31,6 +32,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public interface FunctionalIterator<T> extends Iterator<T> {
@@ -88,6 +90,8 @@ public interface FunctionalIterator<T> extends Iterator<T> {
     Set<T> toSet();
 
     void toSet(Set<T> set);
+
+    <U extends Collection<? super T>> U collect(Supplier<U> constructor);
 
     long count();
 

--- a/common/iterator/sorted/AbstractSortedIterator.java
+++ b/common/iterator/sorted/AbstractSortedIterator.java
@@ -30,6 +30,7 @@ import com.vaticle.typedb.core.common.iterator.OffsetIterator;
 import com.vaticle.typedb.core.common.parameters.Order;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -41,6 +42,7 @@ import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -230,6 +232,13 @@ public abstract class AbstractSortedIterator<T extends Comparable<? super T>, OR
     public void toSet(Set<T> set) {
         this.forEachRemaining(set::add);
         recycle();
+    }
+
+    @Override
+    public <U extends Collection<? super T>> U collect(Supplier<U> constructor) {
+        U collection = constructor.get();
+        this.forEachRemaining(collection::add);
+        return collection;
     }
 
     @Override

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -296,15 +297,15 @@ public class GraphPlanner implements ComponentPlanner {
 
     private void linearise() {
         Set<PlannerVertex<?>> visited = new HashSet<>();
-        List<PlannerVertex<?>> stack = vertices.values().stream().filter(PlannerVertex::isStartingVertex).collect(Collectors.toList());
+        LinkedList<PlannerVertex<?>> toVisit = vertices.values().stream().filter(PlannerVertex::isStartingVertex).collect(Collectors.toCollection(LinkedList::new));
         int vertexOrder = 0;
-        while (!stack.isEmpty()) {
-            PlannerVertex<?> vertex = stack.remove(stack.size() - 1);
+        while (!toVisit.isEmpty()) {
+            PlannerVertex<?> vertex = toVisit.removeFirst();
             vertex.setOrder(vertexOrder++);
             visited.add(vertex);
             for (PlannerVertex<?> v : vertex.outs().stream().filter(PlannerEdge.Directional::isSelected).map(PlannerEdge.Directional::to).collect(Collectors.toSet())) {
                 if (!visited.contains(v) && visited.containsAll(v.ins().stream().filter(PlannerEdge.Directional::isSelected).map(PlannerEdge.Directional::from).collect(Collectors.toSet()))) {
-                    stack.add(v);
+                    toVisit.addFirst(v);
                 }
             }
         }

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -310,8 +310,7 @@ public class GraphPlanner implements ComponentPlanner {
                 }
             }
         }
-        assert visited.size() == vertices.size();
-        assert vertexOrder == vertices.size();
+        assert visited.size() == vertices.size() && vertexOrder == vertices.size();
     }
 
 

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -297,7 +297,7 @@ public class GraphPlanner implements ComponentPlanner {
 
     private void linearise() {
         Set<PlannerVertex<?>> visited = new HashSet<>();
-        LinkedList<PlannerVertex<?>> toVisit = vertices.values().stream().filter(PlannerVertex::isStartingVertex).collect(Collectors.toCollection(LinkedList::new));
+        LinkedList<PlannerVertex<?>> toVisit = iterate(vertices.values()).filter(PlannerVertex::isStartingVertex).collect(LinkedList::new);
         int vertexOrder = 0;
         while (!toVisit.isEmpty()) {
             PlannerVertex<?> vertex = toVisit.removeFirst();

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -295,20 +295,20 @@ public class GraphPlanner implements ComponentPlanner {
     }
 
     private void linearise() {
-        Set<PlannerVertex<?>> orderedSet = new HashSet<>();
+        Set<PlannerVertex<?>> orderedVertices = new HashSet<>();
         List<PlannerVertex<?>> stack = vertices.values().stream().filter(PlannerVertex::isStartingVertex).collect(Collectors.toList());
         int vertexOrder = 0;
         while (!stack.isEmpty()) {
             PlannerVertex<?> vertex = stack.remove(stack.size() - 1);
             vertex.setOrder(vertexOrder++);
-            orderedSet.add(vertex);
+            orderedVertices.add(vertex);
             for (PlannerVertex<?> v : vertex.outs().stream().filter(PlannerEdge.Directional::isSelected).map(PlannerEdge.Directional::to).collect(Collectors.toSet())) {
-                if (!orderedSet.contains(v) && orderedSet.containsAll(v.ins().stream().filter(PlannerEdge.Directional::isSelected).map(PlannerEdge.Directional::from).collect(Collectors.toSet()))) {
+                if (!orderedVertices.contains(v) && orderedVertices.containsAll(v.ins().stream().filter(PlannerEdge.Directional::isSelected).map(PlannerEdge.Directional::from).collect(Collectors.toSet()))) {
                     stack.add(v);
                 }
             }
         }
-        assert orderedSet.size() == vertices.size();
+        assert orderedVertices.size() == vertices.size();
         assert vertexOrder == vertices.size();
     }
 

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -295,20 +295,20 @@ public class GraphPlanner implements ComponentPlanner {
     }
 
     private void linearise() {
-        Set<PlannerVertex<?>> orderedVertices = new HashSet<>();
+        Set<PlannerVertex<?>> visited = new HashSet<>();
         List<PlannerVertex<?>> stack = vertices.values().stream().filter(PlannerVertex::isStartingVertex).collect(Collectors.toList());
         int vertexOrder = 0;
         while (!stack.isEmpty()) {
             PlannerVertex<?> vertex = stack.remove(stack.size() - 1);
             vertex.setOrder(vertexOrder++);
-            orderedVertices.add(vertex);
+            visited.add(vertex);
             for (PlannerVertex<?> v : vertex.outs().stream().filter(PlannerEdge.Directional::isSelected).map(PlannerEdge.Directional::to).collect(Collectors.toSet())) {
-                if (!orderedVertices.contains(v) && orderedVertices.containsAll(v.ins().stream().filter(PlannerEdge.Directional::isSelected).map(PlannerEdge.Directional::from).collect(Collectors.toSet()))) {
+                if (!visited.contains(v) && visited.containsAll(v.ins().stream().filter(PlannerEdge.Directional::isSelected).map(PlannerEdge.Directional::from).collect(Collectors.toSet()))) {
                     stack.add(v);
                 }
             }
         }
-        assert orderedVertices.size() == vertices.size();
+        assert visited.size() == vertices.size();
         assert vertexOrder == vertices.size();
     }
 

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -303,8 +303,9 @@ public class GraphPlanner implements ComponentPlanner {
             PlannerVertex<?> vertex = toVisit.removeFirst();
             vertex.setOrder(vertexOrder++);
             visited.add(vertex);
-            for (PlannerVertex<?> v : vertex.outs().stream().filter(PlannerEdge.Directional::isSelected).map(PlannerEdge.Directional::to).collect(Collectors.toSet())) {
-                if (!visited.contains(v) && visited.containsAll(v.ins().stream().filter(PlannerEdge.Directional::isSelected).map(PlannerEdge.Directional::from).collect(Collectors.toSet()))) {
+            for (PlannerVertex<?> v : iterate(vertex.outs()).filter(PlannerEdge.Directional::isSelected).map(PlannerEdge.Directional::to).toSet()) {
+                if (iterate(v.ins()).filter(PlannerEdge.Directional::isSelected).map(PlannerEdge.Directional::from).allMatch(visited::contains)) {
+                    assert !visited.contains(v);
                     toVisit.addFirst(v);
                 }
             }

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -192,13 +192,13 @@ public class GraphProcedure implements PermutationProcedure {
         }
 
         private void linearise() {
-            List<ProcedureVertex<?, ?>> ordering = new ArrayList<>();
             Set<ProcedureVertex<?, ?>> orderedSet = new HashSet<>();
             List<ProcedureVertex<?, ?>> stack =  vertices.values().stream().filter(ProcedureVertex::isStartVertex).collect(Collectors.toList());
+            int vertexOrder = 0;
             while (!stack.isEmpty()) {
                 ProcedureVertex<?, ?> vertex = stack.remove(stack.size() - 1);
                 if (orderedSet.contains(vertex)) continue;
-                ordering.add(vertex);
+                vertex.setOrder(vertexOrder++);
                 orderedSet.add(vertex);
                 for (ProcedureVertex<?, ?> v : vertex.outs().stream().map(ProcedureEdge::to).toArray(ProcedureVertex[]::new)) {
                     if (!orderedSet.contains(v) && orderedSet.containsAll(v.ins().stream().map(ProcedureEdge::from).collect(Collectors.toSet()))) {
@@ -206,8 +206,8 @@ public class GraphProcedure implements PermutationProcedure {
                     }
                 }
             }
-            assert ordering.size() == vertices.size();
-            for (int i = 0; i < ordering.size(); i++) ordering.get(i).setOrder(i);
+            assert orderedSet.size() == vertices.size();
+            assert vertexOrder == vertices.size();
         }
 
         private void register(GraphPlanner planner, int startOrder) {

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -196,10 +196,9 @@ public class GraphProcedure implements PermutationProcedure {
             int vertexOrder = 0;
             while (!stack.isEmpty()) {
                 ProcedureVertex<?, ?> vertex = stack.remove(stack.size() - 1);
-                if (orderedSet.contains(vertex)) continue;
                 vertex.setOrder(vertexOrder++);
                 orderedSet.add(vertex);
-                for (ProcedureVertex<?, ?> v : vertex.outs().stream().map(ProcedureEdge::to).toArray(ProcedureVertex[]::new)) {
+                for (ProcedureVertex<?, ?> v : vertex.outs().stream().map(ProcedureEdge::to).collect(Collectors.toSet())) {
                     if (!orderedSet.contains(v) && orderedSet.containsAll(v.ins().stream().map(ProcedureEdge::from).collect(Collectors.toSet()))) {
                         stack.add(v);
                     }

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -42,7 +42,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;


### PR DESCRIPTION
## What is the goal of this PR?

We ensure that the traversal of a query procedure is performed with as little "jumping" between unrelated concepts as possible.

## What are the changes implemented in this PR?

When a graph iterator fetches the candidates for ea, it does so in the order specified in the procedure. Because the graph planner only considers the direction of the edges and not the exact ordering of the vertices, the resulting procedure may look as follows:

```
   0
 /   \
1     2
|     |
4     3
```

In this example, if the vertex no. 4 does not match any things in the database, the iterator would backtrack back to vertex no. 1 and revisit vertices no. 2 & 3, duplicating work unnecessarily.

Through a simple depth-first topological sort, we ensure that the traversal follows edges whenever possible, eliminating this problem.