### PR TITLE
Type inference differentiates illegal and queries with no answer

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -279,14 +279,12 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Pattern(14, "Tye type variable '%s' has multiple 'value' constraints.");
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_REGEX =
                 new Pattern(15, "The type variable '%s' has multiple 'regex' constraints.");
-        public static final Pattern UNSATISFIABLE_PATTERN =
+        public static final Pattern INCOHERENT_PATTERN =
                 new Pattern(16, "The pattern '%s' is illegal in the current schema.");
-        public static final Pattern UNSATISFIABLE_SUB_PATTERN =
+        public static final Pattern INCOHERENT_SUB_PATTERN =
                 new Pattern(17, "The pattern '%s' is illegal in the current schema, due to '%s'.");
-        public static final Pattern UNSATISFIABLE_PATTERN_VARIABLE =
-                new Pattern(18, "The pattern '%s' is illegal in the current schema, due to contradicting types for '%s'.");
-        public static final Pattern UNSATISFIABLE_PATTERN_VARIABLE_VALUE =
-                new Pattern(19, "The pattern '%s' is illegal in the current schema, due to contradicting attribute value types for '%s'.");
+        public static final Pattern INCOHERENT_PATTERN_VARIABLE_VALUE =
+                new Pattern(18, "The pattern '%s' is illegal in the current schema, due to contradicting attribute value types for '%s'.");
 
         private static final String codePrefix = "QRY";
         private static final String messagePrefix = "Invalid Query Pattern";
@@ -575,13 +573,13 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new RuleWrite(3, "The rule '%s' contains a negation containing a disjunction, which is currently unsupported");
         public static final RuleWrite RULE_CONCLUSION_ILLEGAL_INSERT =
                 new RuleWrite(4, "The conclusion of rule '%s' may insert types '%s', which is not allowed in the current schema.");
-        public static final RuleWrite RULE_WHEN_CANNOT_BE_SATISFIED =
+        public static final RuleWrite RULE_WHEN_INCOHERENT =
                 new RuleWrite(5, "The rule '%s' has a when clause '%s' that is illegal in the current schema.");
-        public static final RuleWrite RULE_WHEN_CANNOT_HAVE_ANSWERS =
+        public static final RuleWrite RULE_WHEN_UNANSWERABLE =
                 new RuleWrite(6, "The rule '%s' has a when clause '%s' that can never have answers in the current schema.");
-        public static final RuleWrite RULE_THEN_CANNOT_BE_SATISFIED =
+        public static final RuleWrite RULE_THEN_INCOHERENT =
                 new RuleWrite(7, "The rule '%s' has a then clause '%s' that can never be satisfied in the current schema.");
-        public static final RuleWrite RULE_THEN_CANNOT_HAVE_ANSWERS =
+        public static final RuleWrite RULE_THEN_UNANSWERABLE =
                 new RuleWrite(8, "The rule '%s' has a then clause '%s' that can never have answers in the current schema.");
         public static final RuleWrite RULE_THEN_INVALID_VALUE_ASSIGNMENT =
                 new RuleWrite(9, "The rule '%s' has a then clause with an invalid assignment of '%s' into a '%s'.");

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -280,13 +280,13 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_REGEX =
                 new Pattern(15, "The type variable '%s' has multiple 'regex' constraints.");
         public static final Pattern UNSATISFIABLE_PATTERN =
-                new Pattern(16, "The pattern '%s' can never be satisfied in the current schema.");
+                new Pattern(16, "The pattern '%s' is illegal in the current schema.");
         public static final Pattern UNSATISFIABLE_SUB_PATTERN =
-                new Pattern(17, "The pattern '%s' can never be satisfied in the current schema, due to '%s'.");
+                new Pattern(17, "The pattern '%s' is illegal in the current schema, due to '%s'.");
         public static final Pattern UNSATISFIABLE_PATTERN_VARIABLE =
-                new Pattern(18, "The pattern '%s' can never be satisfied in the current schema, due to contradicting types for '%s'.");
+                new Pattern(18, "The pattern '%s' is illegal in the current schema, due to contradicting types for '%s'.");
         public static final Pattern UNSATISFIABLE_PATTERN_VARIABLE_VALUE =
