### PR TITLE
Improve concurrency of TypeDB executors

### DIFF
--- a/concurrent/executor/ParallelThreadPoolExecutor.java
+++ b/concurrent/executor/ParallelThreadPoolExecutor.java
@@ -45,8 +45,9 @@ public class ParallelThreadPoolExecutor implements Executor {
     private ThreadPoolExecutor next() {
         int next = 0, smallest = Integer.MAX_VALUE;
         for (int i = 0; i < executors.length; i++) {
-            if (executors[i].getQueue().size() < smallest) {
-                smallest = executors[i].getQueue().size();
+            int tasks = executors[i].getQueue().size() + executors[i].getActiveCount();
+            if (tasks < smallest) {
+                smallest = tasks;
                 next = i;
             }
         }


### PR DESCRIPTION
## What is the goal of this PR?

We fix a bug in the allocation of jobs onto executor pools, which was limiting high-CPU environments from achieving maximum concurrency. In some workloads this change increased CPU utilisation from 40% to 65%.

## What are the changes implemented in this PR?

* Allocation of a job onto a `ParallelThreadPoolExecutor` considers not only the job queue size currently, but also the number of actively executing jobs. This means that we don't end up queuing a job behind an active job when there is another executor that is fully un-used