### PR TITLE
Optimised relation unification performance

### DIFF
--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -265,7 +265,7 @@ public abstract class Concludable extends Resolvable<Conjunction> implements Alp
             iterate(conjRolePlayers).forEachRemaining(conjRP -> {
                 unifiesWith.put(conjRP, iterate(thenRolePlayers).filter(thenRP -> Unifier.Builder.unificationSatisfiable(conjRP, thenRP, conceptMgr)).toSet());
             });
-            FunctionalIterator<Map<RolePlayer, RolePlayer>> it = iterate(new HashMap<>());
+            FunctionalIterator<Map<RolePlayer, RolePlayer>> it = Iterators.single(new HashMap<>());
             for (int i = 0; i < conjRolePlayers.size(); i++) {
                 RolePlayer conjRP = conjRolePlayers.get(i);
                 it = it.flatMap(currentMapping -> iterate(unifiesWith.get(conjRP))

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -82,7 +82,9 @@ public abstract class Concludable extends Resolvable<Conjunction> implements Alp
     }
 
     @Override
-    public Set<Variable> variables() { return pattern().variables(); }
+    public Set<Variable> variables() {
+        return pattern().variables();
+    }
 
     public boolean isConcludable() {
         return true;
@@ -100,13 +102,21 @@ public abstract class Concludable extends Resolvable<Conjunction> implements Alp
 
     public abstract boolean isInferredAnswer(ConceptMap conceptMap);
 
-    public boolean isRelation() { return false; }
+    public boolean isRelation() {
+        return false;
+    }
 
-    public boolean isHas() { return false; }
+    public boolean isHas() {
+        return false;
+    }
 
-    public boolean isIsa() { return false; }
+    public boolean isIsa() {
+        return false;
+    }
 
-    public boolean isAttribute() { return false; }
+    public boolean isAttribute() {
+        return false;
+    }
 
     public Relation asRelation() {
         throw TypeDBException.of(INVALID_CASTING, className(this.getClass()), className(Relation.class));
@@ -182,7 +192,7 @@ public abstract class Concludable extends Resolvable<Conjunction> implements Alp
                 clonedIsa = cloner.getClone(isa).asThing().asIsa();
             }
             return new Relation(cloner.conjunction(), cloner.getClone(relation).asThing().asRelation(), clonedIsa,
-                                iterate(labels).map(l -> cloner.getClone(l).asType().asLabel()).toSet());
+                    iterate(labels).map(l -> cloner.getClone(l).asType().asLabel()).toSet());
         }
 
         public RelationConstraint relation() {
@@ -247,7 +257,7 @@ public abstract class Concludable extends Resolvable<Conjunction> implements Alp
         }
 
         private FunctionalIterator<Map<RolePlayer, RolePlayer>> matchRolePlayers(Set<RolePlayer> conjRolePlayerSet, Set<RolePlayer> thenRolePlayers, ConceptManager conceptMgr) {
-            // TODO: If this is ever slow again, consider Divide & Conquer: Partition conjRolePlayers such that the result sets of all partitions are disjoint
+            // If this is ever slow again, consider Divide & Conquer: Partition conjRolePlayers such that the result sets of all partitions are disjoint
             // Sort, So that the once with identical role-labels are together; They hopefully fail together
             List<RolePlayer> conjRolePlayers = new ArrayList<>(conjRolePlayerSet);
             conjRolePlayers.sort(Comparator.comparing(rolePlayer -> rolePlayer.roleType().map(typeVariable -> typeVariable.label().map(LabelConstraint::label).orElse("")).orElse("")));


### PR DESCRIPTION
## What is the goal of this PR?

We improve the relation unification algorithm, which in turn unlocks relation unification with many role-players.

## What are the changes implemented in this PR?
* Modify `Concludable.Relation.MatchRolePlayers` to
  *  recursively/iteratively constructing the iterator rather than doing the recursion in the iterator. 
  * Index the list of role-players in the conclusion that each concludable role-player can unify with.
  * Sort based on role-label as a naive way of grouping competing role-players together. May not be a case that's common in practice.