### PR TITLE
Short-cut rules where possible & relax reasoner planner orderings

### DIFF
--- a/reasoner/controller/ConcludableController.java
+++ b/reasoner/controller/ConcludableController.java
@@ -47,7 +47,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
@@ -258,11 +257,12 @@ public abstract class ConcludableController<INPUT, OUTPUT,
 
             private boolean canBypassReasoning(ConceptMap bounds) {
                 if (concludable.isHas()) {
-                    return bounds.contains(concludable.asHas().owner().id()) &&
-                            bounds.contains(concludable.asHas().attribute().id()) &&
-                            concludable.isInferredAnswer(bounds);
+                    Concept owner; Concept attribute;
+                    return  (owner = bounds.get(concludable.asHas().owner().id())) != null &&
+                            (attribute = bounds.get(concludable.asHas().attribute().id())) != null &&
+                            (owner.asThing().hasInferred(attribute.asAttribute()) || owner.asThing().hasNonInferred(attribute.asAttribute()));
                 } else {
-                    return bounds.contains(concludable.generating().get().id()) && concludable.isInferredAnswer(bounds);
+                    return bounds.contains(concludable.generating().get().id());
                 }
             }
 

--- a/reasoner/controller/ConcludableController.java
+++ b/reasoner/controller/ConcludableController.java
@@ -163,7 +163,7 @@ public abstract class ConcludableController<INPUT, OUTPUT,
             //  concludable. They should be filtered before being passed to the concludableProcessor's constructor
             assert bounds.equals(this.bounds);
             return new Processor.Explain(
-                    explainDriver, driver(), processorContext(), concludable, bounds, set(), conclusionUnifiers, reasonerConsumer,
+                    explainDriver, driver(), processorContext(), concludable, bounds, conclusionUnifiers, reasonerConsumer,
                     () -> Traversal.traversalIterator(registry(), concludable.pattern(), bounds),
                     () -> Processor.class.getSimpleName() + "(pattern: " + concludable.pattern() + ", bounds: " + bounds + ")"
             );
@@ -348,7 +348,6 @@ public abstract class ConcludableController<INPUT, OUTPUT,
                     Driver<Explain> driver, Driver<ConcludableController.Explain> controller, Context context,
                     Concludable concludable,
                     ConceptMap bounds,
-                    Set<Variable.Retrievable> unboundVars,
                     Map<Conclusion, Set<Unifier>> conclusionUnifiers,
                     ReasonerConsumer<Explanation> reasonerConsumer,
                     Supplier<FunctionalIterator<ConceptMap>> traversalSuppplier,

--- a/reasoner/controller/ConcludableController.java
+++ b/reasoner/controller/ConcludableController.java
@@ -182,7 +182,6 @@ public abstract class ConcludableController<INPUT, OUTPUT,
 
         final Concludable concludable;
         final ConceptMap bounds;
-        private final Set<Variable.Retrievable> unboundVars;  // TODO: Can just use a boolean to indicate if fully bound
         private final Map<Conclusion, Set<Unifier>> conclusionUnifiers;
         private final Set<Identifier> requestedConnections;
         final java.util.function.Supplier<FunctionalIterator<ConceptMap>> traversalSuppplier;
