### PR TITLE
Simplify isolation manager

### DIFF
--- a/database/CoreDatabase.java
+++ b/database/CoreDatabase.java
@@ -671,6 +671,7 @@ public class CoreDatabase implements TypeDB.Database {
          * and correct them if we have enough information to do so.
          */
         protected void correctMiscounts() {
+            if (!databaseMgr.isOpen()) return;
             try (CoreTransaction.Data txn = session.transaction(WRITE)) {
                 if (mayCorrectMiscounts(txn)) cache.incrementStatisticsVersion();
             }

--- a/database/CoreDatabase.java
+++ b/database/CoreDatabase.java
@@ -552,7 +552,7 @@ public class CoreDatabase implements TypeDB.Database {
         private void cleanupCommitted() {
             if (cleanupRunning.compareAndSet(false, true)) {
                 long lastCommittedSnapshot = approximateLastCommitSnapshot.get();
-                Long cleanupUntil = oldestUnCommittedSnapshot().orElse(lastCommittedSnapshot + 1);
+                Long cleanupUntil = oldestUncommittedSnapshot().orElse(lastCommittedSnapshot + 1);
                 commitStates.forEach((txn, state) -> {
                     if (txn.snapshotEnd().isPresent() && txn.snapshotEnd().get() < cleanupUntil) {
                         txn.delete();
@@ -563,7 +563,7 @@ public class CoreDatabase implements TypeDB.Database {
             }
         }
 
-        private Optional<Long> oldestUnCommittedSnapshot() {
+        private Optional<Long> oldestUncommittedSnapshot() {
             return getNotCommitted().map(CoreTransaction.Data::snapshotStart).stream().min(Comparator.naturalOrder());
         }
 

--- a/database/CoreDatabase.java
+++ b/database/CoreDatabase.java
@@ -497,8 +497,6 @@ public class CoreDatabase implements TypeDB.Database {
         private final ConcurrentSet<CoreTransaction.Data> committed;
         private final AtomicBoolean cleanupRunning;
 
-        private enum CommitState {UNCOMMITTED, COMMITTING, COMMITTED}
-
         IsolationManager() {
             uncommitted = new ConcurrentSet<>();
             committing = new ConcurrentSet<>();

--- a/database/CoreDatabase.java
+++ b/database/CoreDatabase.java
@@ -570,7 +570,7 @@ public class CoreDatabase implements TypeDB.Database {
         }
 
         private long newestCommittedSnapshot() {
-            return iterate(committed).map(txn -> txn.snapshotEnd().get()).stream().min(Comparator.naturalOrder()).orElse(0L);
+            return iterate(committed).map(txn -> txn.snapshotEnd().get()).stream().max(Comparator.naturalOrder()).orElse(0L);
         }
 
         FunctionalIterator<CoreTransaction.Data> getNotCommitted() {


### PR DESCRIPTION
## What is the goal of this PR?

We discover that a ConcurrentSkipListMap does not implement locking/atomic `compute` operations. This behaviour was relied on to implement Isolation Manager's cleanup of transaction state, and errors could manifest as concurrent modification exceptions. To fix this, we refactor the IsolationManager with a simpler state model to optimally allow both isolation validation and deletion.


## What are the changes implemented in this PR?

* `IsolationManager` cleanup of committed transactions no longer relies on a `timeline`, but just the current set of transactions and the state they are in. We also delete the single concurrent hash map of `CommitState`
* Introduce three maps: `uncommitted`, `committing`, and `committed`. These allow us to optimise the single-threaded lock duration in the isolation manager, and implement a simplified cleanup mechanism.
