### PR TITLE
Propagate bound-restrictions through conjunction model

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -122,6 +122,9 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-21.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
@@ -214,7 +217,8 @@ release:
       dependencies: [deploy-github]
       command: |
         docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
-        bazel run //:deploy-docker
+        bazel run //:deploy-docker-latest
+        bazel run //:deploy-docker-versioned
     deploy-artifact-release:
       image: vaticle-ubuntu-21.04
       filter:

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -87,6 +87,9 @@ public abstract class Concludable extends Resolvable<Conjunction> implements Alp
         return retrievableIds;
     }
 
+    @Override
+    public Set<Variable> variables() { return pattern().variables(); }
+
     public boolean isConcludable() {
         return true;
     }

--- a/logic/resolvable/Negated.java
+++ b/logic/resolvable/Negated.java
@@ -20,6 +20,7 @@ package com.vaticle.typedb.core.logic.resolvable;
 import com.vaticle.typedb.core.pattern.Disjunction;
 import com.vaticle.typedb.core.pattern.Negation;
 import com.vaticle.typedb.core.pattern.variable.ThingVariable;
+import com.vaticle.typedb.core.pattern.variable.Variable;
 import com.vaticle.typedb.core.traversal.common.Identifier.Variable.Retrievable;
 
 import java.util.HashSet;
@@ -53,6 +54,9 @@ public class Negated extends Resolvable<Disjunction> {
     public Set<Retrievable> retrieves() {
         return this.identifiers;
     }
+
+    @Override
+    public Set<Variable> variables() { return iterate(pattern().conjunctions()).flatMap(conj -> iterate(conj.variables())).toSet(); }
 
     @Override
     public boolean isNegated() {

--- a/logic/resolvable/Resolvable.java
+++ b/logic/resolvable/Resolvable.java
@@ -20,6 +20,7 @@ package com.vaticle.typedb.core.logic.resolvable;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.pattern.Pattern;
 import com.vaticle.typedb.core.pattern.variable.ThingVariable;
+import com.vaticle.typedb.core.pattern.variable.Variable;
 import com.vaticle.typedb.core.traversal.common.Identifier.Variable.Retrievable;
 
 import java.util.Optional;
@@ -41,6 +42,8 @@ public abstract class Resolvable<T extends Pattern> {
     public abstract Optional<ThingVariable> generating();
 
     public abstract Set<Retrievable> retrieves();
+
+    public abstract Set<Variable> variables();
 
     public boolean isRetrievable() {
         return false;

--- a/logic/resolvable/ResolvableConjunction.java
+++ b/logic/resolvable/ResolvableConjunction.java
@@ -62,4 +62,9 @@ public class ResolvableConjunction {
                 iterate(negations()).flatMap(negated -> iterate(negated.disjunction().conjunctions()))
                         .flatMap(conj -> conj.allConcludables()));
     }
+
+    @Override
+    public String toString() {
+        return "ResolvableConjunction{" +  conjunctionPattern + '}';
+    }
 }

--- a/logic/resolvable/ResolvableConjunction.java
+++ b/logic/resolvable/ResolvableConjunction.java
@@ -65,6 +65,6 @@ public class ResolvableConjunction {
 
     @Override
     public String toString() {
-        return "ResolvableConjunction{" +  conjunctionPattern + '}';
+        return conjunctionPattern.toString();
     }
 }

--- a/logic/resolvable/Retrievable.java
+++ b/logic/resolvable/Retrievable.java
@@ -57,6 +57,9 @@ public class Retrievable extends Resolvable<Conjunction> {
     }
 
     @Override
+    public Set<Variable> variables() { return pattern().variables(); }
+
+    @Override
     public Retrievable asRetrievable() {
         return this;
     }

--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -361,7 +361,6 @@ public class AnswerCountEstimator {
             }
         }
 
-
         private static class RelationModel extends LocalModel {
             private final RelationConstraint relation;
             private final Map<TypeVariable, Long> rolePlayerEstimates;
@@ -383,7 +382,6 @@ public class AnswerCountEstimator {
                     TypeVariable roleType = player.roleType().isPresent() ? player.roleType().get() : null;
                     this.rolePlayerTypes.put(player.player(), roleType);
                 });
-
             }
 
             @Override
@@ -523,7 +521,6 @@ public class AnswerCountEstimator {
 
             inferredRelationsEstimate = Math.min(inferredRelationsEstimate, relationUpperBound - persistedRelationEstimate);
 
-
             for (RelationConstraint.RolePlayer rp : rolePlayers) {
                 TypeVariable key = rp.roleType().orElse(null);
                 rolePlayerCounts.put(key, rolePlayerCounts.getOrDefault(key, 0) + 1);
@@ -546,10 +543,7 @@ public class AnswerCountEstimator {
                     boolean rulesConcludeOwner = iterate(hasConstraint.owner().inferredTypes()).flatMap(ownerType -> iterate(answerCountEstimator.logicMgr.rulesConcluding(ownerType))).hasNext();
                     if (rulesConcludeOwner) ownerEstimate = hasEdgeEstimate / attributeEstimate;
                 }
-
-
             }
-
             return new LocalModel.HasModel(hasConstraint, hasEdgeEstimate, ownerEstimate, attributeEstimate);
         }
 

--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -15,12 +15,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-
 package com.vaticle.typedb.core.reasoner.planner;
 
+import com.vaticle.typedb.common.collection.Pair;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
-import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
-import com.vaticle.typedb.core.common.iterator.Iterators;
 import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.logic.LogicManager;
@@ -40,6 +38,7 @@ import com.vaticle.typedb.core.pattern.constraint.thing.ValueConstraint;
 import com.vaticle.typedb.core.pattern.variable.ThingVariable;
 import com.vaticle.typedb.core.pattern.variable.TypeVariable;
 import com.vaticle.typedb.core.pattern.variable.Variable;
+import com.vaticle.typedb.core.reasoner.planner.ConjunctionSummarizer.ConjunctionSummary;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 
 import java.util.ArrayList;
