### PR TITLE
Fix the returning of deleted concepts from update queries

### DIFF
--- a/query/Deleter.java
+++ b/query/Deleter.java
@@ -109,7 +109,7 @@ public class Deleter {
     public void execute() {
         try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "execute")) {
             List<? extends ConceptMap> matches = matcher.execute(context).toList();
-            matches.forEach(matched -> new Operation(matched, variables).execute());
+            matches.forEach(matched -> new Operation(matched, variables).executeInPlace());
         }
     }
 
@@ -127,7 +127,7 @@ public class Deleter {
             this.detached = new HashMap<>();
         }
 
-        void execute() {
+        void executeInPlace() {
             try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "execute")) {
                 variables.forEach(this::delete);
                 variables.forEach(this::deleteIsa);
@@ -183,6 +183,7 @@ public class Deleter {
                         if (type.getSupertypes().anyMatch(t -> t.getLabel().equals(typeLabel))) thing.delete();
                         else throw TypeDBException.of(INVALID_DELETE_THING, var.reference(), typeLabel);
                     }
+                    matched.concepts().remove(var.id());
                 }
             }
         }

--- a/query/Updater.java
+++ b/query/Updater.java
@@ -33,7 +33,6 @@ import com.vaticle.typeql.lang.query.TypeQLUpdate;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 
 import static com.vaticle.factory.tracing.client.FactoryTracingThreadStatic.traceOnThread;
 import static com.vaticle.typedb.common.collection.Collections.list;
@@ -89,23 +88,21 @@ public class Updater {
         List<? extends List<? extends ConceptMap>> lists = matcher.execute(context).toLists(PARALLELISATION_SPLIT_MIN, PARALLELISATION_FACTOR);
         assert !lists.isEmpty();
         List<ConceptMap> updates;
-        Function<ConceptMap, ConceptMap> updateFn = (matched) -> {
-            new Deleter.Operation(matched, deleteVariables).execute();
-            return new Inserter.Operation(conceptMgr, matched, insertVariables).execute();
-        };
-        if (lists.size() == 1) updates = iterate(lists.get(0)).map(updateFn::apply).toList();
+        if (lists.size() == 1) updates = iterate(lists.get(0)).map(this::executeUpdate).toList();
         else updates = produce(async(
-                iterate(lists).map(list -> iterate(list).map(updateFn::apply)), PARALLELISATION_FACTOR
+                iterate(lists).map(list -> iterate(list).map(this::executeUpdate)), PARALLELISATION_FACTOR
         ), Either.first(EXHAUSTIVE), async1()).toList();
         return iterate(updates);
     }
 
     private FunctionalIterator<ConceptMap> executeSerial() {
         List<? extends ConceptMap> matches = matcher.execute(context).onError(conceptMgr::exception).toList();
-        List<ConceptMap> answers = iterate(matches).map(matched -> {
-            new Deleter.Operation(matched, deleteVariables).execute();
-            return new Inserter.Operation(conceptMgr, matched, insertVariables).execute();
-        }).toList();
+        List<ConceptMap> answers = iterate(matches).map(this::executeUpdate).toList();
         return iterate(answers);
+    }
+
+    private ConceptMap executeUpdate(ConceptMap matched) {
+        new Deleter.Operation(matched, deleteVariables).executeInPlace();
+        return new Inserter.Operation(conceptMgr, matched, insertVariables).execute();
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

We fix update queries to no longer be able to return concepts that have been deleted. In general, TypeDB should never return deleted concepts back to the user.

## What are the changes implemented in this PR?

* Update operator uses the Delete operator which in turn executes the delete and modifies the ConceptMap in-place

Note: this is a non-ideal change, but efficient. In the future we should support ConceptMap zero-copy views and extensions.