### PR TITLE
Migrate to Factory

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -36,7 +36,7 @@ build:
         SONARCLOUD_CODE_ANALYSIS_CREDENTIAL=$SONARCLOUD_CREDENTIAL \
           bazel run @vaticle_dependencies//tool/sonarcloud:code-analysis -- \
           --project-key=vaticle_typedb \
-          --branch=$GRABL_BRANCH --commit-id=$GRABL_COMMIT
+          --branch=$FACTORY_BRANCH --commit-id=$FACTORY_COMMIT
     dependency-analysis:
       image: vaticle-ubuntu-21.04
       command: |
@@ -158,7 +158,7 @@ build:
         branch: [master, development]
       dependencies: [deploy-apt-snapshot]
       command: |
-        export TEST_DEPLOYMENT_APT_COMMIT=$GRABL_COMMIT
+        export TEST_DEPLOYMENT_APT_COMMIT=$FACTORY_COMMIT
         bazel test //test/deployment:apt --action_env=TEST_DEPLOYMENT_APT_COMMIT --test_output=streamed
 release:
   filter:
@@ -179,9 +179,9 @@ release:
         pyenv global 3.6.10 system
         pip install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run @vaticle_dependencies//tool/release/notes:create -- $GRABL_OWNER $GRABL_REPO $GRABL_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
+        bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
+        bazel run --define version=$(cat VERSION) //:deploy-github -- $FACTORY_COMMIT
     deploy-brew:
       image: vaticle-ubuntu-21.04
       dependencies: [deploy-github]

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -31,67 +31,67 @@ build:
       owner: vaticle
       branch: master
     build-analysis:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         SONARCLOUD_CODE_ANALYSIS_CREDENTIAL=$SONARCLOUD_CREDENTIAL \
           bazel run @vaticle_dependencies//tool/sonarcloud:code-analysis -- \
           --project-key=vaticle_typedb \
           --branch=$FACTORY_BRANCH --commit-id=$FACTORY_COMMIT
     dependency-analysis:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
   correctness:
     build:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel build //...
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
         bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
     build-dependency:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
         bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
     test-unit:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel test //common/... --test_output=streamed
         bazel test //pattern/... --test_output=streamed
         bazel test //logic/... --test_output=streamed
         bazel test //reasoner/... --test_output=streamed
     test-integration:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel test //test/integration/... --test_output=streamed
     test-behaviour-connection:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel test //test/behaviour/connection/... --test_output=streamed
     test-behaviour-concept:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel test //test/behaviour/concept/... --test_output=streamed
     test-behaviour-match:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel test //test/behaviour/typeql/language/match/... --test_output=streamed
         bazel test //test/behaviour/typeql/language/get/... --test_output=streamed
     test-behaviour-writable:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel test //test/behaviour/typeql/language/insert/... --test_output=streamed
         bazel test //test/behaviour/typeql/language/delete/... --test_output=streamed
         bazel test //test/behaviour/typeql/language/update/... --test_output=streamed
     test-behaviour-definable:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel test //test/behaviour/typeql/language/define/... --test_output=streamed
         bazel test //test/behaviour/typeql/language/undefine/... --test_output=streamed
         bazel test //test/behaviour/typeql/language/rule_validation/... --test_output=streamed
     test-behaviour-reasoner:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
@@ -105,7 +105,7 @@ build:
         bazel test //test/behaviour/reasoner/tests/value_predicate:test --test_output=streamed
         bazel test //test/behaviour/reasoner/tests/variable_roles:test --test_output=streamed
     test-assembly-linux-targz:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
         branch: [master, development]
@@ -113,7 +113,7 @@ build:
       command: |
         bazel test //test/assembly:assembly --test_output=streamed
     test-assembly-docker:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
         branch: [master, development]
@@ -121,7 +121,7 @@ build:
       command: |
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
         branch: [master, development]
@@ -136,7 +136,7 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-zip -- snapshot
         bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-zip -- snapshot
     deploy-apt-snapshot:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
         branch: [master, development]
@@ -166,51 +166,41 @@ release:
     branch: master
   validation:
     validate-dependencies:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: bazel test //:release-validate-deps --test_output=streamed
   deployment:
     deploy-github:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
         branch: master
       command: |
-        pyenv install -s 3.6.10
-        pyenv global 3.6.10 system
-        pip install certifi
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
         bazel run --define version=$(cat VERSION) //:deploy-github -- $FACTORY_COMMIT
     deploy-brew:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [deploy-github]
       filter:
         owner: vaticle
         branch: master
       command: |
