### PR TITLE
Disjunctions in rules

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -573,10 +573,10 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new RuleWrite(3, "The conclusion of rule '%s' may insert types '%s', which is not allowed in the current schema.");
         public static final RuleWrite RULE_WHEN_INCOHERENT =
                 new RuleWrite(4, "The rule '%s' has a when clause '%s' that is illegal in the current schema.");
-        public static final RuleWrite RULE_WHEN_UNANSWERABLE_BRANCH =
-                new RuleWrite(5, "The rule '%s' has a branch in the when clause '%s' that can never have answers in the current schema.");
         public static final RuleWrite RULE_WHEN_UNANSWERABLE =
-                new RuleWrite(6, "The rule '%s' has a when clause '%s' that can never have answers in the current schema.");
+                new RuleWrite(5, "The rule '%s' has a when clause '%s' that can never have answers in the current schema.");
+        public static final RuleWrite RULE_WHEN_UNANSWERABLE_BRANCH =
+                new RuleWrite(6, "The rule '%s' has a branch in the when clause '%s' that can never have answers in the current schema.");
         public static final RuleWrite RULE_THEN_INCOHERENT =
                 new RuleWrite(7, "The rule '%s' has a then clause '%s' that can never be satisfied in the current schema.");
         public static final RuleWrite RULE_THEN_UNANSWERABLE =

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -569,12 +569,12 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new RuleWrite(1, "The rule body of '%s' ('when' or 'then') cannot be undefined. The rule must be undefined entirely by referring to its label.");
         public static final RuleWrite CONTRADICTORY_RULE_CYCLE =
                 new RuleWrite(2, "A cycle containing negation(s) that can cause inference contradictions has been detected in rules: %s");
-        public static final RuleWrite INVALID_NEGATION_CONTAINS_DISJUNCTION =
-                new RuleWrite(3, "The rule '%s' contains a negation containing a disjunction, which is currently unsupported");
         public static final RuleWrite RULE_CONCLUSION_ILLEGAL_INSERT =
-                new RuleWrite(4, "The conclusion of rule '%s' may insert types '%s', which is not allowed in the current schema.");
+                new RuleWrite(3, "The conclusion of rule '%s' may insert types '%s', which is not allowed in the current schema.");
         public static final RuleWrite RULE_WHEN_INCOHERENT =
-                new RuleWrite(5, "The rule '%s' has a when clause '%s' that is illegal in the current schema.");
+                new RuleWrite(4, "The rule '%s' has a when clause '%s' that is illegal in the current schema.");
+        public static final RuleWrite RULE_WHEN_UNANSWERABLE_BRANCH =
+                new RuleWrite(5, "The rule '%s' has a branch in the when clause '%s' that can never have answers in the current schema.");
         public static final RuleWrite RULE_WHEN_UNANSWERABLE =
                 new RuleWrite(6, "The rule '%s' has a when clause '%s' that can never have answers in the current schema.");
         public static final RuleWrite RULE_THEN_INCOHERENT =

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        tag = "3e078513682255d859ecbf88067ea8787647975c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        commit = "3e078513682255d859ecbf88067ea8787647975c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,7 +49,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "9ce29c4e2ccf0d34186dbd9c9708153490732d76",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "36fe6680af4af3463d8ef9daaab5ffc004557f55",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
 )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        tag = "2.12.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        tag = "3e078513682255d859ecbf88067ea8787647975c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
