### PR TITLE
Fix rule indexing to include all disjunction branches

### DIFF
--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -151,7 +151,7 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
     void validateDelete() {
         FunctionalIterator<RuleStructure> rules = graphMgr.schema().rules().references().get(vertex);
         if (rules.hasNext()) {
-            throw exception(TypeDBException.of(TYPE_REFERENCED_IN_RULES, getLabel(), rules.toList()));
+            throw exception(TypeDBException.of(TYPE_REFERENCED_IN_RULES, getLabel(), rules.map(RuleStructure::label).toList()));
         }
     }
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,7 +49,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "563c57435f1386e684dc0a0578a773c2aa355307",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "effeda4b1eb36b96f3b9051bef95aa9e2ae9666b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
 )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -50,7 +50,7 @@ def vaticle_typedb_behaviour():
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
         commit = "effeda4b1eb36b96f3b9051bef95aa9e2ae9666b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
-)
+    )
 
 def vaticle_factory_tracing():
     git_repository(


### PR DESCRIPTION
## What is the goal of this PR?
We update the code for indexing usages of types in rules to account for having disjunctions in the `when` clause.

## What are the changes implemented in this PR?
* The indexed collects variables across all branches of the disjunction.
* It previously only considered the first branch, as disjunctions were disabled.