### PR TITLE
Apply naming conventions to docker deployment targets

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -221,8 +221,8 @@ release:
       dependencies: [deploy-github]
       command: |
         docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
-        bazel run //:deploy-docker-latest
-        bazel run //:deploy-docker-versioned
+        bazel run //:deploy-docker-release
+        bazel run //:deploy-docker-release-overwrite-latest-tag
     deploy-artifact-release:
       image: vaticle-ubuntu-22.04
       filter:

--- a/BUILD
+++ b/BUILD
@@ -75,7 +75,11 @@ artifact_repackage(
 
 assemble_targz(
     name = "assemble-linux-targz",
-    targets = ["//server:server-deps-linux", ":console-artifact-jars", "@vaticle_typedb_common//binary:assemble-bash-targz"],
+    targets = [
+        ":console-artifact-jars",
+        "//server:server-deps-linux",
+        "@vaticle_typedb_common//binary:assemble-bash-targz"
+    ],
     additional_files = assemble_files,
     empty_directories = empty_directories,
     permissions = permissions,
@@ -217,25 +221,25 @@ docker_container_image(
 )
 
 docker_container_push(
-    name = "deploy-docker-latest",
+    name = "deploy-docker-release-overwrite-latest-tag",
     image = ":assemble-docker",
     format = "Docker",
-    registry = deployment_docker["docker.release"],
+    registry = deployment_docker["docker.index"],
     repository = "{}/{}".format(
         deployment_docker["docker.organisation"],
-        deployment_docker["docker.repository"],
+        deployment_docker["docker.release.repository"],
     ),
     tag = "latest"
 )
 
 docker_container_push(
-    name = "deploy-docker-versioned",
+    name = "deploy-docker-release",
     image = ":assemble-docker",
     format = "Docker",
-    registry = deployment_docker["docker.release"],
+    registry = deployment_docker["docker.index"],
     repository = "{}/{}".format(
         deployment_docker["docker.organisation"],
-        deployment_docker["docker.repository"],
+        deployment_docker["docker.release..repository"],
     ),
     tag_file = ":VERSION",
 )

--- a/BUILD
+++ b/BUILD
@@ -239,7 +239,7 @@ docker_container_push(
     registry = deployment_docker["docker.index"],
     repository = "{}/{}".format(
         deployment_docker["docker.organisation"],
-        deployment_docker["docker.release..repository"],
+        deployment_docker["docker.release.repository"],
     ),
     tag_file = ":VERSION",
 )

--- a/deployment.bzl
+++ b/deployment.bzl
@@ -16,9 +16,9 @@
 #
 
 deployment = {
-  'docker.release': 'index.docker.io',
+  'docker.index': 'index.docker.io',
   'docker.organisation': 'vaticle',
-  'docker.repository': 'typedb',
+  'docker.release.repository': 'typedb',
   'github.organisation': 'vaticle',
   'github.repository': 'typedb'
 }


### PR DESCRIPTION
## What is the goal of this PR?

We apply the existing naming conventions for deployment rules and deployment repositories for docker container targets.

## What are the changes implemented in this PR?

* Rename `docker-deploy` to `docker-deploy-release`, to allow for adding future `deploy-docker-snapshot` - this aligns with Cluster's BUILD pattern
* Rename `deploy-docker-latest` to longer but more accurate `deploy-docker-release-overwrite-latest-tag`
* Use updated naming convention for `docker` deployment index and repository name