### PR TITLE
Avoid division by zero in reasoner planner

### DIFF
--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -216,8 +216,7 @@ public class AnswerCountEstimator {
             }
 
             assert !variables.isEmpty() || answerEstimateFromCover(variables, cover) == 1;
-            long ret = answerEstimateFromCover(variables, cover);
-            return Math.max(1, ret); // Avoid divisions by zero
+            return Math.round(Math.ceil(answerEstimateFromCover(variables, cover)));
         }
 
         private static double scaledEstimate(LocalModel model, Pair<Double, Optional<Variable>> scale, Set<Variable> estimateVariables) {

--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -157,7 +157,8 @@ public class AnswerCountEstimator {
             // Find scaling factor
             for (Variable v : model.variables) {
                 double ans = (double) model.estimateAnswers(set(v));
-                if (ans > 0 && minVariableEstimate.containsKey(v) && minVariableEstimate.get(v) / ans < bestScaler) {
+                if (ans == 0) ans = 1;
+                if (minVariableEstimate.containsKey(v) && minVariableEstimate.get(v) / ans < bestScaler) {
                     bestScaler = minVariableEstimate.get(v) / ans;
                     bestScalingVar = v;
                 } else if (ans < minVariableEstimate.getOrDefault(v, Double.MAX_VALUE)) {
@@ -216,7 +217,9 @@ public class AnswerCountEstimator {
             }
 
             assert !variables.isEmpty() || answerEstimateFromCover(variables, cover) == 1;
-            return Math.max(1, answerEstimateFromCover(variables, cover)); // Avoid divisions by zero
+            long ret = answerEstimateFromCover(variables, cover);
+            assert ret != 0;
+            return Math.max(1, ret); // Avoid divisions by zero
         }
 
         private static double scaledEstimate(LocalModel model, Pair<Double, Optional<Variable>> scale, Set<Variable> estimateVariables) {

--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -157,7 +157,7 @@ public class AnswerCountEstimator {
             // Find scaling factor
             for (Variable v : model.variables) {
                 double ans = (double) model.estimateAnswers(set(v));
-                if (minVariableEstimate.containsKey(v) && minVariableEstimate.get(v) / ans < bestScaler) {
+                if (ans > 0 && minVariableEstimate.containsKey(v) && minVariableEstimate.get(v) / ans < bestScaler) {
                     bestScaler = minVariableEstimate.get(v) / ans;
                     bestScalingVar = v;
                 } else if (ans < minVariableEstimate.getOrDefault(v, Double.MAX_VALUE)) {
@@ -216,7 +216,7 @@ public class AnswerCountEstimator {
             }
 
             assert !variables.isEmpty() || answerEstimateFromCover(variables, cover) == 1;
-            return answerEstimateFromCover(variables, cover);
+            return Math.max(1, answerEstimateFromCover(variables, cover)); // Avoid divisions by zero
         }
 
         private static double scaledEstimate(LocalModel model, Pair<Double, Optional<Variable>> scale, Set<Variable> estimateVariables) {
@@ -593,7 +593,7 @@ public class AnswerCountEstimator {
             if (correspondingConcludable != null) {
                 hasEdgeEstimate += estimateInferredAnswerCount(correspondingConcludable, set(hasConstraint.owner(), hasConstraint.attribute()));
                 attributeEstimate += attributesCreatedByExplicitHas(correspondingConcludable);
-                if (ownerEstimate < hasEdgeEstimate / attributeEstimate) {
+                if (attributeEstimate != 0 && ownerEstimate < hasEdgeEstimate / attributeEstimate) {
                     boolean rulesConcludeOwner = iterate(hasConstraint.owner().inferredTypes()).flatMap(ownerType -> iterate(answerCountEstimator.logicMgr.rulesConcluding(ownerType))).hasNext();
                     if (rulesConcludeOwner) ownerEstimate = hasEdgeEstimate / attributeEstimate;
                 }

--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -156,8 +156,7 @@ public class AnswerCountEstimator {
             Variable bestScalingVar = scale.second().orElse(null);
             // Find scaling factor
             for (Variable v : model.variables) {
-                double ans = (double) model.estimateAnswers(set(v));
-                if (ans == 0) ans = 1;
+                double ans = (double) Math.max(1,model.estimateAnswers(set(v)));
                 if (minVariableEstimate.containsKey(v) && minVariableEstimate.get(v) / ans < bestScaler) {
                     bestScaler = minVariableEstimate.get(v) / ans;
                     bestScalingVar = v;

--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -218,7 +218,6 @@ public class AnswerCountEstimator {
 
             assert !variables.isEmpty() || answerEstimateFromCover(variables, cover) == 1;
             long ret = answerEstimateFromCover(variables, cover);
-            assert ret != 0;
             return Math.max(1, ret); // Avoid divisions by zero
         }
 


### PR DESCRIPTION
## What is the goal of this PR?
Correctly handle code-paths with division so the case where the divisor may be zero.

## What are the changes implemented in this PR?

* Avoid dividing by zero with specific checks in the reasoner planner