### PR TITLE
Static server constructor with earlier logging configuration

### DIFF
--- a/server/TypeDBServer.java
+++ b/server/TypeDBServer.java
@@ -71,7 +71,6 @@ public class TypeDBServer implements AutoCloseable {
 
     protected final Factory factory;
     protected final CoreConfig config;
-    protected final CoreLogback logback;
     protected final CoreDatabaseManager databaseMgr;
     protected final io.grpc.Server server;
     protected final boolean debug;
@@ -80,7 +79,7 @@ public class TypeDBServer implements AutoCloseable {
     private static TypeDBServer create(CoreConfig config, boolean debug) {
         CoreLogback coreLogback = new CoreLogback();
         configureLogging(coreLogback, config);
-        return new TypeDBServer(config, debug, new CoreFactory(), coreLogback);
+        return new TypeDBServer(config, debug, new CoreFactory());
     }
 
     protected static void configureLogging(CoreLogback logback, CoreConfig config) {
@@ -88,10 +87,9 @@ public class TypeDBServer implements AutoCloseable {
         java.util.logging.Logger.getLogger("io.grpc").setLevel(Level.SEVERE);
     }
 
-    protected TypeDBServer(CoreConfig config, boolean debug, Factory factory, CoreLogback logback) {
+    protected TypeDBServer(CoreConfig config, boolean debug, Factory factory) {
         this.config = config;
         this.debug = debug;
-        this.logback = logback;
 
         verifyJavaVersion();
         verifyDataDir();

--- a/server/TypeDBServer.java
+++ b/server/TypeDBServer.java
@@ -77,8 +77,7 @@ public class TypeDBServer implements AutoCloseable {
     protected TypeDBService typeDBService;
 
     private static TypeDBServer create(CoreConfig config, boolean debug) {
-        CoreLogback coreLogback = new CoreLogback();
-        configureLogging(coreLogback, config);
+        configureLogging(new CoreLogback(), config);
         return new TypeDBServer(config, debug, new CoreFactory());
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We introduce a static TypeDB server constructor in which the server's logging is configured ahead of time, instead of in the constructor. This allows TypeDB Cluster have more freedom about when the logging is configured.

## What are the changes implemented in this PR?

* introduce `TypeDBServer.create()` static constructor
* move logging configuration into the static constructor, and make it protected to be accessed in cluster's server constructor
* remove unneeded argument to TypeDBServer
