### PR TITLE
Fix the overwriting of owns edges

### DIFF
--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -328,8 +328,11 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
         }
 
         TypeVertex attVertex = attributeType.vertex;
-        TypeEdge keyEdge;
-        if ((keyEdge = vertex.outs().edge(OWNS_KEY, attVertex)) != null) keyEdge.delete();
+        TypeEdge existingEdge;
+        if ((existingEdge = vertex.outs().edge(OWNS_KEY, attVertex)) != null ||
+                (existingEdge = vertex.outs().edge(OWNS, attVertex)) != null) {
+            existingEdge.delete();
+        }
         vertex.outs().put(OWNS, attVertex);
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We fix the overwriting of owns edges in the type graph by explicitly deleting pre-existing owns edges from the type vertex. In addition, we fix the conceptual model of type-edge equality functions by removing the actual java type from the equality function definitions, allowing persisted and buffered edges to be treated as equal.

## What are the changes implemented in this PR?

* Explicitly delete pre-existing owns edges when putting a new one into the schema graph
* Collapse separated equality functions for type edges into one consistent equality function