### PR TITLE
Replace remaining occurences of .grabl with .factory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 /.github                   @haikalpribadi
-/.grabl                    @haikalpribadi
+/.factory                  @haikalpribadi
 /bin                       @haikalpribadi
 /common                    @haikalpribadi
 /concept                   @haikalpribadi

--- a/BUILD
+++ b/BUILD
@@ -242,7 +242,7 @@ docker_container_push(
 
 checkstyle_test(
     name = "checkstyle",
-    include = glob(["*", ".grabl/*", "bin/*", ".circleci/*"]),
+    include = glob(["*", ".factory/*", "bin/*", ".circleci/*"]),
     exclude = glob([
         "*.md",
         ".circleci/windows/*",


### PR DESCRIPTION
## What is the goal of this PR?
Reflect the renaming of the .grabl folder to .factory in all references
   
## What are the changes implemented in this PR?
- Replaces .grabl with .factory in `.github/CODEOWNERS` and `/BUILD` for checkstyle coverage