### PR TITLE
Only let MultiPlanner spawn async2 futures

### DIFF
--- a/traversal/planner/MultiPlanner.java
+++ b/traversal/planner/MultiPlanner.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNEXPECTED_INTERRUPTION;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
-import static com.vaticle.typedb.core.concurrent.executor.Executors.async1;
+import static com.vaticle.typedb.core.concurrent.executor.Executors.async2;
 
 public class MultiPlanner implements Planner {
 
@@ -73,7 +73,7 @@ public class MultiPlanner implements Planner {
     private void mayOptimise(GraphManager graphMgr, boolean singleUse) {
         if (isOptimal()) return;
         List<CompletableFuture<Void>> futures = new ArrayList<>(planners.size());
-        planners.forEach(planner -> futures.add(CompletableFuture.runAsync(() -> planner.tryOptimise(graphMgr, singleUse), async1())));
+        planners.forEach(planner -> futures.add(CompletableFuture.runAsync(() -> planner.tryOptimise(graphMgr, singleUse), async2())));
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
         createProcedure();
     }


### PR DESCRIPTION
## What is the goal of this PR?

We fix an intermittent deadlock that occurs when running disjoint queries (e.g. `match $x isa person; $y isa company;`).

## What are the changes implemented in this PR?

MultiPlanner can be run in an `async1` pool, so it should only be able to spawn futures in the `async2` pool or below. `GraphPlanner` does not have this issue.