@@ -49,8 +49,8 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "eacb1c67a39f846c322ca278a917eb6127e4d123",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
-    )
+        commit = "9ce29c4e2ccf0d34186dbd9c9708153490732d76",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+)
 
 def vaticle_factory_tracing():
     git_repository(

--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -107,7 +107,7 @@ public class LogicManager {
     }
 
     private FunctionalIterator<Rule> rulesWithNegations() {
-        return rules().filter(rule -> iterate(rule.condition()).anyMatch(condition -> !condition.conjunction().negations().isEmpty()));
+        return rules().filter(rule -> iterate(rule.conditionBranches()).anyMatch(condition -> !condition.conjunction().negations().isEmpty()));
     }
 
     public Map<Rule, Set<Unifier>> applicableRules(Concludable concludable) {
@@ -159,7 +159,7 @@ public class LogicManager {
 
         // re-index the concludable-rule unifiers
         this.rules().forEachRemaining(rule -> {
-            iterate(rule.condition()).flatMap(condition -> iterate(condition.conjunction().allConcludables()))
+            iterate(rule.conditionBranches()).flatMap(condition -> iterate(condition.conjunction().allConcludables()))
                     .forEachRemaining(this::indexApplicableRules);
         });
 
@@ -196,16 +196,16 @@ public class LogicManager {
     }
 
     private FunctionalIterator<RuleDependency> ruleDependencies(Rule rule) {
-        return iterate(rule.condition()).flatMap(condition -> condition.conjunction().allConcludables())
+        return iterate(rule.conditionBranches()).flatMap(condition -> condition.conjunction().allConcludables())
                 .flatMap(c -> iterate(applicableRules(c).keySet()))
                 .map(recursiveRule -> RuleDependency.of(recursiveRule, rule));
     }
 
     private FunctionalIterator<RuleDependency> negatedRuleDependencies(Rule rule) {
-        assert iterate(rule.condition()).flatMap(condition -> iterate(condition.conjunction().negations()))
+        assert iterate(rule.conditionBranches()).flatMap(condition -> iterate(condition.conjunction().negations()))
                 .flatMap(negated -> iterate(negated.disjunction().conjunctions()))
                 .allMatch(conj -> conj.negations().isEmpty()); // Revise when we support nested negations in rules
-        return iterate(rule.condition()).flatMap(condition -> iterate(condition.conjunction().negations()))
+        return iterate(rule.conditionBranches()).flatMap(condition -> iterate(condition.conjunction().negations()))
                 .flatMap(neg -> iterate(neg.disjunction().conjunctions()))
                 .flatMap(conj -> conj.allConcludables())
                 .flatMap(concludable -> iterate(applicableRules(concludable).keySet()))

--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -107,7 +107,7 @@ public class LogicManager {
     }
 
     private FunctionalIterator<Rule> rulesWithNegations() {
-        return rules().filter(rule -> iterate(rule.conditionBranches()).anyMatch(condition -> !condition.conjunction().negations().isEmpty()));
+        return rules().filter(rule -> iterate(rule.condition().branches()).anyMatch(condition -> !condition.conjunction().negations().isEmpty()));
     }
 
     public Map<Rule, Set<Unifier>> applicableRules(Concludable concludable) {
@@ -159,7 +159,7 @@ public class LogicManager {
 
         // re-index the concludable-rule unifiers
         this.rules().forEachRemaining(rule -> {
-            iterate(rule.conditionBranches()).flatMap(condition -> iterate(condition.conjunction().allConcludables()))
+            iterate(rule.condition().branches()).flatMap(condition -> iterate(condition.conjunction().allConcludables()))
                     .forEachRemaining(this::indexApplicableRules);
         });
 
@@ -196,16 +196,16 @@ public class LogicManager {
     }
 
     private FunctionalIterator<RuleDependency> ruleDependencies(Rule rule) {
-        return iterate(rule.conditionBranches()).flatMap(condition -> condition.conjunction().allConcludables())
+        return iterate(rule.condition().branches()).flatMap(condition -> condition.conjunction().allConcludables())
                 .flatMap(c -> iterate(applicableRules(c).keySet()))
                 .map(recursiveRule -> RuleDependency.of(recursiveRule, rule));
     }
 
     private FunctionalIterator<RuleDependency> negatedRuleDependencies(Rule rule) {
-        assert iterate(rule.conditionBranches()).flatMap(condition -> iterate(condition.conjunction().negations()))
+        assert iterate(rule.condition().branches()).flatMap(condition -> iterate(condition.conjunction().negations()))
                 .flatMap(negated -> iterate(negated.disjunction().conjunctions()))
                 .allMatch(conj -> conj.negations().isEmpty()); // Revise when we support nested negations in rules
-        return iterate(rule.conditionBranches()).flatMap(condition -> iterate(condition.conjunction().negations()))
+        return iterate(rule.condition().branches()).flatMap(condition -> iterate(condition.conjunction().negations()))
                 .flatMap(neg -> iterate(neg.disjunction().conjunctions()))
                 .flatMap(conj -> conj.allConcludables())
                 .flatMap(concludable -> iterate(applicableRules(concludable).keySet()))

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -121,10 +121,6 @@ public class Rule {
         return condition;
     }
 
-    public Set<Condition.ConditionBranch> conditionBranches() {
-        return condition.branches();
-    }
-
     public Disjunction when() {
         return when;
     }

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -195,11 +195,6 @@ public class Rule {
     private Disjunction whenPattern(com.vaticle.typeql.lang.pattern.Conjunction<? extends Pattern> conjunction,
                                     com.vaticle.typeql.lang.pattern.variable.ThingVariable<?> then, LogicManager logicMgr) {
         Disjunction when = Disjunction.create(conjunction.normalise(), VariableRegistry.createFromThings(list(then)));
-
-        if (iterate(when.conjunctions()).flatMap(conj -> iterate(conj.negations())).anyMatch(neg -> neg.disjunction().conjunctions().size() != 1)) {
-            throw TypeDBException.of(INVALID_NEGATION_CONTAINS_DISJUNCTION, getLabel());
-        }
-
         logicMgr.typeInference().applyCombination(when);
         return when;
     }

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -299,10 +299,6 @@ public class Rule {
             public int hashCode() {
                 return this.hash;
             }
-
-            public Conclusion conclusion() {
-                return rule.conclusion();
-            }
         }
     }
 

--- a/pattern/Disjunction.java
+++ b/pattern/Disjunction.java
@@ -42,14 +42,15 @@ public class Disjunction implements Pattern, Cloneable {
     private static final String TRACE_PREFIX = "disjunction.";
     private final List<Conjunction> conjunctions;
     private final int hash;
-    private Set<Identifier.Variable.Retrievable> allBranchesRetrieve;
+    private final Set<Identifier.Variable.Retrievable> retrieves;
 
     public Disjunction(List<Conjunction> conjunctions) {
         this.conjunctions = conjunctions;
         this.hash = Objects.hash(conjunctions);
-        this.allBranchesRetrieve = iterate(conjunctions)
+        this.retrieves = iterate(conjunctions)
                 .flatMap(conjunction -> iterate(conjunction.retrieves()))
-                .filter(id -> iterate(conjunctions).allMatch(conjunction -> conjunction.retrieves().contains(id))).toSet();
+                .filter(id -> iterate(conjunctions).allMatch(conjunction -> conjunction.retrieves().contains(id)))
+                .toSet();
     }
 
     public static Disjunction create(
@@ -73,6 +74,10 @@ public class Disjunction implements Pattern, Cloneable {
 
     public boolean isCoherent() {
         return iterate(conjunctions).allMatch(Conjunction::isCoherent);
+    }
+
+    public Set<Identifier.Variable.Retrievable> retrieves() {
+        return retrieves;
     }
 
     @Override
@@ -101,9 +106,5 @@ public class Disjunction implements Pattern, Cloneable {
     @Override
     public int hashCode() {
         return hash;
-    }
-
-    public Set<Identifier.Variable.Retrievable> allBranchesRetrieve() {
-        return allBranchesRetrieve;
     }
 }

--- a/pattern/Disjunction.java
+++ b/pattern/Disjunction.java
@@ -20,11 +20,13 @@ package com.vaticle.typedb.core.pattern;
 
 import com.vaticle.factory.tracing.client.FactoryTracingThreadStatic.ThreadTrace;
 import com.vaticle.typedb.core.pattern.variable.VariableRegistry;
+import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typeql.lang.pattern.Conjunctable;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import static com.vaticle.factory.tracing.client.FactoryTracingThreadStatic.traceOnThread;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
@@ -40,10 +42,14 @@ public class Disjunction implements Pattern, Cloneable {
     private static final String TRACE_PREFIX = "disjunction.";
     private final List<Conjunction> conjunctions;
     private final int hash;
+    private Set<Identifier.Variable.Retrievable> allBranchesRetrieve;
 
     public Disjunction(List<Conjunction> conjunctions) {
         this.conjunctions = conjunctions;
         this.hash = Objects.hash(conjunctions);
+        this.allBranchesRetrieve = iterate(conjunctions)
+                .flatMap(conjunction -> iterate(conjunction.retrieves()))
+                .filter(id -> iterate(conjunctions).allMatch(conjunction -> conjunction.retrieves().contains(id))).toSet();
     }
 
     public static Disjunction create(
@@ -95,5 +101,9 @@ public class Disjunction implements Pattern, Cloneable {
     @Override
     public int hashCode() {
         return hash;
+    }
+
+    public Set<Identifier.Variable.Retrievable> allBranchesRetrieve() {
+        return allBranchesRetrieve;
     }
 }

--- a/reasoner/controller/AbstractController.java
+++ b/reasoner/controller/AbstractController.java
@@ -40,7 +40,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.RES
 
 public abstract class AbstractController<
         PROCESSOR_ID, INPUT, OUTPUT,
-        REQ extends AbstractRequest<?, ?, INPUT, ?>,
+        REQ extends AbstractRequest<?, ?, INPUT>,
         PROCESSOR extends AbstractProcessor<INPUT, OUTPUT, ?, PROCESSOR>,
         CONTROLLER extends AbstractController<PROCESSOR_ID, INPUT, OUTPUT, ?, PROCESSOR, CONTROLLER>
         > extends Actor<CONTROLLER> {
@@ -88,7 +88,7 @@ public abstract class AbstractController<
     /*
      * Called on the target controller
      */
-    <RECEIVED_REQ extends AbstractRequest<?, PROCESSOR_ID, OUTPUT, ?>> void establishProcessorConnection(RECEIVED_REQ req) {
+    <RECEIVED_REQ extends AbstractRequest<?, PROCESSOR_ID, OUTPUT>> void establishProcessorConnection(RECEIVED_REQ req) {
         if (isTerminated()) return;
         getOrCreateProcessor(req.bounds()).execute(actor -> actor.establishConnection(req));
     }

--- a/reasoner/controller/ConcludableController.java
+++ b/reasoner/controller/ConcludableController.java
@@ -54,7 +54,7 @@ import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.reasoner.processor.reactive.PoolingStream.BufferedFanStream.fanInFanOut;
 
 public abstract class ConcludableController<INPUT, OUTPUT,
-        REQ extends AbstractRequest<Conclusion, ConceptMap, INPUT, ?>,
+        REQ extends AbstractRequest<Conclusion, ConceptMap, INPUT>,
         PROCESSOR extends ConcludableController.Processor<INPUT, OUTPUT, ?, PROCESSOR>,
         CONTROLLER extends ConcludableController<INPUT, OUTPUT, ?, PROCESSOR, CONTROLLER>
         > extends AbstractController<ConceptMap, INPUT, OUTPUT, REQ, PROCESSOR, CONTROLLER> {
@@ -176,7 +176,7 @@ public abstract class ConcludableController<INPUT, OUTPUT,
     }
 
     protected abstract static class Processor<
-            INPUT, OUTPUT, REQ extends AbstractRequest<?, ?, INPUT, ?>,
+            INPUT, OUTPUT, REQ extends AbstractRequest<?, ?, INPUT>,
             PROCESSOR extends AbstractProcessor<INPUT, OUTPUT, REQ, PROCESSOR>
             > extends AbstractProcessor<INPUT, OUTPUT, REQ, PROCESSOR> {
 
@@ -313,7 +313,7 @@ public abstract class ConcludableController<INPUT, OUTPUT,
                 return new Request(inputPortId, driver(), conclusion, bounds);
             }
 
-            protected static class Request extends AbstractRequest<Conclusion, ConceptMap, Map<Variable, Concept>, ConclusionController.Match> {
+            protected static class Request extends AbstractRequest<Conclusion, ConceptMap, Map<Variable, Concept>> {
 
                 Request(Reactive.Identifier inputPortId,
                         Driver<Match> inputPortProcessor, Conclusion controllerId, ConceptMap processorId) {
@@ -408,7 +408,7 @@ public abstract class ConcludableController<INPUT, OUTPUT,
                 return new Request(inputPortId, driver(), conclusion, bounds);
             }
 
-            protected static class Request extends AbstractRequest<Conclusion, ConceptMap, PartialExplanation, ConclusionController.Explain> {
+            protected static class Request extends AbstractRequest<Conclusion, ConceptMap, PartialExplanation> {
 
                 Request(Reactive.Identifier inputPortId,
                         Driver<Explain> inputPortProcessor, Conclusion conclusion, ConceptMap conceptMap) {

--- a/reasoner/controller/ConclusionController.java
+++ b/reasoner/controller/ConclusionController.java
@@ -230,7 +230,7 @@ public abstract class ConclusionController<
         public void setUp() {
             setHubReactive(fanOut(this));
             InputPort<Either<ConceptMap, Materialisation>> conditionInput = createInputPort();
-            ConceptMap filteredBounds = bounds().filter(rule.condition().pattern().retrieves());
+            ConceptMap filteredBounds = bounds().filter(rule.when().allBranchesRetrieve());
             mayRequestCondition(new ConditionRequest(conditionInput.identifier(), driver(), rule.condition(), filteredBounds));
             Stream<Either<ConceptMap, Map<Variable, Concept>>, OUTPUT> conclusionReactive = createStream();
             conditionInput.map(Processor::convertConclusionInput).registerSubscriber(conclusionReactive);

--- a/reasoner/controller/ConclusionController.java
+++ b/reasoner/controller/ConclusionController.java
@@ -228,7 +228,7 @@ public abstract class ConclusionController<
         public void setUp() {
             setHubReactive(fanOut(this));
             InputPort<Either<ConceptMap, Materialisation>> conditionInput = createInputPort();
-            ConceptMap filteredBounds = bounds().filter(rule.when().allBranchesRetrieve());
+            ConceptMap filteredBounds = bounds().filter(rule.when().retrieves());
             mayRequestCondition(new ConditionRequest(conditionInput.identifier(), driver(), rule.condition(), filteredBounds));
             Stream<Either<ConceptMap, Map<Variable, Concept>>, OUTPUT> conclusionReactive = createStream();
             conditionInput.map(Processor::convertConclusionInput).registerSubscriber(conclusionReactive);
@@ -305,7 +305,7 @@ public abstract class ConclusionController<
                     Either<ConceptMap, Map<Variable, Concept>> packet
             ) {
                 if (packet.isFirst()) {
-                    assert packet.first().concepts().keySet().containsAll(conclusionProcessor().rule().condition().pattern().allBranchesRetrieve());
+                    assert packet.first().concepts().keySet().containsAll(conclusionProcessor().rule().condition().disjunction().pattern().retrieves());
                     InputPort<Either<ConceptMap, Materialisation>> materialisationInput = conclusionProcessor().createInputPort();
                     ConceptMap filteredConditionAns = packet.first().filter(conclusionProcessor().rule().conclusion().retrievableIds());
                     conclusionProcessor().mayRequestMaterialiser(new MaterialiserRequest(

--- a/reasoner/controller/ConclusionController.java
+++ b/reasoner/controller/ConclusionController.java
@@ -307,7 +307,7 @@ public abstract class ConclusionController<
                     Either<ConceptMap, Map<Variable, Concept>> packet
             ) {
                 if (packet.isFirst()) {
-                    assert packet.first().concepts().keySet().containsAll(conclusionProcessor().rule().condition().pattern().retrieves());
+                    assert packet.first().concepts().keySet().containsAll(conclusionProcessor().rule().condition().pattern().allBranchesRetrieve());
                     InputPort<Either<ConceptMap, Materialisation>> materialisationInput = conclusionProcessor().createInputPort();
                     ConceptMap filteredConditionAns = packet.first().filter(conclusionProcessor().rule().conclusion().retrievableIds());
                     conclusionProcessor().mayRequestMaterialiser(new MaterialiserRequest(

--- a/reasoner/controller/ConclusionController.java
+++ b/reasoner/controller/ConclusionController.java
@@ -56,7 +56,7 @@ public abstract class ConclusionController<
         OUTPUT, PROCESSOR extends AbstractProcessor<Either<ConceptMap, Materialisation>, OUTPUT, ?, PROCESSOR>,
         CONTROLLER extends ConclusionController<OUTPUT, PROCESSOR, CONTROLLER>
         > extends AbstractController<
-        ConceptMap, Either<ConceptMap, Materialisation>, OUTPUT, ConclusionController.Request<?, ?, ?>,
+        ConceptMap, Either<ConceptMap, Materialisation>, OUTPUT, ConclusionController.Request<?, ?>,
         PROCESSOR, CONTROLLER
         > {
 
@@ -77,7 +77,7 @@ public abstract class ConclusionController<
     }
 
     @Override
-    public void routeConnectionRequest(Request<?, ?, ?> req) {
+    public void routeConnectionRequest(Request<?, ?> req) {
         if (isTerminated()) return;
         if (req.isCondition()) {
             conditionController.execute(actor -> actor.establishProcessorConnection(req.asCondition()));
@@ -125,10 +125,8 @@ public abstract class ConclusionController<
         }
     }
 
-    protected static class Request<
-            CONTROLLER_ID, BOUNDS,
-            CONTROLLER extends AbstractController<BOUNDS, ?, Either<ConceptMap, Materialisation>, ?, ?, ?>
-            > extends AbstractRequest<CONTROLLER_ID, BOUNDS, Either<ConceptMap, Materialisation>> {
+    protected static class Request<CONTROLLER_ID, BOUNDS>
+            extends AbstractRequest<CONTROLLER_ID, BOUNDS, Either<ConceptMap, Materialisation>> {
 
         Request(Reactive.Identifier inputPortId,
                 Driver<? extends Processor<?, ?>> inputPortProcessor, CONTROLLER_ID controller_id, BOUNDS bounds) {
@@ -151,7 +149,7 @@ public abstract class ConclusionController<
             throw TypeDBException.of(ILLEGAL_STATE);
         }
 
-        protected static class ConditionRequest extends Request<Rule.Condition, ConceptMap, ConditionController> {
+        protected static class ConditionRequest extends Request<Rule.Condition, ConceptMap> {
 
             ConditionRequest(Reactive.Identifier inputPortId,
                              Driver<? extends Processor<?, ?>> inputPortProcessor,
@@ -171,7 +169,7 @@ public abstract class ConclusionController<
 
         }
 
-        protected static class MaterialiserRequest extends Request<Void, Materialisable, MaterialisationController> {
+        protected static class MaterialiserRequest extends Request<Void, Materialisable> {
 
             MaterialiserRequest(
                     Reactive.Identifier inputPortId,
@@ -194,7 +192,7 @@ public abstract class ConclusionController<
     }
 
     protected abstract static class Processor<OUTPUT, PROCESSOR extends Processor<OUTPUT, PROCESSOR>>
-            extends AbstractProcessor<Either<ConceptMap, Materialisation>, OUTPUT, Request<?, ?, ?>, PROCESSOR> {
+            extends AbstractProcessor<Either<ConceptMap, Materialisation>, OUTPUT, Request<?, ?>, PROCESSOR> {
 
         private final Rule rule;
         private final ConceptMap bounds;

--- a/reasoner/controller/ConclusionController.java
+++ b/reasoner/controller/ConclusionController.java
@@ -128,7 +128,7 @@ public abstract class ConclusionController<
     protected static class Request<
             CONTROLLER_ID, BOUNDS,
             CONTROLLER extends AbstractController<BOUNDS, ?, Either<ConceptMap, Materialisation>, ?, ?, ?>
-            > extends AbstractRequest<CONTROLLER_ID, BOUNDS, Either<ConceptMap, Materialisation>, CONTROLLER> {
+            > extends AbstractRequest<CONTROLLER_ID, BOUNDS, Either<ConceptMap, Materialisation>> {
 
         Request(Reactive.Identifier inputPortId,
                 Driver<? extends Processor<?, ?>> inputPortProcessor, CONTROLLER_ID controller_id, BOUNDS bounds) {

--- a/reasoner/controller/ConditionController.java
+++ b/reasoner/controller/ConditionController.java
@@ -49,7 +49,7 @@ public class ConditionController extends DisjunctionController<
                                                           ConceptMap bounds) {
         return new Processor(
                 processorDriver, driver(), processorContext(), disjunction, bounds,
-                () -> Processor.class.getSimpleName() + "(pattern: " + condition.pattern() + ", bounds: " + bounds + ")"
+                () -> Processor.class.getSimpleName() + "(pattern: " + condition.disjunction().pattern() + ", bounds: " + bounds + ")"
         );
     }
 

--- a/reasoner/controller/ConditionController.java
+++ b/reasoner/controller/ConditionController.java
@@ -64,7 +64,7 @@ public class ConditionController extends DisjunctionController<
 
         @Override
         Stream<Either<ConceptMap, Materialisation>, Either<ConceptMap, Materialisation>> getOrCreateHubReactive(Stream<ConceptMap,ConceptMap> fanIn) {
-            Stream<ConceptMap, Either<ConceptMap, Materialisation>> mapStream = fanIn.map(Either::<ConceptMap, Materialisation>first);
+            Stream<ConceptMap, Either<ConceptMap, Materialisation>> mapStream = fanIn.map(Either::first);
             PoolingStream.BufferedFanStream<Either<ConceptMap, Materialisation>> fanMap = fanInFanOut(this);
             mapStream.registerSubscriber(fanMap);
             return fanMap;

--- a/reasoner/controller/ConjunctionController.java
+++ b/reasoner/controller/ConjunctionController.java
@@ -60,7 +60,7 @@ public abstract class ConjunctionController<
         CONTROLLER extends ConjunctionController<CONTROLLER, PROCESSOR>,
         PROCESSOR extends AbstractProcessor<ConceptMap, ConceptMap, ?, PROCESSOR>
         > extends AbstractController<
-        ConceptMap, ConceptMap, ConceptMap, ConjunctionController.Request<?, ?>, PROCESSOR, CONTROLLER
+        ConceptMap, ConceptMap, ConceptMap, ConjunctionController.Request<?>, PROCESSOR, CONTROLLER
         > {
 
     private final Set<Resolvable<?>> resolvables;
@@ -112,7 +112,7 @@ public abstract class ConjunctionController<
     }
 
     @Override
-    public void routeConnectionRequest(Request<?, ?> connectionRequest) {
+    public void routeConnectionRequest(Request<?> connectionRequest) {
         if (isTerminated()) return;
         if (connectionRequest.isRetrievable()) {
             RetrievableRequest req = connectionRequest.asRetrievable();
@@ -148,9 +148,7 @@ public abstract class ConjunctionController<
         else return withExplainable(new ConceptMap(answer.concepts()), concludable);
     }
 
-    static class Request<
-            CONTROLLER_ID, CONTROLLER extends AbstractController<ConceptMap, ?, ConceptMap, ?, ?, ?>
-            > extends AbstractRequest<CONTROLLER_ID, ConceptMap, ConceptMap> {
+    static class Request<CONTROLLER_ID> extends AbstractRequest<CONTROLLER_ID, ConceptMap, ConceptMap> {
         Request(Reactive.Identifier inputPortId,
                 Driver<? extends Processor<?>> inputPortProcessor, CONTROLLER_ID controller_id,
                 ConceptMap conceptMap) {
@@ -184,7 +182,7 @@ public abstract class ConjunctionController<
     }
 
     protected abstract static class Processor<PROCESSOR extends Processor<PROCESSOR>>
-            extends AbstractProcessor<ConceptMap, ConceptMap, Request<?, ?>, PROCESSOR> {
+            extends AbstractProcessor<ConceptMap, ConceptMap, Request<?>, PROCESSOR> {
 
         final ConceptMap bounds;
         final List<Resolvable<?>> plan;
@@ -261,7 +259,7 @@ public abstract class ConjunctionController<
             return input;
         }
 
-        public static class RetrievableRequest extends Request<Retrievable, RetrievableController> {
+        public static class RetrievableRequest extends Request<Retrievable> {
 
             private RetrievableRequest(
                     Reactive.Identifier inputPortId,
@@ -283,7 +281,7 @@ public abstract class ConjunctionController<
 
         }
 
-        static class ConcludableRequest extends Request<Concludable, ConcludableController.Match> {
+        static class ConcludableRequest extends Request<Concludable> {
 
             private ConcludableRequest(
                     Reactive.Identifier inputPortId,
@@ -303,7 +301,7 @@ public abstract class ConjunctionController<
 
         }
 
-        static class NegatedRequest extends Request<Negated, NegationController> {
+        static class NegatedRequest extends Request<Negated> {
 
             private NegatedRequest(
                     Reactive.Identifier inputPortId,

--- a/reasoner/controller/ConjunctionController.java
+++ b/reasoner/controller/ConjunctionController.java
@@ -150,7 +150,7 @@ public abstract class ConjunctionController<
 
     static class Request<
             CONTROLLER_ID, CONTROLLER extends AbstractController<ConceptMap, ?, ConceptMap, ?, ?, ?>
-            > extends AbstractRequest<CONTROLLER_ID, ConceptMap, ConceptMap, CONTROLLER> {
+            > extends AbstractRequest<CONTROLLER_ID, ConceptMap, ConceptMap> {
         Request(Reactive.Identifier inputPortId,
                 Driver<? extends Processor<?, ?>> inputPortProcessor, CONTROLLER_ID controller_id,
                 ConceptMap conceptMap) {

--- a/reasoner/controller/ConjunctionController.java
+++ b/reasoner/controller/ConjunctionController.java
@@ -57,10 +57,10 @@ import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.reasoner.controller.ConcludableController.Processor.Match.withExplainable;
 
 public abstract class ConjunctionController<
-        OUTPUT, CONTROLLER extends ConjunctionController<OUTPUT, CONTROLLER, PROCESSOR>,
-        PROCESSOR extends AbstractProcessor<ConceptMap, OUTPUT, ?, PROCESSOR>
+        CONTROLLER extends ConjunctionController<CONTROLLER, PROCESSOR>,
+        PROCESSOR extends AbstractProcessor<ConceptMap, ConceptMap, ?, PROCESSOR>
         > extends AbstractController<
-        ConceptMap, ConceptMap, OUTPUT, ConjunctionController.Request<?, ?>, PROCESSOR, CONTROLLER
+        ConceptMap, ConceptMap, ConceptMap, ConjunctionController.Request<?, ?>, PROCESSOR, CONTROLLER
         > {
 
     private final Set<Resolvable<?>> resolvables;
@@ -152,7 +152,7 @@ public abstract class ConjunctionController<
             CONTROLLER_ID, CONTROLLER extends AbstractController<ConceptMap, ?, ConceptMap, ?, ?, ?>
             > extends AbstractRequest<CONTROLLER_ID, ConceptMap, ConceptMap> {
         Request(Reactive.Identifier inputPortId,
-                Driver<? extends Processor<?, ?>> inputPortProcessor, CONTROLLER_ID controller_id,
+                Driver<? extends Processor<?>> inputPortProcessor, CONTROLLER_ID controller_id,
                 ConceptMap conceptMap) {
             super(inputPortId, inputPortProcessor, controller_id, conceptMap);
         }
@@ -183,14 +183,14 @@ public abstract class ConjunctionController<
 
     }
 
-    protected abstract static class Processor<OUTPUT, PROCESSOR extends Processor<OUTPUT, PROCESSOR>>
-            extends AbstractProcessor<ConceptMap, OUTPUT, Request<?, ?>, PROCESSOR> {
+    protected abstract static class Processor<PROCESSOR extends Processor<PROCESSOR>>
+            extends AbstractProcessor<ConceptMap, ConceptMap, Request<?, ?>, PROCESSOR> {
 
         final ConceptMap bounds;
         final List<Resolvable<?>> plan;
 
         Processor(Driver<PROCESSOR> driver,
-                  Driver<? extends ConjunctionController<OUTPUT, ?, PROCESSOR>> controller,
+                  Driver<? extends ConjunctionController<?, PROCESSOR>> controller,
                   Context context, ConceptMap bounds, List<Resolvable<?>> plan,
                   Supplier<String> debugName) {
             super(driver, controller, context, debugName);
@@ -265,7 +265,7 @@ public abstract class ConjunctionController<
 
             private RetrievableRequest(
                     Reactive.Identifier inputPortId,
-                    Driver<? extends Processor<?, ?>> inputPortProcessor, Retrievable controllerId,
+                    Driver<? extends Processor<?>> inputPortProcessor, Retrievable controllerId,
                     ConceptMap processorId
             ) {
                 super(inputPortId, inputPortProcessor, controllerId, processorId);
@@ -287,7 +287,7 @@ public abstract class ConjunctionController<
 
             private ConcludableRequest(
                     Reactive.Identifier inputPortId,
-                    Driver<? extends Processor<?, ?>> inputPortProcessor, Concludable controllerId,
+                    Driver<? extends Processor<?>> inputPortProcessor, Concludable controllerId,
                     ConceptMap processorId
             ) {
                 super(inputPortId, inputPortProcessor, controllerId, processorId);
@@ -307,7 +307,7 @@ public abstract class ConjunctionController<
 
             private NegatedRequest(
                     Reactive.Identifier inputPortId,
-                    Driver<? extends Processor<?, ?>> inputPortProcessor, Negated controllerId, ConceptMap processorId
+                    Driver<? extends Processor<?>> inputPortProcessor, Negated controllerId, ConceptMap processorId
             ) {
                 super(inputPortId, inputPortProcessor, controllerId, processorId);
             }

--- a/reasoner/controller/DisjunctionController.java
+++ b/reasoner/controller/DisjunctionController.java
@@ -45,7 +45,8 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILL
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.reasoner.controller.ConjunctionController.merge;
 
-public abstract class DisjunctionController<OUTPUT,
+public abstract class DisjunctionController<
+        OUTPUT,
         PROCESSOR extends DisjunctionController.Processor<OUTPUT, PROCESSOR>,
         CONTROLLER extends DisjunctionController<OUTPUT, PROCESSOR, CONTROLLER>
         > extends AbstractController<ConceptMap, ConceptMap, OUTPUT, Request, PROCESSOR, CONTROLLER> {

--- a/reasoner/controller/DisjunctionController.java
+++ b/reasoner/controller/DisjunctionController.java
@@ -118,7 +118,7 @@ public abstract class DisjunctionController<
             return fanIn;
         }
 
-        static class Request extends AbstractRequest<ResolvableConjunction, ConceptMap, ConceptMap, NestedConjunctionController> {
+        static class Request extends AbstractRequest<ResolvableConjunction, ConceptMap, ConceptMap> {
 
             Request(
                     Reactive.Identifier inputPortId, Driver<? extends Processor<?>> inputPortProcessor,

--- a/reasoner/controller/MaterialisationController.java
+++ b/reasoner/controller/MaterialisationController.java
@@ -35,7 +35,7 @@ import java.util.function.Supplier;
 import static com.vaticle.typedb.core.reasoner.processor.reactive.PoolingStream.BufferedFanStream.fanOut;
 
 public class MaterialisationController extends AbstractController<
-        Materialisable, Void, Either<ConceptMap, Materialisation>, AbstractRequest<?, ?, Void, ?>,
+        Materialisable, Void, Either<ConceptMap, Materialisation>, AbstractRequest<?, ?, Void>,
         MaterialisationController.Processor, MaterialisationController
         > {
     // Either<> is just to match the input to ConclusionController, but this class only ever returns Materialisation
@@ -66,12 +66,12 @@ public class MaterialisationController extends AbstractController<
     }
 
     @Override
-    public void routeConnectionRequest(AbstractRequest<?, ?, Void, ?> connectionRequest) {
+    public void routeConnectionRequest(AbstractRequest<?, ?, Void> connectionRequest) {
         // Nothing to do
     }
 
     public static class Processor extends AbstractProcessor<Void, Either<ConceptMap, Materialisation>,
-                AbstractRequest<?, ?, Void, ?>, Processor> {
+                AbstractRequest<?, ?, Void>, Processor> {
 
         private final Materialisable materialisable;
         private final TraversalEngine traversalEng;

--- a/reasoner/controller/NegationController.java
+++ b/reasoner/controller/NegationController.java
@@ -153,7 +153,7 @@ public class NegationController extends AbstractController<
         }
 
         static class Request extends AbstractRequest<
-                Disjunction, ConceptMap, ConceptMap, NestedDisjunctionController
+                Disjunction, ConceptMap, ConceptMap
                 > {
 
             Request(

--- a/reasoner/controller/NestedConjunctionController.java
+++ b/reasoner/controller/NestedConjunctionController.java
@@ -21,6 +21,7 @@ package com.vaticle.typedb.core.reasoner.controller;
 import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.logic.resolvable.Resolvable;
 import com.vaticle.typedb.core.logic.resolvable.ResolvableConjunction;
+import com.vaticle.typedb.core.reasoner.processor.reactive.PoolingStream;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -58,7 +59,10 @@ public class NestedConjunctionController extends ConjunctionController<
 
         @Override
         public void setUp() {
-            setHubReactive(new CompoundStream(this, plan, bounds).buffer());
+            Processor<NestedConjunctionProcessor>.CompoundStream conjunctionStream = new CompoundStream(this, plan, bounds);
+            PoolingStream.BufferedFanStream<ConceptMap> bufferedFanStream = PoolingStream.BufferedFanStream.fanInFanOut(this);
+            conjunctionStream.registerSubscriber(bufferedFanStream);
+            setHubReactive(bufferedFanStream);
         }
     }
 

--- a/reasoner/controller/NestedConjunctionController.java
+++ b/reasoner/controller/NestedConjunctionController.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.function.Supplier;
 
 public class NestedConjunctionController extends ConjunctionController<
-        ConceptMap,
         NestedConjunctionController,
         NestedConjunctionController.NestedConjunctionProcessor
         > {
@@ -48,7 +47,7 @@ public class NestedConjunctionController extends ConjunctionController<
     }
 
     protected static class NestedConjunctionProcessor
-            extends ConjunctionController.Processor<ConceptMap, NestedConjunctionProcessor> {
+            extends ConjunctionController.Processor<NestedConjunctionProcessor> {
 
         private NestedConjunctionProcessor(Driver<NestedConjunctionProcessor> driver,
                                            Driver<NestedConjunctionController> controller, Context context,

--- a/reasoner/controller/NestedDisjunctionController.java
+++ b/reasoner/controller/NestedDisjunctionController.java
@@ -20,11 +20,12 @@ package com.vaticle.typedb.core.reasoner.controller;
 
 import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.logic.resolvable.ResolvableDisjunction;
+import com.vaticle.typedb.core.reasoner.processor.reactive.Reactive;
 
 import java.util.function.Supplier;
 
 public class NestedDisjunctionController
-        extends DisjunctionController<NestedDisjunctionController.Processor, NestedDisjunctionController>{
+        extends DisjunctionController<ConceptMap, NestedDisjunctionController.Processor, NestedDisjunctionController>{
 
     NestedDisjunctionController(Driver<NestedDisjunctionController> driver, ResolvableDisjunction disjunction,
                                 Context context) {
@@ -41,12 +42,17 @@ public class NestedDisjunctionController
         );
     }
 
-    protected static class Processor extends DisjunctionController.Processor<Processor> {
+    protected static class Processor extends DisjunctionController.Processor<ConceptMap, Processor> {
 
         private Processor(Driver<Processor> driver,
                           Driver<NestedDisjunctionController> controller, Context context,
                           ResolvableDisjunction disjunction, ConceptMap bounds, Supplier<String> debugName) {
             super(driver, controller, context, disjunction, bounds, debugName);
+        }
+
+        @Override
+        protected Reactive.Publisher<ConceptMap> transformInput(Reactive.Publisher<ConceptMap> input) {
+            return input;
         }
     }
 }

--- a/reasoner/controller/NestedDisjunctionController.java
+++ b/reasoner/controller/NestedDisjunctionController.java
@@ -20,7 +20,7 @@ package com.vaticle.typedb.core.reasoner.controller;
 
 import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.logic.resolvable.ResolvableDisjunction;
-import com.vaticle.typedb.core.reasoner.processor.reactive.Reactive;
+import com.vaticle.typedb.core.reasoner.processor.reactive.Reactive.Stream;
 
 import java.util.function.Supplier;
 
@@ -51,8 +51,8 @@ public class NestedDisjunctionController
         }
 
         @Override
-        protected Reactive.Publisher<ConceptMap> transformInput(Reactive.Publisher<ConceptMap> input) {
-            return input;
+        Stream<ConceptMap, ConceptMap> getOrCreateHubReactive(Stream<ConceptMap, ConceptMap> fanIn) {
+            return fanIn;
         }
     }
 }

--- a/reasoner/controller/RetrievableController.java
+++ b/reasoner/controller/RetrievableController.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
 import static com.vaticle.typedb.core.reasoner.processor.reactive.PoolingStream.BufferedFanStream.fanOut;
 
 public class RetrievableController extends AbstractController<
-        ConceptMap, Void, ConceptMap, AbstractRequest<?, ?, Void, ?>, RetrievableController.RetrievableProcessor,
+        ConceptMap, Void, ConceptMap, AbstractRequest<?, ?, Void>, RetrievableController.RetrievableProcessor,
         RetrievableController
         > {
 
@@ -61,14 +61,14 @@ public class RetrievableController extends AbstractController<
     }
 
     @Override
-    public void routeConnectionRequest(AbstractRequest<?, ?, Void, ?> connectionRequest) {
+    public void routeConnectionRequest(AbstractRequest<?, ?, Void> connectionRequest) {
         // Nothing to do
     }
 
     protected static class RetrievableProcessor extends AbstractProcessor<
                 Void,
                 ConceptMap,
-                AbstractRequest<?, ?, Void, ?>,
+                AbstractRequest<?, ?, Void>,
                 RetrievableProcessor
                 > {
 

--- a/reasoner/controller/RootConjunctionController.java
+++ b/reasoner/controller/RootConjunctionController.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 public class RootConjunctionController
-        extends ConjunctionController<ConceptMap, RootConjunctionController, RootConjunctionController.Processor> {
+        extends ConjunctionController<RootConjunctionController, RootConjunctionController.Processor> {
 
     private final Modifiers.Filter filter;
     private final boolean explain;
@@ -69,7 +69,7 @@ public class RootConjunctionController
         reasonerConsumer.exception(cause);
     }
 
-    protected static class Processor extends ConjunctionController.Processor<ConceptMap, Processor> {
+    protected static class Processor extends ConjunctionController.Processor<Processor> {
 
         private final Modifiers.Filter filter;
         private RootSink<ConceptMap> rootSink;

--- a/reasoner/controller/RootConjunctionController.java
+++ b/reasoner/controller/RootConjunctionController.java
@@ -29,7 +29,6 @@ import com.vaticle.typedb.core.traversal.common.Modifiers;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Supplier;
 
 public class RootConjunctionController

--- a/reasoner/controller/RootDisjunctionController.java
+++ b/reasoner/controller/RootDisjunctionController.java
@@ -93,22 +93,17 @@ public class RootDisjunctionController
         }
 
         @Override
-        protected Reactive.Publisher<ConceptMap> transformInput(Reactive.Publisher<ConceptMap> input) {
-            return input;
-        }
-
-        @Override
-        public void rootPull() {
-            rootSink.pull();
-        }
-
-        @Override
-        protected Stream<ConceptMap, ConceptMap> getOrCreateHubReactive(Stream<ConceptMap, ConceptMap> fanIn) {
+        Stream<ConceptMap, ConceptMap> getOrCreateHubReactive(Stream<ConceptMap, ConceptMap> fanIn) {
             // Simply here to be overridden by root disjuntion to avoid duplicating setUp
             Stream<ConceptMap, ConceptMap> op = fanIn;
             if (!explain) op = op.map(conceptMap -> conceptMap.filter(filter));
             op = op.distinct();
             return op;
+        }
+
+        @Override
+        public void rootPull() {
+            rootSink.pull();
         }
 
         @Override

--- a/reasoner/controller/RootDisjunctionController.java
+++ b/reasoner/controller/RootDisjunctionController.java
@@ -30,7 +30,7 @@ import java.util.HashSet;
 import java.util.function.Supplier;
 
 public class RootDisjunctionController
-        extends DisjunctionController<RootDisjunctionController.Processor, RootDisjunctionController> {
+        extends DisjunctionController<ConceptMap, RootDisjunctionController.Processor, RootDisjunctionController> {
 
     private final Modifiers.Filter filter;
     private final boolean explain;
@@ -68,7 +68,7 @@ public class RootDisjunctionController
         reasonerConsumer.exception(cause);
     }
 
-    protected static class Processor extends DisjunctionController.Processor<Processor> {
+    protected static class Processor extends DisjunctionController.Processor<ConceptMap, Processor> {
 
         private final Modifiers.Filter filter;
         private final boolean explain;
@@ -90,6 +90,11 @@ public class RootDisjunctionController
             super.setUp();
             rootSink = new RootSink<>(this, reasonerConsumer);
             hubReactive().registerSubscriber(rootSink);
+        }
+
+        @Override
+        protected Reactive.Publisher<ConceptMap> transformInput(Reactive.Publisher<ConceptMap> input) {
+            return input;
         }
 
         @Override

--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -641,7 +641,7 @@ public class AnswerCountEstimator {
                         ruleSideIds = new HashSet<>(rule.conclusion().pattern().retrieves());
                     }
 
-                    for (Rule.Condition.ConditionBranch conditionBranch: rule.conditionBranches()) {
+                    for (Rule.Condition.ConditionBranch conditionBranch: rule.condition().branches()) {
                         ruleSideVariables = iterate(ruleSideIds)
                                 .filter(id -> conditionBranch.pattern().retrieves().contains(id))
                                 .map(id -> conditionBranch.pattern().variable(id)).toSet();

--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -638,13 +638,13 @@ public class AnswerCountEstimator {
                     if ((concludable.isRelation() || concludable.isIsa())
                             && rule.conclusion().generating().isPresent() && ruleSideIds.contains(rule.conclusion().generating().get().id())) {
                         // There is one generated variable per combination of ALL variables in the conclusion
-                        ruleSideIds = new HashSet<>(rule.conclusion().pattern().retrieves());
+                        ruleSideIds = new HashSet<>(rule.conclusion().conjunction().pattern().retrieves());
                     }
 
                     for (Rule.Condition.ConditionBranch conditionBranch: rule.condition().branches()) {
                         ruleSideVariables = iterate(ruleSideIds)
-                                .filter(id -> conditionBranch.pattern().retrieves().contains(id))
-                                .map(id -> conditionBranch.pattern().variable(id)).toSet();
+                                .filter(id -> conditionBranch.conjunction().pattern().retrieves().contains(id))
+                                .map(id -> conditionBranch.conjunction().pattern().variable(id)).toSet();
                         inferredEstimate += answerCountEstimator.estimateAnswers(conditionBranch.conjunction(), ruleSideVariables);
                     }
                 }

--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -641,10 +641,12 @@ public class AnswerCountEstimator {
                         ruleSideIds = new HashSet<>(rule.conclusion().pattern().retrieves());
                     }
 
-                    ruleSideVariables = iterate(ruleSideIds)
-                            .filter(id -> rule.condition().conjunction().pattern().retrieves().contains(id))
-                            .map(id -> rule.condition().conjunction().pattern().variable(id)).toSet();
-                    inferredEstimate += answerCountEstimator.estimateAnswers(rule.condition().conjunction(), ruleSideVariables);
+                    for (Rule.Condition.ConditionBranch conditionBranch: rule.conditionBranches()) {
+                        ruleSideVariables = iterate(ruleSideIds)
+                                .filter(id -> conditionBranch.pattern().retrieves().contains(id))
+                                .map(id -> conditionBranch.pattern().variable(id)).toSet();
+                        inferredEstimate += answerCountEstimator.estimateAnswers(conditionBranch.conjunction(), ruleSideVariables);
+                    }
                 }
             }
 

--- a/reasoner/planner/ConjunctionGraph.java
+++ b/reasoner/planner/ConjunctionGraph.java
@@ -19,6 +19,7 @@ package com.vaticle.typedb.core.reasoner.planner;
 
 import com.vaticle.typedb.common.collection.Pair;
 import com.vaticle.typedb.core.logic.LogicManager;
+import com.vaticle.typedb.core.logic.Rule;
 import com.vaticle.typedb.core.logic.resolvable.Concludable;
 import com.vaticle.typedb.core.logic.resolvable.Negated;
 import com.vaticle.typedb.core.logic.resolvable.Resolvable;
@@ -45,7 +46,10 @@ public class ConjunctionGraph {
     }
 
     public Set<ResolvableConjunction> dependencies(Concludable concludable) {
-        return iterate(logicMgr.applicableRules(concludable).keySet()).map(rule -> rule.condition().conjunction()).toSet();
+        return iterate(logicMgr.applicableRules(concludable).keySet())
+                .flatMap(rule -> iterate(rule.conditionBranches()))
+                .map(Rule.Condition.ConditionBranch::conjunction)
+                .toSet();
     }
 
     public ConjunctionNode conjunctionNode(ResolvableConjunction conjunction) {

--- a/reasoner/planner/ConjunctionGraph.java
+++ b/reasoner/planner/ConjunctionGraph.java
@@ -47,7 +47,7 @@ public class ConjunctionGraph {
 
     public Set<ResolvableConjunction> dependencies(Concludable concludable) {
         return iterate(logicMgr.applicableRules(concludable).keySet())
-                .flatMap(rule -> iterate(rule.conditionBranches()))
+                .flatMap(rule -> iterate(rule.condition().branches()))
                 .map(Rule.Condition.ConditionBranch::conjunction)
                 .toSet();
     }

--- a/reasoner/planner/ReasonerPlanner.java
+++ b/reasoner/planner/ReasonerPlanner.java
@@ -28,7 +28,6 @@ import com.vaticle.typedb.core.logic.resolvable.Unifier;
 import com.vaticle.typedb.core.pattern.variable.ThingVariable;
 import com.vaticle.typedb.core.pattern.variable.Variable;
 import com.vaticle.typedb.core.traversal.TraversalEngine;
-import com.vaticle.typedb.core.traversal.common.Identifier;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
@@ -135,17 +134,19 @@ public abstract class ReasonerPlanner {
     public Set<CallMode> triggeredCalls(Concludable concludable, Set<Variable> mode, @Nullable Set<ResolvableConjunction> dependencyFilter) {
         Set<CallMode> calls = new HashSet<>();
         for (Map.Entry<Rule, Set<Unifier>> entry : logicMgr.applicableRules(concludable).entrySet()) {
-            ResolvableConjunction ruleConjunction = entry.getKey().condition().conjunction();
-            if (dependencyFilter != null && !dependencyFilter.contains(ruleConjunction)) {
-                continue;
-            }
-            for (Unifier unifier : entry.getValue()) {
-                assert iterate(mode).allMatch(v -> v.id().isRetrievable());
-                Set<Variable> ruleMode = iterate(mode)
-                        .flatMap(v -> iterate(unifier.mapping().get(v.id().asRetrievable())))
-                        .filter(id -> ruleConjunction.pattern().retrieves().contains(id))
-                        .map(id -> ruleConjunction.pattern().variable(id)).toSet();
-                calls.add(new CallMode(ruleConjunction, ruleMode));
+            for (Rule.Condition.ConditionBranch conditionBranch : entry.getKey().conditionBranches()) {
+                ResolvableConjunction ruleConjunction = conditionBranch.conjunction();
+                if (dependencyFilter != null && !dependencyFilter.contains(ruleConjunction)) {
+                    continue;
+                }
+                for (Unifier unifier : entry.getValue()) {
+                    assert iterate(mode).allMatch(v -> v.id().isRetrievable());
+                    Set<Variable> ruleMode = iterate(mode)
+                            .flatMap(v -> iterate(unifier.mapping().get(v.id().asRetrievable())))
+                            .filter(id -> ruleConjunction.pattern().retrieves().contains(id))
+                            .map(id -> ruleConjunction.pattern().variable(id)).toSet();
+                    calls.add(new CallMode(ruleConjunction, ruleMode));
+                }
             }
         }
         return calls;

--- a/reasoner/planner/ReasonerPlanner.java
+++ b/reasoner/planner/ReasonerPlanner.java
@@ -134,7 +134,7 @@ public abstract class ReasonerPlanner {
     public Set<CallMode> triggeredCalls(Concludable concludable, Set<Variable> mode, @Nullable Set<ResolvableConjunction> dependencyFilter) {
         Set<CallMode> calls = new HashSet<>();
         for (Map.Entry<Rule, Set<Unifier>> entry : logicMgr.applicableRules(concludable).entrySet()) {
-            for (Rule.Condition.ConditionBranch conditionBranch : entry.getKey().conditionBranches()) {
+            for (Rule.Condition.ConditionBranch conditionBranch : entry.getKey().condition().branches()) {
                 ResolvableConjunction ruleConjunction = conditionBranch.conjunction();
                 if (dependencyFilter != null && !dependencyFilter.contains(ruleConjunction)) {
                     continue;

--- a/reasoner/processor/AbstractProcessor.java
+++ b/reasoner/processor/AbstractProcessor.java
@@ -44,7 +44,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILL
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.RESOURCE_CLOSED;
 
 public abstract class AbstractProcessor<
-        INPUT, OUTPUT, REQ extends AbstractRequest<?, ?, INPUT, ?>,
+        INPUT, OUTPUT, REQ extends AbstractRequest<?, ?, INPUT>,
         PROCESSOR extends AbstractProcessor<INPUT, OUTPUT, REQ, PROCESSOR>> extends Actor<PROCESSOR> {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractProcessor.class);
@@ -107,7 +107,7 @@ public abstract class AbstractProcessor<
         controller.execute(actor -> actor.routeConnectionRequest(req));
     }
 
-    public <RECEIVED_REQ extends AbstractRequest<?, ?, OUTPUT, ?>> void establishConnection(RECEIVED_REQ request) {
+    public <RECEIVED_REQ extends AbstractRequest<?, ?, OUTPUT>> void establishConnection(RECEIVED_REQ request) {
         if (isTerminated()) return;
         OutputPort<OUTPUT> outputPort = createOutputPort();
         outputPort.setInputPort(request.inputPortId(), request.requestingProcessor());

--- a/reasoner/processor/AbstractRequest.java
+++ b/reasoner/processor/AbstractRequest.java
@@ -19,7 +19,6 @@
 package com.vaticle.typedb.core.reasoner.processor;
 
 import com.vaticle.typedb.core.concurrent.actor.Actor;
-import com.vaticle.typedb.core.reasoner.controller.AbstractController;
 import com.vaticle.typedb.core.reasoner.processor.reactive.Reactive;
 import com.vaticle.typedb.core.reasoner.processor.reactive.Reactive.Stream;
 
@@ -28,8 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
-public abstract class AbstractRequest<CONTROLLER_ID, BOUNDS, PACKET,
-        CONTROLLER extends AbstractController<BOUNDS, ?, PACKET, ?, ?, ?>> {
+public abstract class AbstractRequest<CONTROLLER_ID, BOUNDS, PACKET> {
 
     private final Reactive.Identifier inputPortId;
     private final Actor.Driver<? extends AbstractProcessor<PACKET, ?, ?, ?>> inputPortProcessor;
@@ -77,12 +75,12 @@ public abstract class AbstractRequest<CONTROLLER_ID, BOUNDS, PACKET,
         op.registerSubscriber(output);
     }
 
-    public AbstractRequest<CONTROLLER_ID, BOUNDS, PACKET, CONTROLLER> withMap(Function<PACKET, PACKET> function) {
+    public AbstractRequest<CONTROLLER_ID, BOUNDS, PACKET> withMap(Function<PACKET, PACKET> function) {
         transforms.add(function);
         return this;
     }
 
-    public AbstractRequest<CONTROLLER_ID, BOUNDS, PACKET, CONTROLLER> withNewBounds(BOUNDS newBounds) {
+    public AbstractRequest<CONTROLLER_ID, BOUNDS, PACKET> withNewBounds(BOUNDS newBounds) {
         bounds = newBounds;
         return this;
     }

--- a/test/behaviour/reasoner/verification/BoundPattern.java
+++ b/test/behaviour/reasoner/verification/BoundPattern.java
@@ -253,7 +253,7 @@ public class BoundPattern {
         }
 
         static BoundCondition create(Rule.Condition.ConditionBranch conditionBranch, ConceptMap conditionAnswer) {
-            return new BoundCondition(BoundConjunction.create(conditionBranch.pattern(), conditionAnswer), conditionBranch);
+            return new BoundCondition(BoundConjunction.create(conditionBranch.conjunction().pattern(), conditionAnswer), conditionBranch);
         }
 
         BoundConjunction conjunction() {

--- a/test/behaviour/reasoner/verification/BoundPattern.java
+++ b/test/behaviour/reasoner/verification/BoundPattern.java
@@ -245,15 +245,15 @@ public class BoundPattern {
 
     static class BoundCondition {
         private final BoundConjunction conjunction;
-        private final Rule.Condition unboundCondition;
+        private final Rule.Condition.ConditionBranch unboundConditionBranch;
 
-        private BoundCondition(BoundConjunction conjunction, Rule.Condition unboundCondition) {
+        private BoundCondition(BoundConjunction conjunction, Rule.Condition.ConditionBranch unboundConditionBranch) {
             this.conjunction = conjunction;
-            this.unboundCondition = unboundCondition;
+            this.unboundConditionBranch = unboundConditionBranch;
         }
 
-        static BoundCondition create(Rule.Condition condition, ConceptMap conditionAnswer) {
-            return new BoundCondition(BoundConjunction.create(condition.pattern(), conditionAnswer), condition);
+        static BoundCondition create(Rule.Condition.ConditionBranch conditionBranch, ConceptMap conditionAnswer) {
+            return new BoundCondition(BoundConjunction.create(conditionBranch.pattern(), conditionAnswer), conditionBranch);
         }
 
         BoundConjunction conjunction() {
@@ -266,12 +266,12 @@ public class BoundPattern {
             if (o == null || getClass() != o.getClass()) return false;
             BoundCondition that = (BoundCondition) o;
             return conjunction.equals(that.conjunction) &&
-                    unboundCondition.equals(that.unboundCondition);
+                    unboundConditionBranch.equals(that.unboundConditionBranch);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(conjunction, unboundCondition);
+            return Objects.hash(conjunction, unboundConditionBranch);
         }
     }
 }

--- a/test/behaviour/reasoner/verification/ForwardChainingMaterialiser.java
+++ b/test/behaviour/reasoner/verification/ForwardChainingMaterialiser.java
@@ -209,7 +209,7 @@ public class ForwardChainingMaterialiser {
             // Get all the places where the rule condition is satisfied and materialise for each
             requiresReiteration = false;
             iterate(rule.condition().branches()).forEachRemaining(condition -> {
-                traverse(condition.pattern()).forEachRemaining(conditionAns -> materialiseAndBind(
+                traverse(condition.conjunction().pattern()).forEachRemaining(conditionAns -> materialiseAndBind(
                         rule.conclusion(), conditionAns, tx.traversal(), tx.concepts()
                 ).ifPresent(materialisation -> record(condition, conditionAns, materialisation)));
             });

--- a/test/behaviour/reasoner/verification/ForwardChainingMaterialiser.java
+++ b/test/behaviour/reasoner/verification/ForwardChainingMaterialiser.java
@@ -319,7 +319,7 @@ public class ForwardChainingMaterialiser {
         static Materialisation create(com.vaticle.typedb.core.logic.Rule.Condition.ConditionBranch ruleConditionBranch, ConceptMap conditionAnswer,
                                       Map<Variable, Concept> conclusionAnswer) {
             return new Materialisation(ruleConditionBranch, BoundCondition.create(ruleConditionBranch, conditionAnswer),
-                    BoundConclusion.create(ruleConditionBranch.conclusion(), conclusionAnswer));
+                    BoundConclusion.create(ruleConditionBranch.rule().conclusion(), conclusionAnswer));
         }
 
         BoundCondition boundCondition() {

--- a/test/behaviour/reasoner/verification/ForwardChainingMaterialiser.java
+++ b/test/behaviour/reasoner/verification/ForwardChainingMaterialiser.java
@@ -181,11 +181,11 @@ public class ForwardChainingMaterialiser {
         }
 
         private Set<Rule> negatedDependencies() {
-            assert iterate(rule.conditionBranches()).flatMap(condition -> iterate(condition.conjunction().negations()))
+            assert iterate(rule.condition().branches()).flatMap(condition -> iterate(condition.conjunction().negations()))
                     .flatMap(negated -> iterate(negated.disjunction().conjunctions()))
                     .allMatch(conj -> conj.negations().isEmpty()); // Revise when we support nested negations in rules
             if (negatedDependencies == null) {
-                negatedDependencies = iterate(rule.conditionBranches()).flatMap(condition -> iterate(condition.conjunction().negations()))
+                negatedDependencies = iterate(rule.condition().branches()).flatMap(condition -> iterate(condition.conjunction().negations()))
                     .flatMap(negation -> iterate(negation.disjunction().conjunctions()))
                     .flatMap(conj -> conj.allConcludables())
                     .flatMap(concludable -> iterate(tx.logic().applicableRules(concludable).keySet()))
@@ -197,7 +197,7 @@ public class ForwardChainingMaterialiser {
 
         private Set<Rule> unnegatedDependencies() {
             if (unnegatedDependencies == null) {
-                unnegatedDependencies = iterate(rule.conditionBranches()).flatMap(condition -> iterate(condition.conjunction().positiveConcludables()))
+                unnegatedDependencies = iterate(rule.condition().branches()).flatMap(condition -> iterate(condition.conjunction().positiveConcludables()))
                         .flatMap(concludable -> iterate(tx.logic().applicableRules(concludable).keySet()))
                         .map(r -> rules.get(r))
                         .toSet();
@@ -208,7 +208,7 @@ public class ForwardChainingMaterialiser {
         private boolean materialise() {
             // Get all the places where the rule condition is satisfied and materialise for each
             requiresReiteration = false;
-            iterate(rule.conditionBranches()).forEachRemaining(condition -> {
+            iterate(rule.condition().branches()).forEachRemaining(condition -> {
                 traverse(condition.pattern()).forEachRemaining(conditionAns -> materialiseAndBind(
                         rule.conclusion(), conditionAns, tx.traversal(), tx.concepts()
                 ).ifPresent(materialisation -> record(condition, conditionAns, materialisation)));

--- a/test/behaviour/reasoner/verification/SoundnessVerifier.java
+++ b/test/behaviour/reasoner/verification/SoundnessVerifier.java
@@ -107,7 +107,7 @@ class SoundnessVerifier {
 
     private boolean canExplanationBeVerified(Explanation explanation) {
         return iterate(explanation.conditionAnswer().concepts().values())
-                .filter(c -> c.asThing().isInferred() && !inferredConceptMapping.containsKey(c))
+                .filter(c -> c.isThing() && c.asThing().isInferred() && !inferredConceptMapping.containsKey(c))
                 .first().isEmpty();
     }
 
@@ -238,7 +238,7 @@ class SoundnessVerifier {
                 if (inferredConceptMapping.containsKey(concept)) {
                     substituted.put(var, inferredConceptMapping.get(concept));
                 } else {
-                    assert !concept.asThing().isInferred();
+                    assert !(concept.isThing() && concept.asThing().isInferred());
                     substituted.put(var, concept);
                 }
             } else {

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -1156,8 +1156,8 @@ public class UnifyRelationConcludableTest {
         for (int parentIndex = 0; parentIndex < parents.size(); parentIndex++) {
             String parent = parents.get(parentIndex);
             assertEquals(
-                    String.format("Unexpected unification outcome at index [%s]:\nconjunction: %s\nconclusion: %s\nconditions: %s\n",
-                                  parentIndex, parent, rule.conclusion(), rule.condition()),
+                    String.format("Unexpected unification outcome at index [%s]:\nconjunction: %s\nconclusion: %s\ncondition: %s\n",
+                                  parentIndex, parent, rule.conclusion(), rule.condition().pattern()),
                     unifiableParents.contains(parentIndex), unifiers(parent, rule).hasNext()
             );
         }

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -1157,7 +1157,7 @@ public class UnifyRelationConcludableTest {
             String parent = parents.get(parentIndex);
             assertEquals(
                     String.format("Unexpected unification outcome at index [%s]:\nconjunction: %s\nconclusion: %s\ncondition: %s\n",
-                                  parentIndex, parent, rule.conclusion(), rule.condition().pattern()),
+                                  parentIndex, parent, rule.conclusion(), rule.condition().disjunction().pattern()),
                     unifiableParents.contains(parentIndex), unifiers(parent, rule).hasNext()
             );
         }

--- a/test/integration/reasoner/planner/ReasonerPlannerTest.java
+++ b/test/integration/reasoner/planner/ReasonerPlannerTest.java
@@ -24,6 +24,7 @@ import com.vaticle.typedb.core.database.CoreDatabaseManager;
 import com.vaticle.typedb.core.database.CoreSession;
 import com.vaticle.typedb.core.database.CoreTransaction;
 import com.vaticle.typedb.core.logic.LogicManager;
+import com.vaticle.typedb.core.logic.Rule;
 import com.vaticle.typedb.core.logic.resolvable.Resolvable;
 import com.vaticle.typedb.core.logic.resolvable.ResolvableConjunction;
 import com.vaticle.typedb.core.pattern.Conjunction;
@@ -113,7 +114,9 @@ public class ReasonerPlannerTest {
     }
 
     private void verifyPlan(ReasonerPlanner planner, String ruleLabel, Set<String> inputBounds, List<String> order) {
-        ResolvableConjunction condition = transaction.logic().rules().filter(rule -> rule.getLabel().equals(ruleLabel)).next().condition().conjunction();
+        Rule rule = transaction.logic().rules().filter(rule1 -> rule1.getLabel().equals(ruleLabel)).next();
+        assert rule.conditionBranches().size() == 1;
+        ResolvableConjunction condition = iterate(rule.conditionBranches()).next().conjunction();
         verifyPlan(planner, condition, inputBounds, order);
     }
 

--- a/test/integration/reasoner/planner/ReasonerPlannerTest.java
+++ b/test/integration/reasoner/planner/ReasonerPlannerTest.java
@@ -115,8 +115,8 @@ public class ReasonerPlannerTest {
 
     private void verifyPlan(ReasonerPlanner planner, String ruleLabel, Set<String> inputBounds, List<String> order) {
         Rule rule = transaction.logic().rules().filter(rule1 -> rule1.getLabel().equals(ruleLabel)).next();
-        assert rule.conditionBranches().size() == 1;
-        ResolvableConjunction condition = iterate(rule.conditionBranches()).next().conjunction();
+        assert rule.condition().branches().size() == 1;
+        ResolvableConjunction condition = iterate(rule.condition().branches()).next().conjunction();
         verifyPlan(planner, condition, inputBounds, order);
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
Add support for disjunctions in the rule conditions.

## What are the changes implemented in this PR?
* Re-defines a `Condition` to be a set of `ConditionBranch`es - Each of which is a conjunction obtained from normalising the disjunctions in the condition. 
* Updates rule validation to account for disjunctions
* Updates the reasoner to support disjunctions in Conditions
  - ConditionController (and related classes) now extends DisjunctionController instead of ConjunctionController.
  - The output type of a DisjunctionProcessor is made a generic (from ConceptMap) to support Either<> as expected by ConclusionController
 - Reasoner planner treats each branch as an all new conjunction. 