### PR TITLE
Add missing ErrorMessage parameters for UNSUPPORTED_OPERATION 

### DIFF
--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -142,7 +142,7 @@ public final class ConceptManager {
 
     public AttributeType putAttributeType(String label, AttributeType.ValueType valueType) {
         if (valueType == null) throw exception(TypeDBException.of(ATTRIBUTE_VALUE_TYPE_MISSING, label));
-        if (!valueType.isWritable()) throw exception(TypeDBException.of(UNSUPPORTED_OPERATION));
+        if (!valueType.isWritable()) throw exception(TypeDBException.of(UNSUPPORTED_OPERATION, "putAttributeType", valueType.name()));
 
         TypeVertex vertex = graphMgr.schema().getType(label);
         switch (valueType) {


### PR DESCRIPTION
## What is the goal of this PR?
Trying to create an attribute-type which is unwritable throws a TypeDBException UNSUPPORTED_OPERATION, but the Constructor of the error message is missing the parameters describing the operation being attempted and the argument for what it is invalid (here, putAttribute for ValueType.OBJECT).

## What are the changes implemented in this PR?
- Adds the missing `ErrorMessage` parameters to the exception being thrown.

closes #5903 (if not already considered fixed)