### PR TITLE
Update to match YAML parser update in typedb-common

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,7 +35,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.12.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "b5475e496002fb8d069e5310b8edbb0dbe723cc5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():

--- a/server/parameters/util/YAMLParser.java
+++ b/server/parameters/util/YAMLParser.java
@@ -264,10 +264,10 @@ public class YAMLParser {
                     (yaml) -> yaml.asInt().value(),
                     "<int>"
             );
-            public static final Primitive<Float> FLOAT = new Primitive<>(
-                    (yaml) -> yaml.isFloat(),
-                    (yaml) -> yaml.asFloat().value(),
-                    "<float>"
+            public static final Primitive<Double> DOUBLE = new Primitive<>(
+                    (yaml) -> yaml.isDouble(),
+                    (yaml) -> yaml.asDouble().value(),
+                    "<double>"
             );
             public static final Primitive<Boolean> BOOLEAN = new Primitive<>(
                     (yaml) -> yaml.isBoolean(),


### PR DESCRIPTION
## What is the goal of this PR?

Updated code to incorporate changes made in https://github.com/vaticle/typedb-common/commit/b5475e496002fb8d069e5310b8edbb0dbe723cc5 and bumped dependency.

## What are the changes implemented in this PR?

YAMLParser class now outputs doubles instead of floats.