@@ -190,14 +189,12 @@ public abstract class ConcludableController<INPUT, OUTPUT,
         Processor(Driver<PROCESSOR> driver,
                   Driver<? extends AbstractController<?, INPUT, OUTPUT, REQ, PROCESSOR, ?>> controller,
                   Concludable concludable, Context context, ConceptMap bounds,
-                  Set<Variable.Retrievable> unboundVars,
                   Map<Conclusion, Set<Unifier>> conclusionUnifiers,
                   Supplier<FunctionalIterator<ConceptMap>> traversalSuppplier,
                   Supplier<String> debugName) {
             super(driver, controller, context, debugName);
             this.concludable = concludable;
             this.bounds = bounds;
-            this.unboundVars = unboundVars;
             this.conclusionUnifiers = conclusionUnifiers;
             this.traversalSuppplier = traversalSuppplier;
             this.requestedConnections = new HashSet<>();
@@ -249,14 +246,12 @@ public abstract class ConcludableController<INPUT, OUTPUT,
                     Map<Conclusion, Set<Unifier>> conclusionUnifiers,
                     Supplier<FunctionalIterator<ConceptMap>> traversalSuppplier, Supplier<String> debugName
             ) {
-                super(driver, controller, concludable, context, bounds, unboundVars, conclusionUnifiers, traversalSuppplier,
-                      debugName);
+                super(driver, controller, concludable, context, bounds, conclusionUnifiers, traversalSuppplier, debugName);
             }
 
 
             @Override
             public void setUp() {
-                // TODO: Add a find first optimisation when all variables are bound
                 if (concludable.isRelation() && concludable.generating().isPresent() && bounds.contains(concludable.generating().get().id())) {
                     // Optimisation: If we know the relation instance, just do a lookup.
                     setHubReactive(fanInFanOut(this));
@@ -352,7 +347,7 @@ public abstract class ConcludableController<INPUT, OUTPUT,
                     Supplier<FunctionalIterator<ConceptMap>> traversalSuppplier,
                     Supplier<String> debugName
             ) {
-                super(driver, controller, concludable, context, bounds, unboundVars, conclusionUnifiers, traversalSuppplier,
+                super(driver, controller, concludable, context, bounds, conclusionUnifiers, traversalSuppplier,
                       debugName);
                 this.reasonerConsumer = reasonerConsumer;
             }

--- a/reasoner/planner/RecursivePlanner.java
+++ b/reasoner/planner/RecursivePlanner.java
@@ -359,6 +359,7 @@ public class RecursivePlanner extends ReasonerPlanner {
 
             List<List<Resolvable<?>>> orderings = new ArrayList<>();
             porDFS(new Stack<>(), restrictedVars, remaining, new HashSet<>(), orderings);
+            assert !orderings.isEmpty();
             return orderings; // TODO: If this causes a memory blow-up, POR can "generate" one at a time.
         }
 
@@ -372,10 +373,6 @@ public class RecursivePlanner extends ReasonerPlanner {
             List<Resolvable<?>> enabled = iterate(remaining)
                     .filter(r -> ReasonerPlanner.dependenciesSatisfied(r, currentBoundVars, dependencies) && !sleepSet.contains(r))
                     .toList();
-
-            if (enabled.isEmpty()) {
-                enabled = iterate(remaining).filter(r -> !r.isNegated() && !sleepSet.contains(r)).toList();
-            }
 
             if (enabled.isEmpty()) {
                 return; // All enabled are sleeping


### PR DESCRIPTION
## What is the goal of this PR?
We revise the criteria for a constraint to be dependent on a variable being bound. This refines the search-space of the reasoner planner to include more legal plans, and allows an optimisation for reasoning involving relations playing roles in other relations.

In certain cases during reasoning, we can determine that all answers for a given constraint have already been computed. In such cases, we can bypass inference and simply look up the answers.

## What are the changes implemented in this PR?
* Loosen the criteria for resolvable dependencies:
  * A resolvable _r_ is only dependent on a variable _v_ if : 
      1. _v_ is 'generated' by some other concludable in the conjunction AND
      2. _r_ contains a constraint involving `v`
      3. no constraint in _r_  generates values for `v` 
      * (Currently, predicates are the only constraints which can involve a variable but not generate inferred values for it)
  * Negations remain dependent on variables which occur unnegated in conjunction(s) which contain it.    
* `RecursivePlanner` no longer relaxes dependencies to generate orderings when it cannot schedule any resolvable.
* `ConcludableProcessor.Match` will not trigger rules (i.e. create conclusion processors upstream)  if the answer is already guaranteed to be materialised. It will create instead do a traversal which includes inferred concepts.