### PR TITLE
Planning and statistics are logged on TRACE

### DIFF
--- a/database/CoreDatabase.java
+++ b/database/CoreDatabase.java
@@ -607,11 +607,11 @@ public class CoreDatabase implements TypeDB.Database {
 
         public void initialiseAndCleanUp() {
             initialise();
-            LOG.debug("Cleaning up statistics metadata.");
+            LOG.trace("Cleaning up statistics metadata.");
             correctMiscounts();
             deleteCorrectionMetadata();
-            LOG.debug("Statistics are ready and up to date.");
-            if (LOG.isDebugEnabled()) logSummary();
+            LOG.trace("Statistics are ready and up to date.");
+            if (LOG.isTraceEnabled()) logSummary();
         }
 
         private void deleteCorrectionMetadata() {
@@ -625,7 +625,7 @@ public class CoreDatabase implements TypeDB.Database {
 
         private void logSummary() {
             try (CoreTransaction.Data txn = session.transaction(READ)) {
-                LOG.debug("Total 'thing' count: " +
+                LOG.trace("Total 'thing' count: " +
                         txn.graphMgr.data().stats().thingVertexTransitiveCount(txn.graphMgr.schema().rootThingType())
                 );
                 long hasCount = 0;
@@ -634,10 +634,10 @@ public class CoreDatabase implements TypeDB.Database {
                 for (TypeVertex attr : attributes) {
                     hasCount += txn.graphMgr.data().stats().hasEdgeSum(allTypes, attr);
                 }
-                LOG.debug("Total 'role' count: " +
+                LOG.trace("Total 'role' count: " +
                         txn.graphMgr.data().stats().thingVertexTransitiveCount(txn.graphMgr.schema().rootRoleType())
                 );
-                LOG.debug("Total 'has' count: " + hasCount);
+                LOG.trace("Total 'has' count: " + hasCount);
             }
         }
 

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -45,7 +45,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNEXPECTED_PLANNING_ERROR;
@@ -269,7 +268,7 @@ public class GraphPlanner implements ComponentPlanner {
     private void startReOptimise(GraphManager graphMgr, long timeLimitMillis) {
         updateTraversalCosts(graphMgr);
         if (isUpToDate() && isOptimal()) {
-            if (LOG.isDebugEnabled()) LOG.debug("GraphPlanner still optimal and up-to-date");
+            if (LOG.isTraceEnabled()) LOG.trace("GraphPlanner still optimal and up-to-date");
             isOptimising.set(false);
             return;
         }
@@ -291,7 +290,7 @@ public class GraphPlanner implements ComponentPlanner {
         end = Instant.now();
 
         isUpToDate = true;
-        printDebug(start, endSolver, end);
+        printTrace(start, endSolver, end);
         isOptimising.set(false);
     }
 
@@ -402,13 +401,13 @@ public class GraphPlanner implements ComponentPlanner {
         throw TypeDBException.of(UNEXPECTED_PLANNING_ERROR);
     }
 
-    private void printDebug(Instant start, Instant endSolver, Instant end) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Optimisation status         : {}", optimiser.status().name());
-            LOG.debug("Objective function value    : {}", optimiser.objectiveValue());
-            LOG.debug("Solver duration             : {} (ms)", between(start, endSolver).toMillis());
-            LOG.debug("Procedure creation duration : {} (ms)", between(endSolver, end).toMillis());
-            LOG.debug("Total duration ------------ : {} (ms)", between(start, end).toMillis());
+    private void printTrace(Instant start, Instant endSolver, Instant end) {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Optimisation status         : {}", optimiser.status().name());
+            LOG.trace("Objective function value    : {}", optimiser.objectiveValue());
+            LOG.trace("Solver duration             : {} (ms)", between(start, endSolver).toMillis());
+            LOG.trace("Procedure creation duration : {} (ms)", between(endSolver, end).toMillis());
+            LOG.trace("Total duration ------------ : {} (ms)", between(start, end).toMillis());
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

To reduce the verbosity of the `debug` level, the query planner status and the TypeDB/Rocks statistics are logged on TRACE instead. This should help tests, which are run in DEBUG, be much more readable.

## What are the changes implemented in this PR?

* Use `TRACE` for logging query planning status and database statistics operations