### PR TITLE
Shutdown gracefully on unexpected server exception

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -42,7 +42,7 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final Server EXITED_WITH_ERROR =
                 new Server(3, "Exited with error.");
         public static final Server UNCAUGHT_EXCEPTION =
-                new Server(4, "Uncaught exception thrown at thread '%s'.");
+                new Server(4, "Uncaught exception thrown at thread '%s':\n'%s'");
         public static final Server CONFIG_FILE_NOT_FOUND =
                 new Server(5, "Could not find/read the configuration file '%s'.");
         public static final Server UNRECOGNISED_CLI_COMMAND =

--- a/server/TypeDBServer.java
+++ b/server/TypeDBServer.java
@@ -54,7 +54,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.*;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.ALREADY_RUNNING;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.DATA_DIRECTORY_NOT_FOUND;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.DATA_DIRECTORY_NOT_WRITABLE;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.EXITED_WITH_ERROR;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.FAILED_AT_STOPPING;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.INCOMPATIBLE_JAVA_RUNTIME;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.UNRECOGNISED_CLI_COMMAND;
 import static com.vaticle.typedb.core.server.common.Util.getTypedbDir;
 import static com.vaticle.typedb.core.server.common.Util.printASCIILogo;
 import static org.slf4j.Logger.ROOT_LOGGER_NAME;

--- a/server/TypeDBServer.java
+++ b/server/TypeDBServer.java
@@ -54,14 +54,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.ALREADY_RUNNING;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.DATA_DIRECTORY_NOT_FOUND;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.DATA_DIRECTORY_NOT_WRITABLE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.EXITED_WITH_ERROR;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.FAILED_AT_STOPPING;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.INCOMPATIBLE_JAVA_RUNTIME;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.UNCAUGHT_EXCEPTION;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.UNRECOGNISED_CLI_COMMAND;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.*;
 import static com.vaticle.typedb.core.server.common.Util.getTypedbDir;
 import static com.vaticle.typedb.core.server.common.Util.printASCIILogo;
 import static org.slf4j.Logger.ROOT_LOGGER_NAME;
@@ -103,12 +96,6 @@ public class TypeDBServer implements AutoCloseable {
         this.factory = factory;
         databaseMgr = factory.databaseManager(options);
         server = rpcServer();
-        Thread.setDefaultUncaughtExceptionHandler(
-                (t, e) -> {
-                    logger().error(UNCAUGHT_EXCEPTION.message(t.getName() + ": " + e.getMessage()), e);
-                    System.exit(1);
-                }
-        );
         Runtime.getRuntime().addShutdownHook(
                 NamedThreadFactory.create(TypeDBServer.class, "shutdown").newThread(this::close)
         );

--- a/server/TypeDBServer.java
+++ b/server/TypeDBServer.java
@@ -105,7 +105,7 @@ public class TypeDBServer implements AutoCloseable {
         server = rpcServer();
         Thread.setDefaultUncaughtExceptionHandler(
                 (t, e) -> {
-                    logger().error(UNCAUGHT_EXCEPTION.message(t.getName() + ": " + e.getMessage()), e);
+                    logger().error(UNCAUGHT_EXCEPTION.message(t.getName(), e));
                     close();
                     System.exit(1);
                 }

--- a/server/TypeDBServer.java
+++ b/server/TypeDBServer.java
@@ -104,7 +104,10 @@ public class TypeDBServer implements AutoCloseable {
         databaseMgr = factory.databaseManager(options);
         server = rpcServer();
         Thread.setDefaultUncaughtExceptionHandler(
-                (t, e) -> logger().error(UNCAUGHT_EXCEPTION.message(t.getName() + ": " + e.getMessage()), e)
+                (t, e) -> {
+                    logger().error(UNCAUGHT_EXCEPTION.message(t.getName() + ": " + e.getMessage()), e);
+                    System.exit(1);
+                }
         );
         Runtime.getRuntime().addShutdownHook(
                 NamedThreadFactory.create(TypeDBServer.class, "shutdown").newThread(this::close)


### PR DESCRIPTION
## What is the goal of this PR?

To prevent zombie or broken server states due to unexpected exceptions, we no longer catch and swallow unexpected exceptions. Instead, we shutdown the server. The catch-and-swallow behaviour is dangerous because 1) an uncaught exception means a thread is also killed somewhere, and could put the server into a zombie or otherwise broken state, and specifically can cause 2) zombie state by catching an OOM exception which would stall the server instead of letting it die. 

## What are the changes implemented in this PR?

* Allow TypeDB to exit if there's an unexpected exception by removing the uncaught exception handler