@@ -60,210 +59,216 @@ import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 public class AnswerCountEstimator {
     private final LogicManager logicMgr;
     private final ConjunctionModelFactory conjunctionModelFactory;
-
+    private final ConjunctionSummarizer conjunctionSummarizer;
     private final Map<ResolvableConjunction, ConjunctionModel> conjunctionModels;
-    private final Map<ResolvableConjunction, Set<Concludable>> cyclicConcludables;
 
-    public AnswerCountEstimator(LogicManager logicMgr, GraphManager graph) {
+    public AnswerCountEstimator(LogicManager logicMgr, GraphManager graph, ConjunctionSummarizer conjunctionSummarizer) {
         this.logicMgr = logicMgr;
         this.conjunctionModelFactory = new ConjunctionModelFactory(new LocalModelFactory(this, graph));
+        this.conjunctionSummarizer = conjunctionSummarizer;
         this.conjunctionModels = new HashMap<>();
-        this.cyclicConcludables = new HashMap<>();
     }
 
-    public long estimateAnswers(ResolvableConjunction conjunction, Set<Variable> variables) {
-        return estimateAnswers(conjunction, variables, logicMgr.compile(conjunction));
-    }
-
-    public long estimateAnswers(ResolvableConjunction conjunction, Set<Variable> variables, Set<Resolvable<?>> resolvables) {
-        if (!conjunctionModels.containsKey(conjunction)) registerAndBuildModel(conjunction);
-        assert conjunction.pattern().variables().containsAll(variables);
-        assert logicMgr.compile(conjunction).containsAll(resolvables);
-        return conjunctionModels.get(conjunction).estimateAnswers(variables, resolvables);
-    }
-
-    private void registerAndBuildModel(ResolvableConjunction conjunction) {
-        registerCycles(conjunction, new ConjunctionConcludableStack());
-        buildConjunctionModel(conjunction);
-    }
-
-    private void registerCycles(ResolvableConjunction conjunction, ConjunctionConcludableStack stack) {
-        if (stack.contains(conjunction)) {
-            stack.peekUntil(conjunction).forEach(conj ->
-                    cyclicConcludables.computeIfAbsent(conj, c -> new HashSet<>()).add(stack.getConcludable(conj))
-            );
-        } else {
-            stack.add(conjunction);
-            Set<Resolvable<?>> resolvables = logicMgr.compile(conjunction);
-            iterate(resolvables).filter(Resolvable::isNegated).map(Resolvable::asNegated)
-                    .flatMap(negated -> iterate(negated.disjunction().conjunctions()))
-                    .forEachRemaining(dependency -> registerCycles(dependency, new ConjunctionConcludableStack())); // Stratified negation -> Fresh set
-            iterate(resolvables).filter(Resolvable::isConcludable).map(Resolvable::asConcludable)
-                    .forEachRemaining(concludable -> {
-                        stack.setConcludable(conjunction, concludable);
-                        iterate(dependencies(concludable)).forEachRemaining(dependency -> registerCycles(dependency, stack));
-                    });
-            assert stack.last() == conjunction;
-            stack.pop();
-        }
-    }
-
-    private void buildConjunctionModel(ResolvableConjunction conjunction) {
+    public void buildConjunctionModel(ResolvableConjunction conjunction) {
         if (!conjunctionModels.containsKey(conjunction)) {
-            ConjunctionContext conjunctionContext = new ConjunctionContext(conjunction, logicMgr.compile(conjunction), cyclicConcludables.getOrDefault(conjunction, new HashSet<>()));
-
             // Acyclic estimates
-            iterate(conjunctionContext.negateds()).flatMap(negated -> iterate(negated.disjunction().conjunctions()))
+            ConjunctionSummary conjunctionSummary = conjunctionSummarizer.conjunctionSummary(conjunction);
+            iterate(conjunctionSummary.negateds()).flatMap(negated -> iterate(negated.disjunction().conjunctions()))
                     .forEachRemaining(this::buildConjunctionModel);
-            iterate(conjunctionContext.acyclicConcludables()).flatMap(concludable -> iterate(dependencies(concludable)))
+            iterate(conjunctionSummary.acyclicConcludables()).flatMap(concludable -> iterate(conjunctionSummarizer.dependencies(concludable)))
                     .forEachRemaining(this::buildConjunctionModel);
-
-            ConjunctionModel acyclicModel = conjunctionModelFactory.buildAcyclicModel(conjunctionContext);
+            // Don't recurse into acyclic dependencies of cyclic concludables. That overconstrains the disjunction b/w acyclic & cyclic.
+            // TODO: ^ Does it though?
+            AnswerCountEstimator.ConjunctionModel acyclicModel = conjunctionModelFactory.buildAcyclicModel(conjunctionSummary);
             conjunctionModels.put(conjunction, acyclicModel);
 
             // cyclic calls to this model will answer based on the acyclic model.
-            iterate(conjunctionContext.cyclicConcludables()).flatMap(concludable -> iterate(dependencies(concludable)))
+            iterate(conjunctionSummary.cyclicConcludables()).flatMap(concludable -> iterate(conjunctionSummarizer.dependencies(concludable)))
                     .forEachRemaining(this::buildConjunctionModel);
-            ConjunctionModel cyclicModel = conjunctionModelFactory.buildCyclicModel(conjunctionContext, acyclicModel);
+            AnswerCountEstimator.ConjunctionModel cyclicModel = conjunctionModelFactory.buildCyclicModel(conjunctionSummary, acyclicModel);
             conjunctionModels.put(conjunction, cyclicModel);
         }
     }
 
-    private Set<ResolvableConjunction> dependencies(Concludable concludable) {
-        return iterate(logicMgr.applicableRules(concludable).keySet()).map(rule -> rule.condition().conjunction()).toSet();
+    public long estimateAnswers(ResolvableConjunction conjunction, Set<Variable> variables) {
+        // TODO: REMOVE!
+        if (!conjunctionModels.containsKey(conjunction)) buildConjunctionModel(conjunction);
+        IncrementalEstimator incrementalEstimator = createIncrementalEstimator(conjunction);
+        Set<Variable> estimateableVariables = ReasonerPlanner.estimateableVariables(variables);
+        conjunctionModels.get(conjunction).conjunctionSummary.resolvables().forEach(incrementalEstimator::extend);
+        return incrementalEstimator.scaledEstimate(estimateableVariables);
     }
 
-    private static class ConjunctionConcludableStack {
+//    public long estimateAnswers(ResolvableConjunction conjunction, Set<Variable> variables, Set<Resolvable<?>> resolvables) {
+//        if (!conjunctionModels.containsKey(conjunction)) buildConjunctionModel(conjunction);
+//        Set<Variable> estimateableVariables = ReasonerPlanner.estimateableVariables(variables);
+//        assert conjunction.pattern().variables().containsAll(estimateableVariables);
+//        assert logicMgr.compile(conjunction).containsAll(resolvables);
+//        return conjunctionModels.get(conjunction).estimateAnswers(estimateableVariables, resolvables);
+//    }
 
-        ArrayList<ResolvableConjunction> stack;
-        Map<ResolvableConjunction, Concludable> concludables;
+    public IncrementalEstimator createIncrementalEstimator(ResolvableConjunction conjunction) {
+        if (!conjunctionModels.containsKey(conjunction)) buildConjunctionModel(conjunction);
+        return new IncrementalEstimator(conjunctionModels.get(conjunction), this);
+    }
 
-        ConjunctionConcludableStack() {
-            this.stack = new ArrayList<>();
-            this.concludables = new HashMap<>();
+    public static class IncrementalEstimator {
+        private final ConjunctionModel conjunctionModel;
+        private final Map<LocalModel, Pair<Double, Optional<Variable>>> modelScale;
+        private final Map<Variable, Double> bestUnary;
+        private final Map<Variable, Set<LocalModel>> modelsWithVar;
+
+        private IncrementalEstimator(ConjunctionModel conjunctionModel, AnswerCountEstimator answerCountEstimator) {
+            this.conjunctionModel = conjunctionModel;
+            this.modelScale = new HashMap<>();
+            this.bestUnary = new HashMap<>();
+            this.modelsWithVar = new HashMap<>();
+
         }
 
-        private void add(ResolvableConjunction conjunction) {
-            stack.add(conjunction);
-            concludables.put(conjunction, null);
-        }
-
-        private ResolvableConjunction last() {
-            return stack.get(stack.size() - 1);
-        }
-
-        private boolean contains(ResolvableConjunction conjunction) {
-            return concludables.containsKey(conjunction);
-        }
-
-        private void pop() {
-            ResolvableConjunction conjunction = stack.remove(stack.size() - 1);
-            concludables.remove(conjunction);
-        }
-
-        private void setConcludable(ResolvableConjunction conjunction, Concludable concludable) {
-            assert stack.contains(conjunction);
-            concludables.put(conjunction, concludable);
-        }
-
-        private Concludable getConcludable(ResolvableConjunction conjunction) {
-            return concludables.get(conjunction);
-        }
-
-        public List<ResolvableConjunction> peekUntil(ResolvableConjunction untilInclusive) {
-            assert stack.contains(untilInclusive);
-            List<ResolvableConjunction> subList = new ArrayList<>();
-            for (int i = stack.size() - 1; stack.get(i) != untilInclusive; i--) {
-                subList.add(stack.get(i));
+        public void extend(Resolvable<?> resolvable) {
+            System.out.println("");
+            System.out.println("Extending model for " + conjunctionModel.conjunctionSummary.conjunction() + " with resolvable " + resolvable);
+            Map<Variable, Double> unaryUpdates = new HashMap<>();
+            List<LocalModel> models = conjunctionModel.modelsForResolvable(resolvable);
+            for (LocalModel model : models) {
+                System.out.println("Extending with : " + model);
+                addAndCollectUnaryUpdates(model, unaryUpdates);
             }
-            subList.add(untilInclusive);
-            return subList;
-        }
-    }
-
-    private static class ConjunctionContext {
-        private final ResolvableConjunction conjunction;
-        private final Set<Resolvable<?>> resolvables;
-        private final Set<Variable> estimateableVars;
-        private final Set<Concludable> cyclicConcludables;
-        private final Set<Concludable> acyclicConcludables;
-
-        private ConjunctionContext(ResolvableConjunction conjunction, Set<Resolvable<?>> resolvables, Set<Concludable> cyclicConcludables) {
-            this.conjunction = conjunction;
-            this.resolvables = resolvables;
-            this.estimateableVars = iterate(conjunction.pattern().variables()).filter(Variable::isThing).toSet();
-            this.cyclicConcludables = cyclicConcludables;
-            this.acyclicConcludables = iterate(resolvables)
-                    .filter(resolvable -> resolvable.isConcludable() && !cyclicConcludables.contains(resolvable.asConcludable()))
-                    .map(Resolvable::asConcludable).toSet();
+            propagate(unaryUpdates);
         }
 
-        public FunctionalIterator<Resolvable<?>> resolvables() {
-            return iterate(resolvables);
+        private void addAndCollectUnaryUpdates(LocalModel model, Map<Variable, Double> unaryUpdates) {
+//            assert !modelScale.containsKey(model);
+            Pair<Double, Optional<Variable>> scale = modelScale.computeIfAbsent(model, m -> new Pair<>(1.0, Optional.empty()));
+            double bestScaler = scale.first();
+            Variable bestScalingVar = scale.second().orElse(null);
+            System.out.print("Updating : " + model + ": " + bestScaler + "->");
+            // Update the index
+            model.variables.forEach(v -> {
+                modelsWithVar.computeIfAbsent(v, v1 -> new HashSet<>());
+                modelsWithVar.get(v).add(model);
+            });
+
+            // Find scaling factor
+            for (Variable v : model.variables) {
+                double ans = (double) model.estimateAnswers(set(v));
+                if (bestUnary.containsKey(v)) {
+                    if (ans < bestUnary.get(v)) {
+                        unaryUpdates.put(v, ans);
+                    } else if (bestUnary.get(v) / ans < bestScaler) {
+                        bestScaler = bestUnary.get(v) / ans;
+                        bestScalingVar = v;
+                    }
+                } else {
+                    unaryUpdates.put(v, ans);
+                }
+            }
+
+            // Find cascading effects of scaling on other vars (to propagate)
+            if (bestScalingVar != null) {
+                modelScale.put(model, new Pair<>(bestScaler, Optional.of(bestScalingVar)));
+                for (Variable v : model.variables) {
+                    if (v == bestScalingVar) continue;
+                    double newUnary = scaledEstimate(model, modelScale.get(model), set(v));
+                    if (newUnary < bestUnary.getOrDefault(v, Double.MAX_VALUE)) {
+                        unaryUpdates.put(v, Math.min(newUnary, unaryUpdates.getOrDefault(v, Double.MAX_VALUE)));
+                    }
+                }
+            } else {
+                assert bestScaler == 1;
+                modelScale.put(model, new Pair<>(bestScaler, Optional.empty()));
+            }
+            System.out.println("->" + bestScaler);
         }
 
-        public FunctionalIterator<Retrievable> retrievables() {
-            return iterate(resolvables).filter(Resolvable::isRetrievable).map(Resolvable::asRetrievable);
+        private void propagate(Map<Variable, Double> unaryUpdates) {
+            // Ideally, we'd just remove and add each model again till unaryUpdates is empty.
+            int dbg__iters = 0;
+            int maxIters = 2 * modelScale.size(); // TODO: Revise ; Consider pruning out small changes?
+            while (!unaryUpdates.isEmpty() && maxIters > 0) {
+                Set<LocalModel> affectedModels = iterate(unaryUpdates.keySet()).flatMap(v -> iterate(modelsWithVar.get(v))).toSet();
+                assert iterate(unaryUpdates.entrySet()).allMatch(update -> update.getValue() < bestUnary.getOrDefault(update.getKey(), Double.MAX_VALUE));
+                System.out.println("Propagating-effects : ");
+                unaryUpdates.entrySet().forEach(entry -> System.out.println("\t" + entry.getKey() + ":" + entry.getValue()));
+                bestUnary.putAll(unaryUpdates);
+                unaryUpdates.clear();
+                iterate(affectedModels).forEachRemaining(model -> {
+                    addAndCollectUnaryUpdates(model, unaryUpdates);
+                });
+                maxIters--;
+                dbg__iters++;
+            }
+            System.out.println("Propagation complete in " + dbg__iters + " iterations. BestUnary");
+            bestUnary.entrySet().forEach(entry -> System.out.println("\t" + entry.getKey() + ":" + entry.getValue()));
+
         }
 
-        public FunctionalIterator<Negated> negateds() {
-            return iterate(resolvables).filter(Resolvable::isNegated).map(Resolvable::asNegated);
+        public long scaledEstimate(Set<Variable> variables) {
+            List<LocalModel> relevantModels = iterate(modelScale.keySet())
+                    .filter(model -> model.variables.stream().anyMatch(variables::contains))
+                    .toList();
+
+            Map<Variable, CoverElement> cover = new HashMap<>();
+            iterate(variables).forEachRemaining(v -> cover.put(v, new CoverElement(bestUnary.get(v))));
+
+            Map<LocalModel, Pair<Set<Variable>, Double>> scaledEstimates = new HashMap<>();
+            relevantModels.forEach(model -> {
+                Set<Variable> modelledVars = intersection(model.variables, variables);
+                scaledEstimates.put(model, new Pair<>(modelledVars, scaledEstimate(model, modelScale.get(model), variables)));
+            });
+            relevantModels.sort(Comparator.comparing(model -> scaledEstimates.get(model).second()));
+            for (LocalModel model : relevantModels) {
+                if (scaledEstimates.get(model).second() < answerEstimateFromCover(scaledEstimates.get(model).first(), cover)) {
+                    CoverElement coverElement = new CoverElement(scaledEstimates.get(model).second()); // Same instance for all keys
+                    scaledEstimates.get(model).first().forEach(v -> cover.put(v, coverElement));
+                }
+            }
+            return answerEstimateFromCover(variables, cover);
         }
 
-        public FunctionalIterator<Concludable> cyclicConcludables() {
-            return iterate(cyclicConcludables);
+        private static class CoverElement {
+            private final double estimate;
+
+            private CoverElement(double estimate) {
+                this.estimate = estimate;
+            }
         }
 
-        public FunctionalIterator<Concludable> acyclicConcludables() {
-            return iterate(acyclicConcludables);
+        private static double scaledEstimate(LocalModel model, Pair<Double, Optional<Variable>> scale, Set<Variable> estimateVariables) {
+            assert scale.second().isPresent() || scale.first() == 1.0;
+            Set<Variable> variables = new HashSet<>();
+            iterate(estimateVariables).filter(model.variables::contains).forEachRemaining(variables::add);
+            double ans = model.estimateAnswers(variables);
+            if (scale.second().isPresent()) {
+                assert scale.first() <= 1.0;
+                variables.add(scale.second().get());
+                double scaledAns = scale.first() * model.estimateAnswers(variables);
+                ans = Math.min(ans, scaledAns);
+            }
+            return ans;
+        }
+
+        private static long answerEstimateFromCover(Set<Variable> variables, Map<Variable, CoverElement> coverMap) {
+            Set<CoverElement> coverSet = iterate(variables).map(coverMap::get).toSet();
+            return Math.round(Math.ceil(iterate(coverSet).map(coverElement -> coverElement.estimate).reduce(1.0, (x, y) -> x * y)));
         }
     }
 
     private static class ConjunctionModel {
-        private final ConjunctionContext conjunctionContext;
-        private final Map<Variable, LocalModel.VariableModel> variableModels;
+        private final ConjunctionSummary conjunctionSummary;
         private final Map<Resolvable<?>, List<LocalModel>> constraintModels;
         private final boolean isCyclic;
 
-        private ConjunctionModel(ConjunctionContext conjunctionContext,
-                                 Map<Variable, LocalModel.VariableModel> variableModels, Map<Resolvable<?>, List<LocalModel>> constraintModels,
+        private ConjunctionModel(ConjunctionSummary conjunctionSummary, Map<Resolvable<?>, List<LocalModel>> constraintModels,
                                  boolean isCyclic) {
-            this.conjunctionContext = conjunctionContext;
-            this.variableModels = variableModels;
+            this.conjunctionSummary = conjunctionSummary;
             this.constraintModels = constraintModels;
             this.isCyclic = isCyclic;
         }
 
-        private long estimateAnswers(Set<Variable> variables, Set<Resolvable<?>> resolvables) {
-            List<LocalModel> models = iterate(resolvables)
-                    .flatMap(resolvable -> iterate(constraintModels.get(resolvable)))
-                    .toList();
-
-            Set<Variable> estimateableVars = intersection(variables, conjunctionContext.estimateableVars);
-            Map<Variable, LocalModel> costCover = greedyCover(estimateableVars, variableModels, models);
-            long ret = answerEstimateFromCover(estimateableVars, costCover);
-            assert ret > 0;             // Flag in tests if it happens.
-            return Math.max(ret, 1);    // Don't do stupid stuff in prod when it happens.
-        }
-
-        private static Map<Variable, LocalModel> greedyCover(Set<Variable> variables, Map<Variable, LocalModel.VariableModel> variableModels, List<LocalModel> constraintModels) {
-            // Does a greedy set cover
-            Map<Variable, LocalModel> cover = new HashMap<>();
-            iterate(variables).forEachRemaining(v -> cover.put(v, variableModels.get(v)));
-
-            constraintModels.sort(Comparator.comparing(x -> x.estimateAnswers(variables)));
-            for (LocalModel model : constraintModels) {
-                Set<Variable> resolvableVars = intersection(model.variables, variables);
-                if (answerEstimateFromCover(resolvableVars, cover) > model.estimateAnswers(resolvableVars)) {
-                    resolvableVars.forEach(v -> cover.put(v, model));
-                }
-            }
-            return cover;
-        }
-
-        private static long answerEstimateFromCover(Set<Variable> variables, Map<Variable, LocalModel> coverMap) {
-            Set<LocalModel> models = iterate(intersection(variables, coverMap.keySet())).map(coverMap::get).toSet();
-            return iterate(models).map(model -> model.estimateAnswers(variables)).reduce(1L, (x, y) -> x * y);
+        private List<LocalModel> modelsForResolvable(Resolvable<?> resolvable) {
+            return constraintModels.get(resolvable);
         }
     }
 
@@ -274,63 +279,32 @@ public class AnswerCountEstimator {
             this.localModelFactory = localModelFactory;
         }
 
-        private ConjunctionModel buildAcyclicModel(ConjunctionContext conjunctionContext) {
+        private ConjunctionModel buildAcyclicModel(ConjunctionSummary conjunctionSummary) {
             Map<Resolvable<?>, List<LocalModel>> models = new HashMap<>();
-            List<LocalModel.VariableModel> generatedVariableModels = new ArrayList<>();
-            iterate(conjunctionContext.acyclicConcludables())
-                    .forEachRemaining(concludable -> {
-                        List<LocalModel.VariableModel> generatedVariableModelsForConcludable = modelsForGeneratedVariable(concludable);
-                        generatedVariableModels.addAll(generatedVariableModelsForConcludable);
-                        ArrayList<LocalModel> combinedModels = new ArrayList<>();
-                        combinedModels.addAll(generatedVariableModelsForConcludable);
-                        combinedModels.addAll(buildModelsForConcludable(concludable));
-                        models.put(concludable, combinedModels);
-                    });
+            iterate(conjunctionSummary.acyclicConcludables())
+                    .forEachRemaining(concludable -> models.put(concludable, buildModelsForConcludable(concludable)));
 
-            Map<Variable, LocalModel.VariableModel> variableModels = computeBaselineCover(conjunctionContext.estimateableVars, generatedVariableModels);
-
-            iterate(conjunctionContext.retrievables())
+            iterate(conjunctionSummary.retrievables())
                     .forEachRemaining(retrievable -> models.put(retrievable, buildModelsForRetrievable(retrievable)));
-            iterate(conjunctionContext.negateds())
+            iterate(conjunctionSummary.negateds())
                     .forEachRemaining(negated -> models.put(negated, buildModelsForNegated(negated)));
-            iterate(conjunctionContext.cyclicConcludables()).forEachRemaining(concludable -> models.put(concludable, list()));
+            // Should we recurse into the acyclic dependencies? Don't think so - Would over-constrain
+            iterate(conjunctionSummary.cyclicConcludables())
+                    .forEachRemaining(concludable -> models.put(concludable, buildVariableModelsForConcludable(concludable)));
 
-            // EdgeCase: Efficiently handle inferred `$x has $a` when $x is inferred in the body of the rule.
-            iterate(conjunctionContext.acyclicConcludables()).filter(Concludable::isHas).map(Concludable::asHas)
-                    .forEachRemaining(concludable -> {
-                        if (variableModels.get(concludable.owner()).estimateAnswers(set(concludable.owner())) == 0) {
-                            long attrCount = Math.max(1L, variableModels.get(concludable.attribute()).estimateAnswers(set(concludable.attribute())));
-                            long hasEdgeCount = iterate(models.get(concludable))
-                                    .map(localModel -> localModel.estimateAnswers(set(concludable.owner(), concludable.attribute())))
-                                    .reduce(1L, Long::sum);
-                            variableModels.put(concludable.owner(), new LocalModel.VariableModel(set(concludable.owner()), hasEdgeCount / attrCount));
-                        }
-                    });
-
-            assert !iterate(conjunctionContext.estimateableVars).filter(variable -> !variableModels.containsKey(variable)).hasNext();
-            assert !iterate(conjunctionContext.resolvables()).filter(resolvable -> !models.containsKey(resolvable)).hasNext();
-            return new ConjunctionModel(conjunctionContext, variableModels, models, false);
+            assert !iterate(conjunctionSummary.resolvables()).filter(resolvable -> !models.containsKey(resolvable)).hasNext();
+            return new ConjunctionModel(conjunctionSummary, models, false);
         }
 
-        private ConjunctionModel buildCyclicModel(ConjunctionContext conjunctionContext, ConjunctionModel acyclicModel) {
-            assert acyclicModel.conjunctionContext == conjunctionContext;
+        private ConjunctionModel buildCyclicModel(ConjunctionSummary conjunctionSummary, ConjunctionModel acyclicModel) {
+            assert acyclicModel.conjunctionSummary == conjunctionSummary;
             assert !acyclicModel.isCyclic;
             Map<Resolvable<?>, List<LocalModel>> models = new HashMap<>(acyclicModel.constraintModels);
-            List<LocalModel.VariableModel> generatedVariableModels = new ArrayList<>(acyclicModel.variableModels.values());
-            iterate(conjunctionContext.cyclicConcludables())
-                    .forEachRemaining(concludable -> {
-                        List<LocalModel.VariableModel> generatedVariableModelsForConcludable = modelsForGeneratedVariable(concludable);
-                        generatedVariableModels.addAll(generatedVariableModelsForConcludable);
-                        ArrayList<LocalModel> combinedModels = new ArrayList<>();
-                        combinedModels.addAll(generatedVariableModelsForConcludable);
-                        combinedModels.addAll(buildModelsForConcludable(concludable));
-                        models.put(concludable, combinedModels);
-                    });
-            Map<Variable, LocalModel.VariableModel> variableModels = computeBaselineCover(conjunctionContext.estimateableVars, generatedVariableModels);
+            iterate(conjunctionSummary.cyclicConcludables())
+                    .forEachRemaining(concludable -> models.put(concludable, buildModelsForConcludable(concludable)));
 
-            assert !iterate(conjunctionContext.estimateableVars).filter(variable -> !variableModels.containsKey(variable)).hasNext();
-            assert !iterate(conjunctionContext.resolvables()).filter(resolvable -> !models.containsKey(resolvable)).hasNext();
-            return new ConjunctionModel(conjunctionContext, variableModels, models, true);
+            assert !iterate(conjunctionSummary.resolvables()).filter(resolvable -> !models.containsKey(resolvable)).hasNext();
+            return new ConjunctionModel(conjunctionSummary, models, true);
         }
 
         private List<LocalModel> buildModelsForRetrievable(Retrievable retrievable) {
@@ -339,6 +313,7 @@ public class AnswerCountEstimator {
                     .toList();
         }
 
+        // INACCURACY: We don't consider negations, which can reduce the number of answers retrieved.
         private List<LocalModel> buildModelsForNegated(Negated negated) {
             return list();
         }
@@ -349,28 +324,10 @@ public class AnswerCountEstimator {
                     .toList();
         }
 
-        private List<LocalModel.VariableModel> modelsForGeneratedVariable(Concludable concludable) {
-            return list(localModelFactory.modelForVariable(concludable.generating().get(), concludable));
-        }
-
-        private Map<Variable, LocalModel.VariableModel> computeBaselineCover(Set<Variable> variablesToCover, List<LocalModel.VariableModel> generatedVariableModels) {
-            Map<Variable, LocalModel.VariableModel> newVariableCover = new HashMap<>();
-            iterate(variablesToCover).map(Variable::asThing).forEachRemaining(v -> { // baseline
-                newVariableCover.put(v, new LocalModel.VariableModel(set(v), localModelFactory.countPersistedThingsMatchingType(v)));
-            });
-
-            iterate(generatedVariableModels).flatMap(Iterators::iterate)
-                    .forEachRemaining(model -> {
-                        Variable v = model.variables.stream().findAny().get();
-                        long existingEstimate = newVariableCover.get(v).estimateAnswers(set(v));
-                        long newEstimate = model.estimateAnswers(set(v));
-                        if (newEstimate > existingEstimate) { // Biggest one serves as baseline.
-                            newVariableCover.put(v, model);
-                        }
-                    });
-
-            assert variablesToCover.stream().allMatch(newVariableCover::containsKey);
-            return newVariableCover;
+        private List<LocalModel> buildVariableModelsForConcludable(Concludable concludable) {
+            List<LocalModel> models = new ArrayList<>();
+            iterate(concludable.variables()).filter(Variable::isThing).map(v -> localModelFactory.modelForVariable(v, Optional.empty())).forEachRemaining(models::add);
+            return models;
         }
 
         private LocalModel buildConstraintModel(Constraint constraint, Optional<Concludable> correspondingConcludable) {
@@ -423,29 +380,31 @@ public class AnswerCountEstimator {
             long estimateAnswers(Set<Variable> variableFilter) {
                 return staticEstimate;
             }
-
         }
+
 
         private static class RelationModel extends LocalModel {
             private final RelationConstraint relation;
             private final Map<TypeVariable, Long> rolePlayerEstimates;
-            private final double relationTypeEstimate;
-            private final long inferredRelationEstimate;
+            private final Map<TypeVariable, Long> typeMaximums;
+            private final long relationTypeEstimate;
             private final Map<ThingVariable, TypeVariable> rolePlayerTypes;
 
-            private RelationModel(RelationConstraint relation, double relationTypeEstimate,
-                                  Map<TypeVariable, Long> rolePlayerEstimates, long inferredRelationEstimate) {
+            private RelationModel(RelationConstraint relation, long relationTypeEstimate,
+                                  Map<TypeVariable, Long> typeMaximums, Map<TypeVariable, Long> rolePlayerEstimates) {
                 super(iterate(relation.variables()).filter(Variable::isThing).toSet());
                 this.relation = relation;
                 this.relationTypeEstimate = relationTypeEstimate;
                 this.rolePlayerEstimates = rolePlayerEstimates;
-                this.inferredRelationEstimate = inferredRelationEstimate;
+                this.typeMaximums = typeMaximums;
                 this.rolePlayerTypes = new HashMap<>();
+
                 relation.players().forEach(player -> {
                     // Error: null is a valid role-type, but two unspecified roles are not necessarily interchangable.
                     TypeVariable roleType = player.roleType().isPresent() ? player.roleType().get() : null;
                     this.rolePlayerTypes.put(player.player(), roleType);
                 });
+
             }
 
             @Override
@@ -459,15 +418,23 @@ public class AnswerCountEstimator {
                     }
                 }
 
+                long typeBasedUpperBound = 1L;
+                long typeBasedUpperBoundFromRelations = relationTypeEstimate;
                 if (relationTypeEstimate > 0) {
                     for (TypeVariable key : queriedRolePlayerCounts.keySet()) {
                         assert rolePlayerEstimates.containsKey(key);
-                        long avgRolePlayers = Double.valueOf(Math.ceil(rolePlayerEstimates.get(key) / relationTypeEstimate)).longValue();
+                        long avgRolePlayers = Double.valueOf(Math.ceil((double) rolePlayerEstimates.get(key) / relationTypeEstimate)).longValue();
                         singleRelationEstimate *= nPermuteKforSmallK(avgRolePlayers, queriedRolePlayerCounts.get(key));
+                        typeBasedUpperBoundFromRelations *= nPermuteKforSmallK(avgRolePlayers, queriedRolePlayerCounts.get(key));
+                        typeBasedUpperBound *= nPermuteKforSmallK(typeMaximums.get(key), queriedRolePlayerCounts.get(key));
                     }
                 }
 
-                return Double.valueOf(Math.ceil(relationTypeEstimate * singleRelationEstimate)).longValue() + inferredRelationEstimate;
+                // How do you correctly query $q($x) from $r($a, $b) ?
+                if (variableFilter.contains(relation.owner()))
+                    typeBasedUpperBound = typeBasedUpperBoundFromRelations; // We need the type based upper bound for the relationEstimate too
+
+                return Math.min(typeBasedUpperBound, Double.valueOf(Math.ceil(relationTypeEstimate * singleRelationEstimate)).longValue());
             }
 
             private long nPermuteKforSmallK(long n, long k) {
@@ -475,14 +442,38 @@ public class AnswerCountEstimator {
                 for (int i = 0; i < k; i++) ans *= n - i;
                 return ans;
             }
+
+            @Override
+            public String toString() {
+                return "RelationModel[" + relation.toString() + "]";
+            }
         }
 
-        private static class HasModel extends StaticModel {
+        private static class HasModel extends LocalModel {
             private final HasConstraint has;
+            private final long hasEdgeEstimate;
+            private final long ownerEstimate;
+            private final long attributeEstimate;
 
-            private HasModel(HasConstraint has, long hasEdgeEstimate) {
-                super(set(has.owner(), has.attribute()), hasEdgeEstimate);
+            private HasModel(HasConstraint has, long hasEdgeEstimate, long ownerEstimate, long attributeEstimate) {
+                super(set(has.owner(), has.attribute()));
                 this.has = has;
+                this.hasEdgeEstimate = hasEdgeEstimate;
+                this.ownerEstimate = ownerEstimate;
+                this.attributeEstimate = attributeEstimate;
+            }
+
+            @Override
+            long estimateAnswers(Set<Variable> variableFilter) {
+                long answerEstimate = 1;
+                if (variableFilter.contains(has.owner())) answerEstimate *= ownerEstimate;
+                if (variableFilter.contains(has.attribute())) answerEstimate *= attributeEstimate;
+                return Math.min(answerEstimate, this.hasEdgeEstimate);
+            }
+
+            @Override
+            public String toString() {
+                return "HasModel[" + has.toString() + "]";
             }
         }
 
@@ -493,11 +484,21 @@ public class AnswerCountEstimator {
                 super(set(isa.owner()), estimate);
                 this.isa = isa;
             }
+
+            @Override
+            public String toString() {
+                return "IsaModel[" + isa.toString() + "]";
+            }
         }
 
         private static class VariableModel extends StaticModel {
             private VariableModel(Set<Variable> variables, long estimate) {
                 super(variables, estimate);
+            }
+
+            @Override
+            public String toString() {
+                return "VariableModel[" + variables.stream().findAny().toString() + "=" + estimateAnswers(set()) + "]";
             }
         }
     }
@@ -519,16 +520,17 @@ public class AnswerCountEstimator {
             Map<TypeVariable, Long> rolePlayerEstimates = new HashMap<>();
             Map<TypeVariable, Integer> rolePlayerCounts = new HashMap<>();
 
-            double relationTypeEstimate = countPersistedThingsMatchingType(relationConstraint.owner());
-
+            Map<TypeVariable, Long> typeMaximums = new HashMap<>();
+            long relationUpperBound = 1L;
             for (RelationConstraint.RolePlayer rp : rolePlayers) {
                 TypeVariable key = rp.roleType().orElse(null);
-                rolePlayerCounts.put(key, rolePlayerCounts.getOrDefault(key, 0) + 1);
-                if (!rolePlayerEstimates.containsKey(key)) {
-                    rolePlayerEstimates.put(key, countPersistedRolePlayers(rp));
+                if (!typeMaximums.containsKey(key)) {
+                    typeMaximums.put(key, countPersistedThingsMatchingType(rp.player()));
                 }
+                relationUpperBound *= typeMaximums.get(key);
             }
 
+            long persistedRelationEstimate = countPersistedThingsMatchingType(relationConstraint.owner());
             // TODO: Can improve estimate by collecting List<List<LocalModel>> from the triggered rules and doing sum(costCover).
             long inferredRelationsEstimate = 0L;
             if (correspondingConcludable.isPresent()) {
@@ -540,15 +542,36 @@ public class AnswerCountEstimator {
                 inferredRelationsEstimate = estimateInferredAnswerCount(correspondingConcludable.get(), new HashSet<>(constrainedVars));
             }
 
-            return new LocalModel.RelationModel(relationConstraint, relationTypeEstimate, rolePlayerEstimates, inferredRelationsEstimate);
+            inferredRelationsEstimate = Math.min(inferredRelationsEstimate, relationUpperBound - persistedRelationEstimate);
+
+
+            for (RelationConstraint.RolePlayer rp : rolePlayers) {
+                TypeVariable key = rp.roleType().orElse(null);
+                rolePlayerCounts.put(key, rolePlayerCounts.getOrDefault(key, 0) + 1);
+                if (!rolePlayerEstimates.containsKey(key)) {
+                    rolePlayerEstimates.put(key, countPersistedRolePlayers(rp) + inferredRelationsEstimate);
+                }
+            }
+
+            return new LocalModel.RelationModel(relationConstraint, inferredRelationsEstimate + persistedRelationEstimate, typeMaximums, rolePlayerEstimates);
         }
 
         private LocalModel.HasModel modelForHas(HasConstraint hasConstraint, Optional<Concludable> correspondingConcludable) {
             long hasEdgeEstimate = countPersistedHasEdges(hasConstraint.owner().inferredTypes(), hasConstraint.attribute().inferredTypes());
+            long ownerEstimate = countPersistedThingsMatchingType(hasConstraint.owner());
+            long attributeEstimate = countPersistedThingsMatchingType(hasConstraint.attribute());
             if (correspondingConcludable.isPresent()) {
                 hasEdgeEstimate += estimateInferredAnswerCount(correspondingConcludable.get(), set(hasConstraint.owner(), hasConstraint.attribute()));
+                attributeEstimate += attributesCreatedByExplicitHas(correspondingConcludable.get());
+                if (ownerEstimate < hasEdgeEstimate / attributeEstimate) {
+                    boolean rulesConcludeOwner = iterate(hasConstraint.owner().inferredTypes()).flatMap(ownerType -> iterate(answerCountEstimator.logicMgr.rulesConcluding(ownerType))).hasNext();
+                    if (rulesConcludeOwner) ownerEstimate = hasEdgeEstimate / attributeEstimate;
+                }
+
+
             }
-            return new LocalModel.HasModel(hasConstraint, hasEdgeEstimate);
+
+            return new LocalModel.HasModel(hasConstraint, hasEdgeEstimate, ownerEstimate, attributeEstimate);
         }
 
         private LocalModel.IsaModel modelForIsa(IsaConstraint isaConstraint, Optional<Concludable> correspondingConcludable) {
@@ -566,10 +589,12 @@ public class AnswerCountEstimator {
             } else throw TypeDBException.of(UNSUPPORTED_OPERATION);
         }
 
-        private LocalModel.VariableModel modelForVariable(Variable v, Concludable sourceConcludable) {
+        private LocalModel.VariableModel modelForVariable(Variable v, Optional<Concludable> concludable) {
             long persistedAnswerCount = countPersistedThingsMatchingType(v.asThing());
             long inferredAnswerCount = 0;
-            if (v == sourceConcludable.generating().get()) {
+            Concludable sourceConcludable;
+            if (concludable.isPresent() && v == concludable.get().generating().get()) {
+                sourceConcludable = concludable.get();
                 inferredAnswerCount = (sourceConcludable.isHas() || sourceConcludable.isAttribute()) ?
                         attributesCreatedByExplicitHas(sourceConcludable) :
                         estimateInferredAnswerCount(sourceConcludable, set(v));
@@ -590,14 +615,7 @@ public class AnswerCountEstimator {
                         // There is one generated variable per combination of ALL variables in the conclusion
                         ruleSideIds = new HashSet<>(rule.conclusion().pattern().retrieves());
                     }
-//                        ruleSideVariables = iterate(rule.conclusion().pattern().variables())
-//                                .filter(v -> v.isThing() && v != rule.conclusion().generating().get())
-//                                .toSet();
-//                    } else {
-//                        ruleSideVariables = iterate(ruleSideIds)
-//                                .filter(id -> rule.condition().conjunction().pattern().variables().contains(id)) // avoids constant has
-//                                .map(id -> rule.conclusion().conjunction().pattern().variable(id)).toSet();
-//                    }
+
                     ruleSideVariables = iterate(ruleSideIds)
                             .filter(id -> rule.condition().conjunction().pattern().retrieves().contains(id)) // avoids constant has
                             .map(id -> rule.condition().conjunction().pattern().variable(id)).toSet();
@@ -631,5 +649,4 @@ public class AnswerCountEstimator {
             ).reduce(0L, Long::sum);
         }
     }
-
 }

--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -125,8 +125,6 @@ public class AnswerCountEstimator {
         public void extend(Resolvable<?> resolvable) {
             Map<Variable, Double> improvedVariableEstimates = new HashMap<>();
             List<LocalModel> models = conjunctionModel.modelsForResolvable(resolvable);
-            assert models.stream().allMatch(model -> model.variables.size() > 0);
-
             iterate(models).flatMap(model -> iterate(model.variables)).forEachRemaining(v -> affectedModels.computeIfAbsent(v, v1 -> new HashSet<>()));
 
             iterate(models).filter(model -> model.variables.size() == 1).forEachRemaining(model -> {

--- a/reasoner/planner/ConjunctionSummarizer.java
+++ b/reasoner/planner/ConjunctionSummarizer.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2022 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+package com.vaticle.typedb.core.reasoner.planner;
+
+import com.vaticle.typedb.common.collection.Pair;
+import com.vaticle.typedb.core.logic.LogicManager;
+import com.vaticle.typedb.core.logic.resolvable.Concludable;
+import com.vaticle.typedb.core.logic.resolvable.Negated;
+import com.vaticle.typedb.core.logic.resolvable.Resolvable;
+import com.vaticle.typedb.core.logic.resolvable.ResolvableConjunction;
+import com.vaticle.typedb.core.logic.resolvable.Retrievable;
+import com.vaticle.typedb.core.pattern.variable.Variable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
+
+public class ConjunctionSummarizer {
+    private final LogicManager logicMgr;
+    private final Map<ResolvableConjunction, ConjunctionSummary> conjunctionSummaries;
+
+    public ConjunctionSummarizer(LogicManager logicMgr) {
+        this.logicMgr = logicMgr;
+        this.conjunctionSummaries = new HashMap<>();
+    }
+
+    public Set<ResolvableConjunction> dependencies(Concludable concludable) {
+        return iterate(logicMgr.applicableRules(concludable).keySet()).map(rule -> rule.condition().conjunction()).toSet();
+    }
+
+    public ConjunctionSummary conjunctionSummary(ResolvableConjunction conjunction) {
+        if (!conjunctionSummaries.containsKey(conjunction)) {
+            recursivelySummarizeConjunctions(conjunction);
+        }
+        return conjunctionSummaries.get(conjunction);
+    }
+
+    private ConjunctionSummary createConjunctionSummary(ResolvableConjunction conjunction, Set<Pair<Concludable, ResolvableConjunction>> cyclicConcludables) {
+        Set<Resolvable<?>> resolvables = logicMgr.compile(conjunction);
+        Map<Concludable, Set<ResolvableConjunction>> cyclicDependencies = new HashMap<>();
+        Map<Concludable, Set<ResolvableConjunction>> acyclicDependencies = new HashMap<>();
+        iterate(resolvables).filter(Resolvable::isConcludable).map(Resolvable::asConcludable).forEachRemaining(concludable -> {
+            cyclicDependencies.put(concludable, new HashSet<>());
+            acyclicDependencies.put(concludable, new HashSet<>());
+        });
+
+        iterate(cyclicConcludables).forEachRemaining(concludableDependency -> {
+            cyclicDependencies.get(concludableDependency.first()).add(concludableDependency.second());
+        });
+
+        iterate(resolvables).filter(Resolvable::isConcludable).map(Resolvable::asConcludable).forEachRemaining(concludable -> {
+            iterate(dependencies(concludable))
+                    .filter(dependency -> !cyclicDependencies.get(concludable).contains(dependency))
+                    .forEachRemaining(dependency -> acyclicDependencies.get(concludable).add(dependency));
+        });
+
+        return new ConjunctionSummary(conjunction, resolvables, cyclicDependencies, acyclicDependencies);
+    }
+
+    private void recursivelySummarizeConjunctions(ResolvableConjunction root) {
+        ConjunctionConcludableStack stack = new ConjunctionConcludableStack();
+        Map<ResolvableConjunction, Set<Pair<Concludable, ResolvableConjunction>>> cyclicConcludables = new HashMap<>();
+        findCyclicDependencies(root, stack, cyclicConcludables);
+        iterate(stack.visited()).forEachRemaining(conjunction -> {
+            conjunctionSummaries.put(conjunction, createConjunctionSummary(conjunction, cyclicConcludables.getOrDefault(conjunction, new HashSet<>())));
+        });
+    }
+
+    private void findCyclicDependencies(ResolvableConjunction conjunction, ConjunctionConcludableStack stack, Map<ResolvableConjunction, Set<Pair<Concludable, ResolvableConjunction>>> cyclicConcludables) {
+        if (conjunctionSummaries.containsKey(conjunction)) {
+            return; // We only add conjunction summaries at the end of a search -> this does not loop back.
+        }
+
+        if (stack.contains(conjunction)) {
+            ResolvableConjunction cyclicDependency = conjunction;
+            List<ResolvableConjunction> stackPeek = stack.peekUntil(conjunction);
+            for (ResolvableConjunction conj : stackPeek) {
+                cyclicConcludables.computeIfAbsent(conj, c -> new HashSet<>()).add(new Pair<>(stack.getConcludable(conj), cyclicDependency));
+                cyclicDependency = conj;
+            }
+        } else {
+            stack.add(conjunction);
+            Set<Resolvable<?>> resolvables = logicMgr.compile(conjunction);
+            iterate(resolvables).filter(Resolvable::isNegated).map(Resolvable::asNegated)
+                    .flatMap(negated -> iterate(negated.disjunction().conjunctions()))
+                    .forEachRemaining(dependency -> conjunctionSummary(dependency)); // Stratified negation -> Fresh set
+            iterate(resolvables).filter(Resolvable::isConcludable).map(Resolvable::asConcludable)
+                    .forEachRemaining(concludable -> {
+                        stack.setConcludable(conjunction, concludable);
+                        iterate(dependencies(concludable)).forEachRemaining(dependency -> findCyclicDependencies(dependency, stack, cyclicConcludables));
+                    });
+            assert stack.last() == conjunction;
+            stack.pop();
+        }
+    }
+
+    static class ConjunctionSummary {
+        private final ResolvableConjunction conjunction;
+        private final Set<Resolvable<?>> resolvables;
+        private final Set<Variable> estimateableVars;
+        private final Set<Concludable> cyclicConcludables;
+        private final Set<Concludable> acyclicConcludables;
+        private final Map<Concludable, Set<ResolvableConjunction>> cyclicDependencies;
+        private final Map<Concludable, Set<ResolvableConjunction>> acyclicDependencies;
+
+        ConjunctionSummary(ResolvableConjunction conjunction, Set<Resolvable<?>> resolvables,
+                           Map<Concludable, Set<ResolvableConjunction>> cyclicDependencies, Map<Concludable, Set<ResolvableConjunction>> acyclicDependencies) {
+            this.conjunction = conjunction;
+            this.resolvables = resolvables;
+            this.estimateableVars = ReasonerPlanner.estimateableVariables(conjunction.pattern().variables());
+            this.cyclicDependencies = cyclicDependencies;
+            this.acyclicDependencies = acyclicDependencies;
+            this.cyclicConcludables = iterate(resolvables).filter(Resolvable::isConcludable).map(Resolvable::asConcludable)
+                    .filter(concludable -> !cyclicDependencies.get(concludable).isEmpty()).toSet();
+            this.acyclicConcludables = iterate(resolvables).filter(Resolvable::isConcludable).map(Resolvable::asConcludable)
+                    .filter(concludable -> cyclicDependencies.get(concludable).isEmpty()).toSet();
+            assert cyclicDependencies.keySet().containsAll(iterate(resolvables).filter(Resolvable::isConcludable).toList());
+            assert acyclicDependencies.keySet().containsAll(iterate(resolvables).filter(Resolvable::isConcludable).toList());
+        }
+
+        public Set<Resolvable<?>> resolvables() {
+            return resolvables;
+        }
+
+        public Set<Retrievable> retrievables() {
+            return iterate(resolvables).filter(Resolvable::isRetrievable).map(Resolvable::asRetrievable).toSet();
+        }
+
+        public Set<Negated> negateds() {
+            return iterate(resolvables).filter(Resolvable::isNegated).map(Resolvable::asNegated).toSet();
+        }
+
+        public Set<Concludable> cyclicConcludables() {
+            return cyclicConcludables;
+        }
+
+        public Set<Concludable> acyclicConcludables() {
+            return acyclicConcludables;
+        }
+
+        public Set<ResolvableConjunction> cyclicDependencies(Concludable concludable) {
+            return cyclicDependencies.get(concludable);
+        }
+
+        public Set<ResolvableConjunction> acyclicDependencies(Concludable concludable) {
+            return acyclicDependencies.get(concludable);
+        }
+
+
+        public ResolvableConjunction conjunction() {
+            return conjunction;
+        }
+
+        public Set<Variable> estimateableVars() {
+            return estimateableVars;
+        }
+    }
+
+    private static class ConjunctionConcludableStack {
+
+        private final Set<ResolvableConjunction> visited;
+        ArrayList<ResolvableConjunction> stack;
+        Map<ResolvableConjunction, Concludable> concludables;
+
+        ConjunctionConcludableStack() {
+            this.stack = new ArrayList<>();
+            this.visited = new HashSet<>();
+            this.concludables = new HashMap<>();
+        }
+
+        private void add(ResolvableConjunction conjunction) {
+            stack.add(conjunction);
+            this.visited.add(conjunction);
+            concludables.put(conjunction, null);
+        }
+
+        private ResolvableConjunction last() {
+            return stack.get(stack.size() - 1);
+        }
+
+        private boolean contains(ResolvableConjunction conjunction) {
+            return concludables.containsKey(conjunction);
+        }
+
+        private void pop() {
+            ResolvableConjunction conjunction = stack.remove(stack.size() - 1);
+            concludables.remove(conjunction);
+        }
+
+        private void setConcludable(ResolvableConjunction conjunction, Concludable concludable) {
+            assert stack.contains(conjunction);
+            concludables.put(conjunction, concludable);
+        }
+
+        private Concludable getConcludable(ResolvableConjunction conjunction) {
+            return concludables.get(conjunction);
+        }
+
+        private Set<ResolvableConjunction> visited() {
+            return visited;
+        }
+
+        private List<ResolvableConjunction> peekUntil(ResolvableConjunction untilInclusive) {
+            assert stack.contains(untilInclusive);
+            List<ResolvableConjunction> subList = new ArrayList<>();
+            for (int i = stack.size() - 1; stack.get(i) != untilInclusive; i--) {
+                subList.add(stack.get(i));
+            }
+            subList.add(untilInclusive);
+            return subList;
+        }
+    }
+}

--- a/reasoner/planner/ReasonerPlanner.java
+++ b/reasoner/planner/ReasonerPlanner.java
@@ -24,6 +24,7 @@ import com.vaticle.typedb.core.logic.LogicManager;
 import com.vaticle.typedb.core.logic.resolvable.Resolvable;
 import com.vaticle.typedb.core.logic.resolvable.ResolvableConjunction;
 import com.vaticle.typedb.core.pattern.variable.ThingVariable;
+import com.vaticle.typedb.core.pattern.variable.Variable;
 import com.vaticle.typedb.core.traversal.TraversalEngine;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 
@@ -53,6 +54,9 @@ public abstract class ReasonerPlanner {
         return new GreedyCostSearch.OldPlannerEmulator(traversalEng, conceptMgr, logicMgr);
     }
 
+    static Set<Variable> estimateableVariables(Set<Variable> variables) {
+        return iterate(variables).filter(Variable::isThing).toSet();
+    }
     public Plan plan(ResolvableConjunction conjunction, Set<Identifier.Variable.Retrievable> bounds) {
         return planCache.get(new Pair<>(conjunction, bounds), cbPair -> computeResolvableOrdering(logicMgr.compile(cbPair.first()), cbPair.second()));
     }

--- a/test/integration/reasoner/planner/AnswerCountEstimatorTest.java
+++ b/test/integration/reasoner/planner/AnswerCountEstimatorTest.java
@@ -458,7 +458,7 @@ public class AnswerCountEstimatorTest {
             Set<Resolvable<?>> resolvables = transaction.logic().compile(conjunction);
             AnswerCountEstimator.IncrementalEstimator incrementalEstimator = answerCountEstimator.createIncrementalEstimator(conjunction);
             resolvables.forEach(incrementalEstimator::extend);
-            long answers = incrementalEstimator.scaledEstimate(getVariablesByName(conjunction.pattern(), set("p1", "p2")));
+            long answers = incrementalEstimator.answerEstimate(getVariablesByName(conjunction.pattern(), set("p1", "p2")));
             assertEquals(3L, answers);
         }
 
@@ -469,7 +469,7 @@ public class AnswerCountEstimatorTest {
             Set<Resolvable<?>> justJealous = resolvables.stream().filter(Resolvable::isConcludable).collect(Collectors.toSet());
             AnswerCountEstimator.IncrementalEstimator incrementalEstimator = answerCountEstimator.createIncrementalEstimator(conjunction);
             justJealous.forEach(incrementalEstimator::extend);
-            long answers = incrementalEstimator.scaledEstimate(getVariablesByName(conjunction.pattern(), set("p1", "p2")));
+            long answers = incrementalEstimator.answerEstimate(getVariablesByName(conjunction.pattern(), set("p1", "p2")));
             assertEquals(25L, answers);
         }
     }

--- a/test/integration/reasoner/planner/AnswerCountEstimatorTest.java
+++ b/test/integration/reasoner/planner/AnswerCountEstimatorTest.java
@@ -661,6 +661,7 @@ public class AnswerCountEstimatorTest {
     }
 
     // TODO: Add tests with two rules inferring same relation but w/ different number of role-players
+    // TODO: Add test with non-tree pattern to check propagation time.
 
     private static Conjunction resolvedConjunction(String query, LogicManager logicMgr) {
         Disjunction disjunction = resolvedDisjunction(query, logicMgr);


### PR DESCRIPTION
## What is the goal of this PR?
Address the locality assumption of the conjunction answer count model by propagating the reduction in the number of possible bounds for a variable to other resolvable models. The current model (without this) was prone to wildly over-estimating the number of answers to a conjunction containing a strongly selective resolvable.

## What are the changes implemented in this PR?
* The answer-count scales resolvable models according to the estimate of bounds propagated from other resolvables.
* Introduces an `IncrementalEstimator` which can return answers for any prefix when building up a conjunction resolvable by resolvable.
* The propagation implementation is handled by the IncrementalEstimator - Every time a resolvable is added, any reduction  on the estimates of bounds sizes for the variables are propagated  to the scale the other resolvables.