-                new Pattern(19, "The pattern '%s' can never be satisfied in the current schema, due to contradicting attribute value types for '%s'.");
+                new Pattern(19, "The pattern '%s' is illegal in the current schema, due to contradicting attribute value types for '%s'.");
 
         private static final String codePrefix = "QRY";
         private static final String messagePrefix = "Invalid Query Pattern";
@@ -576,13 +576,17 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final RuleWrite RULE_CONCLUSION_ILLEGAL_INSERT =
                 new RuleWrite(4, "The conclusion of rule '%s' may insert types '%s', which is not allowed in the current schema.");
         public static final RuleWrite RULE_WHEN_CANNOT_BE_SATISFIED =
-                new RuleWrite(5, "The rule '%s' has a when clause '%s' that can never be satisfied in the current schema.");
+                new RuleWrite(5, "The rule '%s' has a when clause '%s' that is illegal in the current schema.");
+        public static final RuleWrite RULE_WHEN_CANNOT_HAVE_ANSWERS =
+                new RuleWrite(6, "The rule '%s' has a when clause '%s' that can never have answers in the current schema.");
         public static final RuleWrite RULE_THEN_CANNOT_BE_SATISFIED =
-                new RuleWrite(6, "The rule '%s' has a then clause '%s' that can never be satisfied in the current schema.");
+                new RuleWrite(7, "The rule '%s' has a then clause '%s' that can never be satisfied in the current schema.");
+        public static final RuleWrite RULE_THEN_CANNOT_HAVE_ANSWERS =
+                new RuleWrite(8, "The rule '%s' has a then clause '%s' that can never have answers in the current schema.");
         public static final RuleWrite RULE_THEN_INVALID_VALUE_ASSIGNMENT =
-                new RuleWrite(7, "The rule '%s' has a then clause with an invalid assignment of '%s' into a '%s'.");
+                new RuleWrite(9, "The rule '%s' has a then clause with an invalid assignment of '%s' into a '%s'.");
         public static final RuleWrite MAX_RULE_REACHED =
-                new RuleWrite(8, "The maximum number of rules has been reached: '%s'");
+                new RuleWrite(10, "The maximum number of rules has been reached: '%s'");
 
         private static final String codePrefix = "RUW";
         private static final String messagePrefix = "Invalid Rule Write";

