### PR TITLE
Improve write performance by removing persisted statistics version

### DIFF
--- a/database/CoreDatabase.java
+++ b/database/CoreDatabase.java
@@ -829,7 +829,7 @@ public class CoreDatabase implements TypeDB.Database {
         private final LogicCache logicCache;
         private final TypeGraph typeGraph;
         private final RocksStorage schemaStorage;
-        private final AtomicLong DBStatisticsVersion;
+        private final AtomicLong statisticsVersion;
         private long borrowerCount;
         private boolean invalidated;
 
@@ -840,7 +840,7 @@ public class CoreDatabase implements TypeDB.Database {
             logicCache = new LogicCache();
             borrowerCount = 0L;
             invalidated = false;
-            DBStatisticsVersion = new AtomicLong(0);
+            statisticsVersion = new AtomicLong(0);
         }
 
         public TraversalCache traversal() {
@@ -875,12 +875,12 @@ public class CoreDatabase implements TypeDB.Database {
             }
         }
 
-        AtomicLong getDBStatisticsVersion() {
-            return DBStatisticsVersion;
+        AtomicLong statisticsVersion() {
+            return statisticsVersion;
         }
 
         void incrementStatisticsVersion() {
-            DBStatisticsVersion.incrementAndGet();
+            statisticsVersion.incrementAndGet();
         }
 
         private void close() {

--- a/database/CoreTransaction.java
+++ b/database/CoreTransaction.java
@@ -281,7 +281,7 @@ public abstract class CoreTransaction implements TypeDB.Transaction {
 
             this.cache = session.database().cacheBorrow();
             this.dataStorage = storageFactory.storageData(session.database(), this);
-            ThingGraph.Statistics statistics = new ThingGraph.Statistics(cache.typeGraph(), dataStorage, cache.getDBStatisticsVersion());
+            ThingGraph.Statistics statistics = new ThingGraph.Statistics(cache.typeGraph(), dataStorage, cache.statisticsVersion());
             ThingGraph thingGraph = new ThingGraph(dataStorage, cache.typeGraph(), statistics);
             this.graphMgr = new GraphManager(cache.typeGraph(), thingGraph);
 

--- a/database/CoreTransaction.java
+++ b/database/CoreTransaction.java
@@ -41,6 +41,7 @@ import org.rocksdb.RocksDBException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.vaticle.typedb.common.util.Objects.className;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
@@ -170,7 +171,8 @@ public abstract class CoreTransaction implements TypeDB.Transaction {
             TypeGraph typeGraph = new TypeGraph(schemaStorage, type().isRead());
 
             dataStorage = storageFactory.storageData(session.database(), this);
-            ThingGraph thingGraph = new ThingGraph(dataStorage, typeGraph);
+            ThingGraph.Statistics statistics = new ThingGraph.Statistics(typeGraph, dataStorage, new AtomicLong(0));
+            ThingGraph thingGraph = new ThingGraph(dataStorage, typeGraph, statistics);
 
             graphMgr = new GraphManager(typeGraph, thingGraph);
             initialise(graphMgr, new TraversalCache(), new LogicCache());
@@ -279,7 +281,8 @@ public abstract class CoreTransaction implements TypeDB.Transaction {
 
             this.cache = session.database().cacheBorrow();
             this.dataStorage = storageFactory.storageData(session.database(), this);
-            ThingGraph thingGraph = new ThingGraph(dataStorage, cache.typeGraph());
+            ThingGraph.Statistics statistics = new ThingGraph.Statistics(cache.typeGraph(), dataStorage, cache.getDBStatisticsVersion());
+            ThingGraph thingGraph = new ThingGraph(dataStorage, cache.typeGraph(), statistics);
             this.graphMgr = new GraphManager(cache.typeGraph(), thingGraph);
 
             if (type().isWrite()) session.database().isolationMgr().opened(this);
@@ -328,6 +331,7 @@ public abstract class CoreTransaction implements TypeDB.Transaction {
                     dataStorage.commit();
                     session.database().isolationMgr().committed(this);
                     session.database().statisticsCorrector().committed(this);
+                    if (graphMgr.data().stats().statisticsPersisted()) cache.incrementStatisticsVersion();
                 } catch (TypeDBException e) {
                     delete();
                     throw e;

--- a/encoding/key/StatisticsKey.java
+++ b/encoding/key/StatisticsKey.java
@@ -63,10 +63,6 @@ public class StatisticsKey implements Key {
         ));
     }
 
-    public static StatisticsKey snapshot() {
-        return new StatisticsKey(Statistics.Prefix.SNAPSHOT.bytes());
-    }
-
     public static StatisticsKey txnCommitted(long txnID) {
         return new StatisticsKey(join(
                 Statistics.Prefix.TXN_COMMITTED_ID.bytes(),

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -338,9 +338,10 @@ public class GraphPlanner implements ComponentPlanner {
     }
 
     private void updateTraversalCosts(GraphManager graphMgr) {
-        if (snapshot < graphMgr.data().stats().snapshot()) {
-            // TODO: we should not include the graph's uncommitted writes, but only the persisted counts in the costs
-            snapshot = graphMgr.data().stats().snapshot();
+        long statisticsVersion = graphMgr.data().stats().getDBStatisticsVersion();
+        if (snapshot < statisticsVersion) {
+            // update this shared planner based on the databases latest committed statistics version
+            snapshot = statisticsVersion;
             computeTotalCost(graphMgr);
 
             if (!isUpToDate) {


### PR DESCRIPTION
## What is the goal of this PR?

We fix a performance bottlenecks during bulk-writes: the continuous persistence and reading of the statistics version number. We completely remove the on-disk statistics version, and only maintain an in-memory statistics version number. This improves pure write throughput by up to 2x.

## What are the changes implemented in this PR?

#### Problem

Each write transaction uses RocksDB `merge` to increment the statistics snapshot number. However, each transaction also reads the snapshot version number (note that each transaction is snapshotted, so will see its own statistics snapshot number). 

However, over 70% of a transaction time was spent reading the version number on transaction open when a huge number of writes are happening to the DB (normally when doing straight writes without reads). We suspect this is because RocksDB has to deal with both snapshotting & flatten all atomic increment-and-set on a key-value pair in the LSM tree each time the statistics snapshot read occurs.

#### Solution

We realise that the statistics verison number of is used for updating query plans when the statistics have changed. However, the query plans are shared across all transactions, and not bound to a particular transaction or data snapshot. So, it makes sense to replan whenever the database statistics version has changed -- we don't need to keep the snapshot version bound to a transaction, but the database.

Additionally, query plans are discarded on shutdown - so the statistics snapshot number does not have to be persisted. 

Instead, we no keep an in-memory `AtomicLong` that represents the statistics version of the database. A write transaction that commits any statistics to disk will induce an increment the in-memory `statisticsVersion`. Query planning in turn reads the database statistics version instead of a transaction statistics version.
