### PR TITLE
Make plan linearisation respect native sort

### DIFF
--- a/traversal/planner/PlannerVertex.java
+++ b/traversal/planner/PlannerVertex.java
@@ -19,6 +19,7 @@
 package com.vaticle.typedb.core.traversal.planner;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
+import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.optimiser.OptimiserConstraint;
 import com.vaticle.typedb.core.common.optimiser.OptimiserVariable;
 import com.vaticle.typedb.core.encoding.Encoding;
@@ -80,6 +81,14 @@ public abstract class PlannerVertex<PROPERTIES extends TraversalVertex.Propertie
 
     public boolean hasOutgoingEdges() {
         return iterate(outs()).anyMatch(PlannerEdge.Directional::isSelected);
+    }
+
+    public FunctionalIterator<PlannerEdge.Directional<?, ?>> selectedIns() {
+        return iterate(ins()).filter(PlannerEdge.Directional::isSelected);
+    }
+
+    public FunctionalIterator<PlannerEdge.Directional<?, ?>> selectedOuts() {
+        return iterate(outs()).filter(PlannerEdge.Directional::isSelected);
     }
 
     public int getOrder() {


### PR DESCRIPTION
## What is the goal of this PR?

Query plan linearisation, introduced in #6660, can reorder starting vertices. This can be at odds with native sorting, which expects the variables sorted on to be traversed first, such that we can leverage the fact that the data is stored in a sorted order on disk.

This PR ensures that the linearisation step preserves the native sort vertex ordering.

## What are the changes implemented in this PR?

We skip natively sorted vertices in the linearisation routine.

Closes #6753 