### PR TITLE
Unset overriddes when replacing pre-existing type edges

### DIFF
--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -146,9 +146,7 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
                 roleType.setSupertype(RoleTypeImpl.of(graphMgr, graphMgr.schema().rootRoleType()));
             }
             assert roleType.getSupertype() != null;
-            TypeEdge existingEdge = vertex.outs().edge(RELATES, roleType.vertex);
-            if (existingEdge != null) existingEdge.delete();
-            vertex.outs().edge(RELATES, roleType.vertex).overridden(roleType.getSupertype().vertex);
+            vertex.outs().edge(RELATES, roleType.vertex).setOverridden(roleType.getSupertype().vertex);
         }
     }
 
@@ -167,9 +165,7 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
         ) { throw exception(TypeDBException.of(RELATION_RELATES_ROLE_NOT_AVAILABLE, roleLabel, overriddenLabel)); }
 
         roleType.setSupertype(inherited.get());
-        TypeEdge existingEdge = vertex.outs().edge(RELATES, roleType.vertex);
-        if (existingEdge != null) existingEdge.delete();
-        vertex.outs().edge(RELATES, roleType.vertex).overridden(inherited.get().vertex);
+        vertex.outs().edge(RELATES, roleType.vertex).setOverridden(inherited.get().vertex);
     }
 
     @Override

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -146,6 +146,8 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
                 roleType.setSupertype(RoleTypeImpl.of(graphMgr, graphMgr.schema().rootRoleType()));
             }
             assert roleType.getSupertype() != null;
+            TypeEdge existingEdge = vertex.outs().edge(RELATES, roleType.vertex);
+            if (existingEdge != null) existingEdge.delete();
             vertex.outs().edge(RELATES, roleType.vertex).overridden(roleType.getSupertype().vertex);
         }
     }
@@ -165,6 +167,8 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
         ) { throw exception(TypeDBException.of(RELATION_RELATES_ROLE_NOT_AVAILABLE, roleLabel, overriddenLabel)); }
 
         roleType.setSupertype(inherited.get());
+        TypeEdge existingEdge = vertex.outs().edge(RELATES, roleType.vertex);
+        if (existingEdge != null) existingEdge.delete();
         vertex.outs().edge(RELATES, roleType.vertex).overridden(inherited.get().vertex);
     }
 

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -307,9 +307,9 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
             throw exception(TypeDBException.of(OWNS_KEY_PRECONDITION_NO_INSTANCES, vertex.label(), attVertex.label()));
         }
         ownsKeyEdge = vertex.outs().put(OWNS_KEY, attVertex);
-        if (getSupertype().declaredOwns(false).findFirst(attributeType).isPresent())
+        if (getSupertype().declaredOwns(false).findFirst(attributeType).isPresent()) {
             ownsKeyEdge.setOverridden(attVertex);
-        else ownsKeyEdge.unsetOverridden();
+        } else ownsKeyEdge.unsetOverridden();
     }
 
     private void ownsKey(AttributeTypeImpl attributeType, AttributeTypeImpl overriddenType) {

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -439,7 +439,9 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
         } else if (getSupertypes().filter(t -> !t.equals(this)).mergeMapForwardable(ThingType::getPlays, ASC).findFirst(roleType).isPresent()) {
             throw exception(TypeDBException.of(PLAYS_ROLE_NOT_AVAILABLE, getLabel(), roleType.getLabel()));
         }
-        vertex.outs().put(Encoding.Edge.Type.PLAYS, ((RoleTypeImpl) roleType).vertex);
+        TypeEdge existingEdge = vertex.outs().edge(PLAYS, ((RoleTypeImpl) roleType).vertex);
+        if (existingEdge != null) existingEdge.delete();
+        vertex.outs().put(PLAYS, ((RoleTypeImpl) roleType).vertex);
     }
 
     @Override

--- a/graph/edge/TypeEdge.java
+++ b/graph/edge/TypeEdge.java
@@ -49,7 +49,9 @@ public interface TypeEdge extends Edge<Encoding.Edge.Type, TypeVertex> {
      *
      * @param overridden the type vertex to override by the head vertex
      */
-    void overridden(TypeVertex overridden);
+    void setOverridden(TypeVertex overridden);
+
+    void unsetOverridden();
 
     View.Forward forwardView();
 

--- a/graph/edge/impl/TypeEdgeImpl.java
+++ b/graph/edge/impl/TypeEdgeImpl.java
@@ -216,8 +216,13 @@ public abstract class TypeEdgeImpl implements TypeEdge {
         }
 
         @Override
-        public void overridden(TypeVertex overridden) {
+        public void setOverridden(TypeVertex overridden) {
             this.overridden = overridden;
+        }
+
+        @Override
+        public void unsetOverridden() {
+            this.overridden = null;
         }
 
         /**
@@ -314,7 +319,12 @@ public abstract class TypeEdgeImpl implements TypeEdge {
         }
 
         @Override
-        public void overridden(TypeVertex overridden) {
+        public void setOverridden(TypeVertex overridden) {
+            throw TypeDBException.of(ILLEGAL_OPERATION);
+        }
+
+        @Override
+        public void unsetOverridden() {
             throw TypeDBException.of(ILLEGAL_OPERATION);
         }
 
@@ -430,11 +440,19 @@ public abstract class TypeEdgeImpl implements TypeEdge {
          * @param overridden the type vertex to override by the head
          */
         @Override
-        public void overridden(TypeVertex overridden) {
+        public void setOverridden(TypeVertex overridden) {
             this.overridden = overridden;
             overriddenIID = overridden.iid();
             graph.storage().putUntracked(computeForwardIID(), overriddenIID.bytes());
             graph.storage().putUntracked(computeBackwardIID(), overriddenIID.bytes());
+        }
+
+        @Override
+        public void unsetOverridden() {
+            this.overridden = null;
+            this.overriddenIID = null;
+            graph.storage().putUntracked(computeForwardIID());
+            graph.storage().putUntracked(computeBackwardIID());
         }
 
         /**


### PR DESCRIPTION
## What is the goal of this PR?

We introduce a new API that allows removing the overridden types on a Type edge. This is used to fix a class of bugs that expected edge "overwrite" behaviour in the type graph to unset overridden types on edges, but actually encounter "put" behaviour, meaning the overridden type is never replaced if the edge pre-existed.

## What are the changes implemented in this PR?

* Introduce `TypeEdge.unsetOverridden`, an idempotent operation that removes any existing overridden vertex on the edge
* Refactor setters on the Type concept API that were trying to overwrite any existing edge to use the new `unset` when the exact edge pre-exists