-        pyenv install -s 3.6.10
-        pyenv global 3.6.10 system
         export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN DEPLOY_BREW_USERNAME=$REPO_GITHUB_USERNAME DEPLOY_BREW_EMAIL=$REPO_GITHUB_EMAIL
         bazel run --define version=$(cat VERSION) //:deploy-brew -- release
     deploy-apt-release:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
         branch: master
       dependencies: [deploy-github]
       command: |
-        pyenv install 3.7.9
-        pyenv global 3.7.9
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run --define version=$(cat VERSION) //server:deploy-apt -- release
         bazel run --define version=$(cat VERSION) //:deploy-apt -- release
     deploy-docker:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
         branch: master
@@ -220,7 +210,7 @@ release:
         bazel run //:deploy-docker-latest
         bazel run //:deploy-docker-versioned
     deploy-artifact-release:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       filter:
         owner: vaticle
         branch: master

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Grabl](https://grabl.io/api/status/vaticle/typedb/badge.svg)](https://grabl.io/vaticle/typedb)
+[![Factory](https://factory.vaticle.com/api/status/vaticle/typedb/badge.svg)](https://factory.vaticle.com/vaticle/typedb)
 [![CircleCI](https://circleci.com/gh/vaticle/typedb/tree/master.svg?style=shield)](https://circleci.com/gh/vaticle/typedb/tree/master)
 [![GitHub release](https://img.shields.io/github/release/vaticle/typedb.svg)](https://github.com/vaticle/typedb/releases/latest)
 [![Discord](https://img.shields.io/discord/665254494820368395?color=7389D8&label=chat&logo=discord&logoColor=ffffff)](https://vaticle.com/discord)

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "92563e91bf032c6361f17e71b4837210ce16353e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/jamesreprise/vaticle-dependencies",
+        commit = "5a9b5ca0adbcb1b7d2ad769c7dbd3221f6ddbf97", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():
@@ -34,8 +34,8 @@ def vaticle_typeql():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "8400246456704657bfcaacbfac5ef2f6adbd8263" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/jamesreprise/typedb-common",
+        commit = "426c22f2413b8de17d1582af0c5306b16a59948c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -1,18 +1,22 @@
 #
 # Copyright (C) 2022 Vaticle
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
@@ -20,41 +24,41 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/jamesreprise/vaticle-dependencies",
-        commit = "5a9b5ca0adbcb1b7d2ad769c7dbd3221f6ddbf97", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "4464b506ca469f37d3b696fb2f1eda34061cdaa1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/vaticle/typeql",
-        commit = "63adf08e04351c740bdfc7d66af5e6239559450d", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/jamesreprise/typeql",
+        commit = "9f738b87fdc9443c978e01199dd673df825eb237", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/jamesreprise/typedb-common",
-        commit = "426c22f2413b8de17d1582af0c5306b16a59948c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        commit = "17c162fe7135db6988d7ac1ae5416568231c8789" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/vaticle/typedb-protocol",
-        commit = "6d47f21951abf2752ed65525cf17e9ecaef131e1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        commit = "192ee408a841130d75da9ca67630263126da3bd4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "4952c635173c76e7cb0ce0e26861083bd6fbc174", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "a503356d9d22e794393ced5b3d3f014db4189b60", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():
     git_repository(
         name = "vaticle_factory_tracing",
         remote = "https://github.com/vaticle/factory-tracing",
-        commit = "a4d5e36b1b0c56bd370e5a7583d628de9272f086"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
+        commit = "e61d2d00e0c0321406da5fed14bd32ccb41cf03c"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_factory_tracing
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -1,22 +1,18 @@
 #
 # Copyright (C) 2022 Vaticle
 #
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
 #
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -27,8 +27,8 @@ def vaticle_dependencies():
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/jamesreprise/typeql",
-        commit = "9f738b87fdc9443c978e01199dd673df825eb237", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/vaticle/typeql",
+        commit = "20688efec99f40c90c9261c61306e66902135651", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():


### PR DESCRIPTION
## What is the goal of this PR?

We've migrated our continuous integration for this repo to Vaticle Factory from Grabl.

## What are the changes implemented in this PR?

We've updated:
- dependencies.
- uses of pyenv that are no longer in line with our approach.
- machine definitions from ubuntu 21.04 to 22.04.

