### PR TITLE
Simplify RecursivePlanner - separate cost computation for different phases 

### DIFF
--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -243,15 +243,6 @@ public class AnswerCountEstimator {
             return ans;
         }
 
-        public IncrementalEstimator clone() {
-            // initialbounds = set() is ok, the next steps will take care of it.
-            IncrementalEstimator cloned = new IncrementalEstimator(conjunctionModel, localModelFactory, set());
-            cloned.minVariableEstimate.putAll(this.minVariableEstimate);
-            cloned.modelScale.putAll(this.modelScale);
-            cloned.affectedModels.putAll(this.affectedModels);
-            return cloned;
-        }
-
         private static long answerEstimateFromCover(Set<Variable> variables, Map<Variable, CoverElement> coverMap) {
             double estimate = iterate(variables).map(coverMap::get).distinct()
                     .map(coverElement -> coverElement.estimate).reduce(1.0, (x, y) -> x * y);


### PR DESCRIPTION
## What is the goal of this PR?


## What are the changes implemented in this PR?
When choosing an ordering of resolvables for a conjunction plan, the ordering with minimum estimated cost for a **single call** is chosen. When choosing the subgraph plan, we compute the cost of the ordering for **all calls** and scale it down according to the scaling-factors.

The single-call cost and all-calls cost were computed in the same function `CreateOrderingChoice`, which returned an `OrderingChoice`. This has been split into two methods -
* `CreateOrderingSummary` - Given a callMode (conjunction + inputBounds), it summarises every resolvable ordering into an `OrderingSummary` object including the `cyclicConcludableModes`, `singlyBoundCost`.
* `CreateOrderingChoice` - Given an OrderingSummary, it evaluates the all-calls cost for the resolvable ordering and returns an `OrderingChoice` object.

We do not create an `OrderingChoice` for every `OrderingSummary`. It suffices to group `OrderingSummary`s by `cyclicConcludableModes` and pick the one with the lowest single-call cost - This is the ` OrderingChoice` for that `cyclicConcludableModes`.