--- a/logic/LogicCache.java
+++ b/logic/LogicCache.java
@@ -31,23 +31,30 @@ import java.util.Set;
 
 public class LogicCache {
 
-    private final CommonCache<GraphTraversal.Type, Optional<Map<Identifier.Variable.Retrievable, Set<Label>>>> typeInferenceCache;
     private final CommonCache<String, Rule> ruleCache;
     private final CommonCache<Concludable, Map<Rule, Set<Unifier>>> unifiers;
+    private final CommonCache<GraphTraversal.Type, Optional<Map<Identifier.Variable.Retrievable, Set<Label>>>> typeInferenceCache;
+    private final CommonCache<GraphTraversal.Type, Boolean> queryCoherenceCache;
 
     public LogicCache() {
         this.ruleCache = new CommonCache<>();
-        this.typeInferenceCache = new CommonCache<>();
         this.unifiers = new CommonCache<>();
+        this.typeInferenceCache = new CommonCache<>();
+        this.queryCoherenceCache = new CommonCache<>();
     }
 
     public LogicCache(int size, int timeOutMinutes) {
         this.ruleCache = new CommonCache<>(size, timeOutMinutes);
-        this.typeInferenceCache = new CommonCache<>(size, timeOutMinutes);
         this.unifiers = new CommonCache<>(size, timeOutMinutes);
+        this.typeInferenceCache = new CommonCache<>(size, timeOutMinutes);
+        this.queryCoherenceCache = new CommonCache<>();
     }
 
-    public CommonCache<GraphTraversal.Type, Optional<Map<Identifier.Variable.Retrievable, Set<Label>>>> inference() {
+    public CommonCache<GraphTraversal.Type, Boolean> queryCoherence() {
+        return queryCoherenceCache;
+    }
+
+    public CommonCache<GraphTraversal.Type, Optional<Map<Identifier.Variable.Retrievable, Set<Label>>>> typeInference() {
         return typeInferenceCache;
     }
 

--- a/logic/LogicCache.java
+++ b/logic/LogicCache.java
@@ -47,15 +47,15 @@ public class LogicCache {
         this.ruleCache = new CommonCache<>(size, timeOutMinutes);
         this.unifiers = new CommonCache<>(size, timeOutMinutes);
         this.typeInferenceCache = new CommonCache<>(size, timeOutMinutes);
-        this.queryCoherenceCache = new CommonCache<>();
-    }
-
-    public CommonCache<GraphTraversal.Type, Boolean> queryCoherence() {
-        return queryCoherenceCache;
+        this.queryCoherenceCache = new CommonCache<>(size, timeOutMinutes);
     }
 
     public CommonCache<GraphTraversal.Type, Optional<Map<Identifier.Variable.Retrievable, Set<Label>>>> typeInference() {
         return typeInferenceCache;
+    }
+
+    public CommonCache<GraphTraversal.Type, Boolean> queryCoherence() {
+        return queryCoherenceCache;
     }
 
     CommonCache<String, Rule> rule() {

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -65,7 +65,9 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.INVA
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.INVALID_NEGATION_CONTAINS_DISJUNCTION;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_CONCLUSION_ILLEGAL_INSERT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_CANNOT_BE_SATISFIED;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_CANNOT_HAVE_ANSWERS;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_INVALID_VALUE_ASSIGNMENT;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_WHEN_CANNOT_HAVE_ANSWERS;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_WHEN_CANNOT_BE_SATISFIED;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COLON;
@@ -172,7 +174,9 @@ public class Rule {
 
     private void validateSatisfiable() {
         if (!when.isCoherent()) throw TypeDBException.of(RULE_WHEN_CANNOT_BE_SATISFIED, structure.label(), when);
+        if (!when.isAnswerable()) throw TypeDBException.of(RULE_WHEN_CANNOT_HAVE_ANSWERS, structure.label(), when);
         if (!then.isCoherent()) throw TypeDBException.of(RULE_THEN_CANNOT_BE_SATISFIED, structure.label(), then);
+        if (!then.isAnswerable()) throw TypeDBException.of(RULE_THEN_CANNOT_HAVE_ANSWERS, structure.label(), then);
     }
 
     /**

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -64,11 +64,11 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILL
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.INVALID_CASTING;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.INVALID_NEGATION_CONTAINS_DISJUNCTION;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_CONCLUSION_ILLEGAL_INSERT;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_CANNOT_BE_SATISFIED;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_CANNOT_HAVE_ANSWERS;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_INCOHERENT;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_UNANSWERABLE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_INVALID_VALUE_ASSIGNMENT;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_WHEN_CANNOT_HAVE_ANSWERS;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_WHEN_CANNOT_BE_SATISFIED;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_WHEN_UNANSWERABLE;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_WHEN_INCOHERENT;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.COLON;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Char.CURLY_CLOSE;
@@ -173,10 +173,10 @@ public class Rule {
     }
 
     private void validateSatisfiable() {
-        if (!when.isCoherent()) throw TypeDBException.of(RULE_WHEN_CANNOT_BE_SATISFIED, structure.label(), when);
-        if (!when.isAnswerable()) throw TypeDBException.of(RULE_WHEN_CANNOT_HAVE_ANSWERS, structure.label(), when);
-        if (!then.isCoherent()) throw TypeDBException.of(RULE_THEN_CANNOT_BE_SATISFIED, structure.label(), then);
-        if (!then.isAnswerable()) throw TypeDBException.of(RULE_THEN_CANNOT_HAVE_ANSWERS, structure.label(), then);
+        if (!when.isCoherent()) throw TypeDBException.of(RULE_WHEN_INCOHERENT, structure.label(), when);
+        if (!when.isAnswerable()) throw TypeDBException.of(RULE_WHEN_UNANSWERABLE, structure.label(), when);
+        if (!then.isCoherent()) throw TypeDBException.of(RULE_THEN_INCOHERENT, structure.label(), then);
+        if (!then.isAnswerable()) throw TypeDBException.of(RULE_THEN_UNANSWERABLE, structure.label(), then);
     }
 
     /**

--- a/logic/tool/TypeInference.java
+++ b/logic/tool/TypeInference.java
@@ -61,8 +61,8 @@ import java.util.Set;
 
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_PATTERN_VARIABLE_VALUE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_SUB_PATTERN;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.INCOHERENT_PATTERN_VARIABLE_VALUE;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.INCOHERENT_SUB_PATTERN;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.ROLE_TYPE_NOT_FOUND;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.TYPE_NOT_FOUND;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
@@ -363,7 +363,7 @@ public class TypeInference {
             TypeVertex type = graphMgr.schema().convert(VertexIID.Thing.of(constraint.iid()).type());
             if (type == null) {
                 conjunction.setCoherent(false);
-                throw TypeDBException.of(UNSATISFIABLE_SUB_PATTERN, conjunction, constraint);
+                throw TypeDBException.of(INCOHERENT_SUB_PATTERN, conjunction, constraint);
             }
             restrictTypes(resolver.id(), iterate(type).map(TypeVertex::properLabel));
         }
@@ -436,7 +436,7 @@ public class TypeInference {
             }
             if (props.valueTypes().isEmpty()) {
                 conjunction.setCoherent(false);
-                throw TypeDBException.of(UNSATISFIABLE_PATTERN_VARIABLE_VALUE, conjunction, inferenceToOriginal.get(id.asRetrievable()));
+                throw TypeDBException.of(INCOHERENT_PATTERN_VARIABLE_VALUE, conjunction, inferenceToOriginal.get(id.asRetrievable()));
             }
         }
 

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -76,7 +76,7 @@ public class Conjunction implements Pattern, Cloneable {
     private final int hash;
 
     private boolean isCoherent;
-    private boolean isBounded;
+    private boolean isAnswerable;
     private Set<Identifier.Variable.Retrievable> retrieves;
 
     public Conjunction(Set<Variable> variables, List<Negation> negations) {
@@ -85,7 +85,7 @@ public class Conjunction implements Pattern, Cloneable {
         this.negations = unmodifiableList(negations);
         this.hash = Objects.hash(variables, negations);
         this.isCoherent = true;
-        this.isBounded = false;
+        this.isAnswerable = true;
     }
 
     private Map<Identifier.Variable, Variable> parseToMap(Set<Variable> variables) {
@@ -126,7 +126,7 @@ public class Conjunction implements Pattern, Cloneable {
                 else if (var.isType()) {
                     Optional<LabelConstraint> existingLabel = var.asType().label();
                     if (existingLabel.isPresent() && !existingLabel.get().properLabel().equals(boundVar.first())) {
-                        this.setCoherent(false);
+                        this.setAnswerable(false);
                     } else if (!existingLabel.isPresent()) {
                         var.asType().label(boundVar.first());
                         var.asType().setInferredTypes(set(boundVar.first()));
@@ -134,14 +134,13 @@ public class Conjunction implements Pattern, Cloneable {
                 } else if (var.isThing()) {
                     Optional<IIDConstraint> existingIID = var.asThing().iid();
                     if (existingIID.isPresent() && !existingIID.get().iid().equals(boundVar.second())) {
-                        this.setCoherent(false);
+                        this.setAnswerable(false);
                     } else {
                         var.asThing().iid(boundVar.second());
                     }
                 } else throw TypeDBException.of(ILLEGAL_STATE);
             }
         });
-        isBounded = true;
     }
 
     public Variable variable(Identifier.Variable identifier) {
@@ -199,6 +198,14 @@ public class Conjunction implements Pattern, Cloneable {
 
     public boolean isCoherent() {
         return isCoherent && iterate(negations).allMatch(Negation::isCoherent);
+    }
+
+    public void setAnswerable(boolean isAnswerable) {
+        this.isAnswerable = isAnswerable;
+    }
+
+    public boolean isAnswerable() {
+        return isAnswerable;
     }
 
     @Override

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -22,7 +22,6 @@ import com.vaticle.typedb.common.collection.Either;
 import com.vaticle.typedb.core.common.collection.ByteArray;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
-import com.vaticle.typedb.core.common.iterator.Iterators;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator;
 import com.vaticle.typedb.core.common.parameters.Arguments;
 import com.vaticle.typedb.core.common.parameters.Context;
@@ -59,8 +58,8 @@ import java.util.Set;
 
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.collection.Collections.set;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_PATTERN;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_SUB_PATTERN;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.INCOHERENT_PATTERN;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.INCOHERENT_SUB_PATTERN;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingRead.SORT_ATTRIBUTE_NOT_COMPARABLE;
 import static com.vaticle.typedb.core.common.iterator.Iterators.cartesian;
 import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
@@ -134,9 +133,9 @@ public class Reasoner {
         if (!disjunction.isCoherent()) {
             Set<Conjunction> causes = incoherentConjunctions(disjunction);
             if (set(disjunction.conjunctions()).equals(causes)) {
-                throw TypeDBException.of(UNSATISFIABLE_PATTERN, disjunction);
+                throw TypeDBException.of(INCOHERENT_PATTERN, disjunction);
             } else {
-                throw TypeDBException.of(UNSATISFIABLE_SUB_PATTERN, disjunction, causes);
+                throw TypeDBException.of(INCOHERENT_SUB_PATTERN, disjunction, causes);
             }
         }
     }

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -33,6 +33,7 @@ import com.vaticle.typedb.core.concept.answer.ConceptMap;
 import com.vaticle.typedb.core.concept.type.AttributeType;
 import com.vaticle.typedb.core.concept.type.ThingType;
 import com.vaticle.typedb.core.concurrent.producer.Producer;
+import com.vaticle.typedb.core.concurrent.producer.Producers;
 import com.vaticle.typedb.core.logic.LogicManager;
 import com.vaticle.typedb.core.logic.resolvable.Concludable;
 import com.vaticle.typedb.core.pattern.Conjunction;
@@ -62,6 +63,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSA
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_SUB_PATTERN;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingRead.SORT_ATTRIBUTE_NOT_COMPARABLE;
 import static com.vaticle.typedb.core.common.iterator.Iterators.cartesian;
+import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.common.parameters.Arguments.Query.Producer.EXHAUSTIVE;
 import static com.vaticle.typedb.core.common.parameters.Arguments.Query.Producer.INCREMENTAL;
@@ -96,29 +98,35 @@ public class Reasoner {
 
     public FunctionalIterator<? extends ConceptMap> execute(Disjunction disjunction, TypeQLMatch.Modifiers modifiers, Context.Query context) {
         inferAndValidateTypes(disjunction);
-        FunctionalIterator<? extends ConceptMap> answers;
         Filter filter = Filter.create(modifiers.filter());
         Optional<Sorting> sorting = modifiers.sort().map(Sorting::create);
         sorting.ifPresent(value -> validateSorting(disjunction, value));
-        if (mayReason(disjunction, context)) {
-            answers = executeReasoner(disjunction, filter, context);
+        Disjunction answerableDisjunction = filterUnanswerable(disjunction);
+        FunctionalIterator<? extends ConceptMap> answers;
+        if (answerableDisjunction.conjunctions().isEmpty()) return empty();
+        else if (mayReason(answerableDisjunction, context)) {
+            answers = executeReasoner(answerableDisjunction, filter, context);
             if (sorting.isPresent()) answers = eagerSort(answers, sorting.get());
-        } else if (sorting.isPresent() && isNativelySortable(disjunction, sorting.get())) {
-            answers = executeTraversalSorted(disjunction, filter, sorting.get());
+        } else if (sorting.isPresent() && isNativelySortable(answerableDisjunction, sorting.get())) {
+            answers = executeTraversalSorted(answerableDisjunction, filter, sorting.get());
         } else {
             if (sorting.isPresent()) {
-                answers = executeTraversal(disjunction, context.producer(Either.first(EXHAUSTIVE)), filter);
+                answers = executeTraversal(answerableDisjunction, context.producer(Either.first(EXHAUSTIVE)), filter);
                 answers = eagerSort(answers, sorting.get());
             } else if (modifiers.limit().isPresent()) {
-                answers = executeTraversal(disjunction, context.producer(Either.second(modifiers.offset().orElse(0L) + modifiers.limit().get())), filter);
+                answers = executeTraversal(answerableDisjunction, context.producer(Either.second(modifiers.offset().orElse(0L) + modifiers.limit().get())), filter);
             } else {
-                answers = executeTraversal(disjunction, context.producer(Either.first(INCREMENTAL)), filter);
+                answers = executeTraversal(answerableDisjunction, context.producer(Either.first(INCREMENTAL)), filter);
             }
         }
 
         if (modifiers.offset().isPresent()) answers = answers.offset(modifiers.offset().get());
         if (modifiers.limit().isPresent()) answers = answers.limit(modifiers.limit().get());
         return answers;
+    }
+
+    private Disjunction filterUnanswerable(Disjunction disjunction) {
+        return new Disjunction(iterate(disjunction.conjunctions()).filter(Conjunction::isAnswerable).toList());
     }
 
     private void inferAndValidateTypes(Disjunction disjunction) {
@@ -231,6 +239,8 @@ public class Reasoner {
     }
 
     private Producer<ConceptMap> producer(Conjunction conjunction, Filter filter) {
+        assert conjunction.isCoherent();
+        if (!conjunction.isAnswerable()) return Producers.empty();
         if (conjunction.negations().isEmpty()) {
             return traversalEng.producer(conjunction.traversal(filter), PARALLELISATION_FACTOR)
                     .map(conceptMgr::conceptMap);
@@ -254,7 +264,8 @@ public class Reasoner {
     }
 
     private FunctionalIterator<ConceptMap> iterator(Conjunction conjunction, Filter filter) {
-        if (!conjunction.isCoherent()) return Iterators.empty();
+        assert conjunction.isCoherent();
+        if (!conjunction.isAnswerable()) return empty();
         FunctionalIterator<ConceptMap> answers = traversalEng.iterator(conjunction.traversal(filter)).map(conceptMgr::conceptMap);
         if (conjunction.negations().isEmpty()) return answers;
         else {

--- a/test/integration/logic/RuleTest.java
+++ b/test/integration/logic/RuleTest.java
@@ -56,8 +56,8 @@ import static com.vaticle.typedb.common.collection.Collections.pair;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.core.common.collection.Bytes.MB;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.CONTRADICTORY_RULE_CYCLE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_CANNOT_BE_SATISFIED;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_WHEN_CANNOT_BE_SATISFIED;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_INCOHERENT;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.RuleWrite.RULE_WHEN_INCOHERENT;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typedb.core.common.test.Util.assertNotThrows;
 import static com.vaticle.typedb.core.common.test.Util.assertThrows;
@@ -660,7 +660,7 @@ public class RuleTest {
                             "dogs-are-named-fido",
                             TypeQL.parsePattern("{$x isa dog;}").asConjunction(),
                             then
-                    ), RULE_THEN_CANNOT_BE_SATISFIED.code());
+                    ), RULE_THEN_INCOHERENT.code());
                 }
             }
         }
@@ -686,7 +686,7 @@ public class RuleTest {
                             "two-unique-dogs-exist-called-fido",
                             TypeQL.parsePattern("{$x isa dog; $y isa dog; $x != $y;}").asConjunction(),
                             TypeQL.parseVariable("$x has name 'fido'").asThing()
-                    ), RULE_WHEN_CANNOT_BE_SATISFIED.code());
+                    ), RULE_WHEN_INCOHERENT.code());
                 }
             }
         }


### PR DESCRIPTION
## What is the goal of this PR?

We update the usage of type inference to differentiate between an impossible-to-satisfy query (eg. using relations between types that are not playing the right roles, mismatched value types, etc.) and a query that will not have any answers but is semantically sound - such as querying for instances of an abstract type that has no concrete subtypes.

## What are the changes implemented in this PR?

* Type inference sets two booleans on `Conjunction`: `isCoherent` is set to `false` when the query represents a semantic schema violation. `isAnswerable` is set to `false` when the conjunction will never create any answers in the current schema.
* Short-circuit the execution of a query that does not have any answerable conjunctions and return an empty iterator

To implement these changes, we run type inference twice.
1. run type inference, including abstract types in the type inference output
2. If no types are found, then the query is illegal and we throw an exception
3. Run type inference disallowing abstract types. If any variables do not have any types, we set the query ans unanswerable

This restores the built-in assumption implementation of traversal, planning, reasoner, rule validation etc. that only queries where each variable contains a non-empty set of concrete types on each variable shall be processed.