### PR TITLE
Update to error messages for illegal pattern matches

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -280,7 +280,7 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_REGEX =
                 new Pattern(15, "The type variable '%s' has multiple 'regex' constraints.");
         public static final Pattern INCOHERENT_PATTERN =
-                new Pattern(16, "The pattern '%s' is illegal in the current schema.");
+                new Pattern(16, "The schema does not allow for data matching the pattern '%s'.");
         public static final Pattern INCOHERENT_SUB_PATTERN =
                 new Pattern(17, "The pattern '%s' is illegal in the current schema, due to '%s'.");
         public static final Pattern INCOHERENT_PATTERN_VARIABLE_VALUE =

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -282,9 +282,9 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final Pattern INCOHERENT_PATTERN =
                 new Pattern(16, "The schema does not allow for data matching the pattern '%s'.");
         public static final Pattern INCOHERENT_SUB_PATTERN =
-                new Pattern(17, "The pattern '%s' is illegal in the current schema, due to '%s'.");
+                new Pattern(17, "The schema does not allow for data matching the pattern '%s', due to the included pattern '%s'.");
         public static final Pattern INCOHERENT_PATTERN_VARIABLE_VALUE =
-                new Pattern(18, "The pattern '%s' is illegal in the current schema, due to contradicting attribute value types for '%s'.");
+                new Pattern(18, "The schema does not allow for data matching the pattern '%s', due to contradicting attribute value types for '%s'.");
 
         private static final String codePrefix = "QRY";
         private static final String messagePrefix = "Invalid Query Pattern";


### PR DESCRIPTION
## What is the goal of this PR?

The error messages returned for illegal pattern matches were not descriptive enough, leading to potential ambiguity for the user. The are now more descriptive.

## What are the changes implemented in this PR?

The error messages for `INCOHERENT_PATTERN`, `INCOHERENT_SUB_PATTERN`, and `INCOHERENT_PATTERN_VARIABLE_VALUE` in `common/exception/ErrorMessage.java` have been updated.
