### PR TITLE
Refactor statistics corrector module to allow lazy initialisation

### DIFF
--- a/database/CoreDatabase.java
+++ b/database/CoreDatabase.java
@@ -456,7 +456,7 @@ public class CoreDatabase implements TypeDB.Database {
         }
     }
 
-    protected void close() {
+    public void close() {
         if (isOpen.compareAndSet(true, false)) {
             if (scheduledPropertiesLogger != null) shutdownRocksPropertiesLogger();
             closeResources();


### PR DESCRIPTION
## What is the goal of this PR?

We formalise the state model in a database statistics correction module, which now allows lazy initialisation. This is used in cluster to transition between primary/secondary multiple times within the lifetime of one database.

## What are the changes implemented in this PR?

* Update naming in database `initialise`/`load` methods consistently
* Introduce a state model in `StatisticsCorrector`, which allows lazy or eager initialisation on database initialisation or loading.
  * The "lazy" operation is called "mark*", while the operation itself is called "do*". 
  * In core, we call both the `markActivating` and `doActivate` together
 

The `StatisticsCorrector` now has the following states:
`INACTIVE` - constructed, not ready to set up
`ACTIVATING` - we are activating, but the activation hasn't happened yet
`REACTIVATING` - we are reactivating (init + more work), but the operation hasn't happened yet
`WAITING` - the corrector is ready to accept correction jobs
`CORRECTION_QUEUED` - there is a correction job queued
`CLOSED` - the corrector is closed and cannot be opened