### PR TITLE
Fix concludable-unifier caching

### DIFF
--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -111,7 +111,7 @@ public class LogicManager {
     }
 
     public Map<Rule, Set<Unifier>> applicableRules(Concludable concludable) {
-        return logicCache.unifiers().get(concludable, concludable1 -> concludable1.computeApplicableRules(conceptMgr, this));
+        return logicCache.unifiers().get(concludable, c -> c.computeApplicableRules(conceptMgr, this));
     }
 
     public Set<Resolvable<?>> compile(ResolvableConjunction conjunction) {

--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -111,15 +111,7 @@ public class LogicManager {
     }
 
     public Map<Rule, Set<Unifier>> applicableRules(Concludable concludable) {
-        Map<Rule, Set<Unifier>> unifiers = logicCache.unifiers().getIfPresent(concludable);
-        if (unifiers == null) {
-            unifiers = concludable.computeApplicableRules(conceptMgr, this);
-        }
-        return unifiers;
-    }
-
-    public void indexApplicableRules(Concludable concludable) {
-        logicCache.unifiers().get(concludable, c -> c.computeApplicableRules(conceptMgr, this));
+        return logicCache.unifiers().get(concludable, concludable1 -> concludable1.computeApplicableRules(conceptMgr, this));
     }
 
     public Set<Resolvable<?>> compile(ResolvableConjunction conjunction) {
@@ -156,14 +148,6 @@ public class LogicManager {
             // recreate rule index conclusions
             graphMgr.schema().rules().all().forEachRemaining(s -> fromStructure(s).conclusion().reindex());
         }
-
-        // re-index the concludable-rule unifiers
-        this.rules().forEachRemaining(
-                rule -> iterate(rule.condition().branches())
-                        .flatMap(condition -> iterate(condition.conjunction().allConcludables()))
-                        .forEachRemaining(this::indexApplicableRules)
-        );
-
         // using the new index, validate new rules are stratifiable (eg. do not cause cycles through a negation)
         validateCyclesThroughNegations();
     }


### PR DESCRIPTION
## What is the goal of this PR?
The unifiers between a concludable and its applicable rules were not being cached, leading to them being recomputed multiple times during reasoner-planning. We rectify this and simplify the caching process    

## What are the changes implemented in this PR?
* LogicManager uses the `LogicCache.unifiers` as a cache. 