### PR TITLE
Reasoner planner add multiplicative cost to all calls costing

### DIFF
--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -229,7 +229,8 @@ public class AnswerCountEstimator {
         }
 
         public double answerSetSize() {
-            return answerEstimate(iterate(minVariableEstimate.keySet()).filter(v -> !v.reference().isAnonymous()).toSet());
+            // TODO: ignore the anonymous variables iff/when ConjunctionController can ignore them when branching CompoundStreams
+            return answerEstimate(minVariableEstimate.keySet());
         }
 
         private static double scaledEstimate(LocalModel model, Pair<Double, Optional<Variable>> scale, Set<Variable> estimateVariables) {

--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -229,7 +229,7 @@ public class AnswerCountEstimator {
         }
 
         public double answerSetSize() {
-            return answerEstimate(minVariableEstimate.keySet());
+            return answerEstimate(iterate(minVariableEstimate.keySet()).filter(v -> !v.reference().isAnonymous()).toSet());
         }
 
         private static double scaledEstimate(LocalModel model, Pair<Double, Optional<Variable>> scale, Set<Variable> estimateVariables) {

--- a/reasoner/planner/AnswerCountEstimator.java
+++ b/reasoner/planner/AnswerCountEstimator.java
@@ -709,7 +709,7 @@ public class AnswerCountEstimator {
                             double replacementForInferred = !inferredRolePlayers.isEmpty() ? inferredEstimateForThisBranch : 1.0;
 
                             // All possible combinations (of non-recursive players) assumes full-connectivity, producing an unrealistically large/worst-case estimate.
-                            // We take the square root of all possible combinations as a more realistic estimate.
+                            // Instead, we model each role-player as being recursively related to sqrt(|r_i|) instances of each other role-player r_i.
                             Set<Variable> nonRecursivePlayers = iterate(ruleSideVariables).filter(v -> !recursivePlayers.contains(v)).toSet();
                             double estimateForNonRecursivePlayers = answerCountEstimator.estimateAnswers(conditionBranch.conjunction(), nonRecursivePlayers);
                             double rootOfAll = Math.max(1.0, Math.sqrt(iterate(typeBasedEstimateForRecursivePlayer.values()).reduce(replacementForInferred, (x,y) -> x * y)));

--- a/reasoner/planner/OrderingCoster.java
+++ b/reasoner/planner/OrderingCoster.java
@@ -101,7 +101,7 @@ public class OrderingCoster {
                 disconnectedCost += resolvableCost;
             }
             // Traversal cost - DFS style permutative work
-            acyclicCost += estimator.answerSetSize() * RELATIVE_COST_ANSWER_COMBINATION;;
+            acyclicCost += estimator.answerSetSize() * RELATIVE_COST_ANSWER_COMBINATION;
 
             if (!resolvable.isNegated()) {
                 boundVars.addAll(resolvableVars);

--- a/reasoner/planner/OrderingCoster.java
+++ b/reasoner/planner/OrderingCoster.java
@@ -100,8 +100,8 @@ public class OrderingCoster {
             } else {
                 disconnectedCost += resolvableCost;
             }
-            // TODO: Add permutative traversal cost as below. (Needs to be uncommented and tested)
-            // acyclicCost += estimator.answerEstimate(boundVars);
+            // Traversal cost - DFS style permutative work
+            acyclicCost += estimator.answerSetSize() * RELATIVE_COST_ANSWER_COMBINATION;;
 
             if (!resolvable.isNegated()) {
                 boundVars.addAll(resolvableVars);

--- a/test/integration/reasoner/planner/AnswerCountEstimatorTest.java
+++ b/test/integration/reasoner/planner/AnswerCountEstimatorTest.java
@@ -550,10 +550,8 @@ public class AnswerCountEstimatorTest {
         {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{(friendor: $x, friendee: $y) isa transitive-friendship; }", transaction.logic()));
             double answers = answerCountEstimator.estimateAnswers(conjunction, getVariablesByName(conjunction.pattern(), set("x", "y")));
-            assertEquals(8.0, answers);
-            // 8 = 3 + min(sqrt(5 * 5),  3 * 5)  =  3 from rule-1 (coplayer) +  min(   from rule-2
-            //                                                                       sqrt(5 * 5), ($f1.unary(type) * f2.unary(type)
-            //                                                                       3 * 5  ($f1.unary(rp) * $f2.unary(type))
+            assertEquals(18.0, answers);
+            // 18 = 3 + 3 * 5  =  3 from rule-1 (coplayer) +  3 * 5  ($f1.unary(rp) * $f2.unary(type))  from rule-2
         }
 
         {
@@ -573,27 +571,51 @@ public class AnswerCountEstimatorTest {
     public void test_cycles_same_type_transitive() {
         initialise(Arguments.Session.Type.SCHEMA, Arguments.Transaction.Type.WRITE);
         transaction.query().define(TypeQL.parseQuery("define " +
-                "rule friendship-iteself-is-transitive: " +
+                "rule friendship-itself-is-transitive: " +
                 "when { (friendor: $f1, friendee: $f2) isa friendship; (friendor: $f2, friendee: $f3) isa friendship;  } " +
                 "then { (friendor: $f1, friendee: $f3) isa friendship; };"));
         transaction.commit();
         session.close();
 
         initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
-        AnswerCountEstimator answerCountEstimator = new AnswerCountEstimator(transaction.logic(), transaction.traversal().graph(), new ConjunctionGraph(transaction.logic()));
         {
+            AnswerCountEstimator answerCountEstimator = new AnswerCountEstimator(transaction.logic(), transaction.traversal().graph(), new ConjunctionGraph(transaction.logic()));
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{$r (friendor: $x, friendee: $y) isa friendship; }", transaction.logic()));
 
             double answers = answerCountEstimator.estimateAnswers(conjunction, getVariablesByName(conjunction.pattern(), set("x", "y")));
-            assertEquals(8.0, answers);
-            // 8 = sqrt(5 * 5) + 3  = reachability estimate + retrieved count
+            assertEquals(25.0, answers);
+            // 25 = 5 * 5 = $x-unary(type) from ; $y-unary(type);   The multivar estimates aren't used because they are 3 + 25
 
             double answers1 = answerCountEstimator.estimateAnswers(conjunction, getVariablesByName(conjunction.pattern(), set("r", "x", "y")));
-            assertEquals(8.0, answers1); // Still exceeds the types.
-            // 8 = sqrt(5 * 5) + 3  = reachability estimate + retrieved count
+            assertEquals(25.0, answers1); // Still exceeds the types.
 
             double answers2 = answerCountEstimator.estimateAnswers(conjunction, getVariablesByName(conjunction.pattern(), set("r")));
-            assertEquals(8.0, answers2);
+            assertEquals(25.0, answers2);
+        }
+        transaction.close();
+
+        // Add a friendship and verify the upper bound kicks in.
+        initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.WRITE);
+        transaction.query().insert(TypeQL.parseQuery("insert " +
+                "$p5 isa person, has first-name \"p5_f\";\n" +
+                "$p6 isa person, has first-name \"p6_f\";\n" +
+                "(friendor: $p5, friendee: $p6) isa friendship;"));
+        transaction.commit();
+
+        initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
+        {
+            AnswerCountEstimator answerCountEstimator = new AnswerCountEstimator(transaction.logic(), transaction.traversal().graph(), new ConjunctionGraph(transaction.logic()));
+            ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{$r (friendor: $x, friendee: $y) isa friendship; }", transaction.logic()));
+
+            double answers = answerCountEstimator.estimateAnswers(conjunction, getVariablesByName(conjunction.pattern(), set("x", "y")));
+            assertEquals(42.0, answers);
+            //  = 4 + 6 * sqrt(6) ; from persisted + inferred-upper-bounded
+
+            double answers1 = answerCountEstimator.estimateAnswers(conjunction, getVariablesByName(conjunction.pattern(), set("r", "x", "y")));
+            assertEquals(42.0, answers1);
+
+            double answers2 = answerCountEstimator.estimateAnswers(conjunction, getVariablesByName(conjunction.pattern(), set("r")));
+            assertEquals(42.0, answers2);
         }
     }
 
@@ -638,14 +660,13 @@ public class AnswerCountEstimatorTest {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{(friendor: $x, friendee: $y) isa transitive-friendship; }", transaction.logic()));
 
             double answers = answerCountEstimator.estimateAnswers(conjunction, getVariablesByName(conjunction.pattern(), set("x", "y")));
-            assertEquals(13.0, answers);  // Costs are dominated by types. This test mainly tests the ability to handle nested loops
-            // 13 = 3 (rule 1) + sqrt(5*5) (rule 2) + sqrt(5*5) (rule 5)
+            assertEquals(25.0, answers);  // Costs are dominated by types. This test mainly tests the ability to handle nested loops
         }
         {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{(guest: $x, host: $y) isa can-live-with; }", transaction.logic()));
 
             double answers = answerCountEstimator.estimateAnswers(conjunction, getVariablesByName(conjunction.pattern(), set("x", "y")));
-            assertEquals(9.0, answers);  // 4 (rule 3) + (sqrt(5*5) rule 4)
+            assertEquals(25.0, answers);  // Costs are dominated by types. This test mainly tests the ability to handle nested loops
         }
     }
 

--- a/test/integration/reasoner/planner/AnswerCountEstimatorTest.java
+++ b/test/integration/reasoner/planner/AnswerCountEstimatorTest.java
@@ -660,7 +660,7 @@ public class AnswerCountEstimatorTest {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{(friendor: $x, friendee: $y) isa transitive-friendship; }", transaction.logic()));
 
             double answers = answerCountEstimator.estimateAnswers(conjunction, getVariablesByName(conjunction.pattern(), set("x", "y")));
-            assertEquals(25.0, answers);  // Costs are dominated by types. This test mainly tests the ability to handle nested loops
+             assertEquals(25.0, answers);  // Costs are dominated by types. This test mainly tests the ability to handle nested loops
         }
         {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{(guest: $x, host: $y) isa can-live-with; }", transaction.logic()));

--- a/test/integration/reasoner/planner/RecursivePlannerTest.java
+++ b/test/integration/reasoner/planner/RecursivePlannerTest.java
@@ -42,6 +42,8 @@ import static com.vaticle.typedb.core.common.collection.Bytes.MB;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 
+// TODO: Either recompute for the updated cost model or delete when we have a reasoner benchmark
+@Ignore
 public class RecursivePlannerTest {
 
     private static final Path dataDir = Paths.get(System.getProperty("user.dir")).resolve("recursive-por-planner-test");
@@ -193,8 +195,7 @@ public class RecursivePlannerTest {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{(friendor: $x, friendee: $y) isa transitive-friendship; }", transaction.logic()));
             planSpaceSearch.plan(conjunction, set());
             ReasonerPlanner.Plan plan = planSpaceSearch.getPlan(conjunction, set());
-            assertTrue(45.0 > plan.allCallsCost());
-            // TODO: Update or delete. For now, we assert the cost is less than the cost we calculated with the n^2 transitivity
+            assertEquals(45.0, plan.allCallsCost());
             // Answercount($x,$y) = 18
             // Answercount($x) = Answercount($y) = 5
             // Cost = (18) query + (3) rule1{} + (24) rule2{}
@@ -229,8 +230,7 @@ public class RecursivePlannerTest {
 
             planSpaceSearch.plan(conjunction, set());
             ReasonerPlanner.Plan plan = planSpaceSearch.getPlan(conjunction, set());
-            // TODO: Update or delete. For now, we assert the cost is less than the cost we calculated with the n^2 transitivity
-            assertTrue(125.0 > plan.allCallsCost());
+            assertEquals(125.0, plan.allCallsCost());
             // LocalCost = AnswerCount( $_0, $x, $y ) = 25
             // AnswerCount($x) = AnswerCount($y) = 5
             // Cost = (25 + 1 * rule{} + * 5/5 rule{f1}) = 25 + 1 * 50 + 5/5 * 50 = 125     [ = (25 + 1 * rule{} + 5/5 * rule{f2}) ]
@@ -252,7 +252,6 @@ public class RecursivePlannerTest {
         }
     }
 
-    @Ignore
     @Test
     public void test_nested_cycles() {
         // the example may not make sense.
@@ -329,8 +328,7 @@ public class RecursivePlannerTest {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{$x has name \"Jim\"; (friendor: $x, friendee: $y) isa transitive-friendship; }", transaction.logic()));
             planner.plan(conjunction, set());
             ReasonerPlanner.Plan plan = planner.getPlan(conjunction, set());
-            // TODO: Update or delete. For now, we assert the cost is less than the cost we calculated with the n^2 transitivity
-            assertTrue(18.0 > plan.allCallsCost());
+            assertEquals(18.0, plan.allCallsCost());
             // Answercount($x) = 1; Answercount($y) = 5
             // Cost = 18 = (1 + 1/5 * 18) query + 1/5 * (3) rule1{$x:1} + min(1, (1/5+3/5) ) * (16) rule2{$x:1}
             //           = 3.6 + 0.6 + 13.8
@@ -341,8 +339,7 @@ public class RecursivePlannerTest {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{$y has name \"Jim\"; (friendor: $x, friendee: $y) isa transitive-friendship; }", transaction.logic()));
             planner.plan(conjunction, set());
             ReasonerPlanner.Plan plan = planner.getPlan(conjunction, set());
-            // TODO: Update or delete. For now, we assert the cost is less than the cost we calculated with the n^2 transitivity
-            assertTrue(10.0 > plan.allCallsCost());
+            assertEquals(10.0, plan.allCallsCost());
             // Answercount($x,$y) = 5
             // Answercount($x) = 3; Answercount($y) = 1
             // Cost = 15 = (8) query + min(1,5/3) * (3) rule1{$y:1} + (0 + 1/5) * (21) rule2{$y:1}

--- a/test/integration/reasoner/planner/RecursivePlannerTest.java
+++ b/test/integration/reasoner/planner/RecursivePlannerTest.java
@@ -30,7 +30,6 @@ import com.vaticle.typedb.core.test.integration.util.Util;
 import com.vaticle.typeql.lang.TypeQL;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -42,8 +41,6 @@ import static com.vaticle.typedb.core.common.collection.Bytes.MB;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 
-// TODO: Either recompute for the updated cost model or delete when we have a reasoner benchmark
-@Ignore
 public class RecursivePlannerTest {
 
     private static final Path dataDir = Paths.get(System.getProperty("user.dir")).resolve("recursive-por-planner-test");
@@ -111,7 +108,7 @@ public class RecursivePlannerTest {
         ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{ $p isa person; }", transaction.logic()));
         planSpaceSearch.plan(conjunction, set());
         ReasonerPlanner.Plan plan = planSpaceSearch.getPlan(conjunction, set());
-        assertEquals(5.0, plan.allCallsCost()); // For now the retrieval cost is just the answer-count
+        assertEquals(10.0, plan.allCallsCost()); // For now the retrieval cost is just the answer-count
     }
 
     @Test
@@ -124,21 +121,21 @@ public class RecursivePlannerTest {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{ $p isa man, has name $n; }", transaction.logic()));
             planSpaceSearch.plan(conjunction, set());
             ReasonerPlanner.Plan plan = planSpaceSearch.getPlan(conjunction, set());
-            assertEquals(3.0, plan.allCallsCost());
+            assertEquals(6.0, plan.allCallsCost());
         }
 
         {   // Query count of both variables $p and $n, where $p isa! person
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{ $p isa! person, has name $n; }", transaction.logic()));
             planSpaceSearch.plan(conjunction, set());
             ReasonerPlanner.Plan plan = planSpaceSearch.getPlan(conjunction, set());
-            assertEquals(2.0, plan.allCallsCost());
+            assertEquals(4.0, plan.allCallsCost());
         }
 
         {   // Query count of both variables $p and $n, where $p isa person (and subtypes)
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{ $p isa person, has name $n; }", transaction.logic()));
             planSpaceSearch.plan(conjunction, set());
             ReasonerPlanner.Plan plan = planSpaceSearch.getPlan(conjunction, set());
-            assertEquals(5.0, plan.allCallsCost());
+            assertEquals(10.0, plan.allCallsCost());
         }
     }
 
@@ -158,16 +155,14 @@ public class RecursivePlannerTest {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{ $p has name $n; }", transaction.logic()));
             planSpaceSearch.plan(conjunction, set());
             ReasonerPlanner.Plan plan = planSpaceSearch.getPlan(conjunction, set());
-            assertEquals(15.0, plan.allCallsCost()); // = (10)localCost + (5)costOfRule = 15
+            assertEquals(30.0, plan.allCallsCost());
         }
 
         {
-            // Plan: {$p has name $n} -> { (...) isa friendship;} } :  1 * (10 + 5) + min(1,5/3) * 3 = 18
-            // Plan: { (...) isa friendship;} -> {$p has name $n} } :  1 * 3  + min(1, 3/5) * (10 + 5) = 12
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{ $p has name $n; (friendor: $p, friendee: $f) isa friendship; }", transaction.logic()));
             planSpaceSearch.plan(conjunction, set());
             ReasonerPlanner.Plan plan = planSpaceSearch.getPlan(conjunction, set());
-            assertEquals(12.0, plan.allCallsCost());
+            assertEquals(36.0, plan.allCallsCost());
         }
     }
 
@@ -195,21 +190,7 @@ public class RecursivePlannerTest {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{(friendor: $x, friendee: $y) isa transitive-friendship; }", transaction.logic()));
             planSpaceSearch.plan(conjunction, set());
             ReasonerPlanner.Plan plan = planSpaceSearch.getPlan(conjunction, set());
-            assertEquals(45.0, plan.allCallsCost());
-            // Answercount($x,$y) = 18
-            // Answercount($x) = Answercount($y) = 5
-            // Cost = (18) query + (3) rule1{} + (24) rule2{}
-            // rule1{}: Acyclic-cost = 3 regardless of plan, (Acyclic -> added into the acyclic costs of callers)
-            // rule2{}:
-            //      Plan: {(...) isa friendship;} -> {(...) isa transitive-friendship;}
-            //          Acyclic-cost : 1 * 3 + (3/5) * 21 = 15.6;
-            //          CyclicConcludables -> ScalingFactor: { rule2{$f1}: : 3/5}
-            //      Plan: {(...) isa transitive-friendship;} -> {(...) isa friendship;}
-            //          Acyclic-cost : 1 * 21 + min(1, 5/3) * 3 = 24
-            //          CyclicConcludables -> ScalingFactor: { rule2{}: 1 }
-            //      Both candidate orderings)
-            //      (rule2 used to be 21 when we didn't discern between acyclic/cyclic dependencies
-
+            assertEquals(120.0, plan.allCallsCost());
         }
     }
 
@@ -217,7 +198,7 @@ public class RecursivePlannerTest {
     public void test_cycles_same_type_transitive() {
         initialise(Arguments.Session.Type.SCHEMA, Arguments.Transaction.Type.WRITE);
         transaction.query().define(TypeQL.parseQuery("define " +
-                "rule friendship-iteself-is-transitive: " +
+                "rule friendship-itself-is-transitive: " +
                 "when { (friendor: $f1, friendee: $f2) isa friendship; (friendor: $f2, friendee: $f3) isa friendship;  } " +
                 "then { (friendor: $f1, friendee: $f3) isa friendship; };"));
         transaction.commit();
@@ -230,25 +211,7 @@ public class RecursivePlannerTest {
 
             planSpaceSearch.plan(conjunction, set());
             ReasonerPlanner.Plan plan = planSpaceSearch.getPlan(conjunction, set());
-            assertEquals(125.0, plan.allCallsCost());
-            // LocalCost = AnswerCount( $_0, $x, $y ) = 25
-            // AnswerCount($x) = AnswerCount($y) = 5
-            // Cost = (25 + 1 * rule{} + * 5/5 rule{f1}) = 25 + 1 * 50 + 5/5 * 50 = 125     [ = (25 + 1 * rule{} + 5/5 * rule{f2}) ]
-            // rule{}:
-            //      Plan: f12 -> f23
-            //          AcyclicCost: 1 * 25 + 5/5 * 25 = 50
-            //          CyclicConcludables: { rule{}: 1, rule{f1}: 1 }
-            //      Plan: f23 -> f12
-            //          AcyclicCost: 1 * 25 + 5/5 * 25 = 50
-            //          CyclicConcludables: { rule{}: 1, rule{f2}: 1 }
-            // rule{f1}:
-            //      Plan: f12 -> f23
-            //          AcyclicCost: 1 * 25 + 5/5 * 25 = 50
-            //          CyclicConcludables: { rule{f1}: 1}
-            // rule{f2}:
-            //      Plan: f23 -> f12
-            //          AcyclicCost: 1 * 25 + 5/5 * 25 = 50
-            //          CyclicConcludables: { rule{f2}: 1}
+            assertEquals(429.0, plan.allCallsCost());
         }
     }
 
@@ -328,22 +291,14 @@ public class RecursivePlannerTest {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{$x has name \"Jim\"; (friendor: $x, friendee: $y) isa transitive-friendship; }", transaction.logic()));
             planner.plan(conjunction, set());
             ReasonerPlanner.Plan plan = planner.getPlan(conjunction, set());
-            assertEquals(18.0, plan.allCallsCost());
-            // Answercount($x) = 1; Answercount($y) = 5
-            // Cost = 18 = (1 + 1/5 * 18) query + 1/5 * (3) rule1{$x:1} + min(1, (1/5+3/5) ) * (16) rule2{$x:1}
-            //           = 3.6 + 0.6 + 13.8
-            // With plan(rule2{$x}) = { (...) isa friendship; } -> { (...) isa transitive-friendship; }
+            assertEquals(46.0, plan.allCallsCost());
         }
 
         {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{$y has name \"Jim\"; (friendor: $x, friendee: $y) isa transitive-friendship; }", transaction.logic()));
             planner.plan(conjunction, set());
             ReasonerPlanner.Plan plan = planner.getPlan(conjunction, set());
-            assertEquals(10.0, plan.allCallsCost());
-            // Answercount($x,$y) = 5
-            // Answercount($x) = 3; Answercount($y) = 1
-            // Cost = 15 = (8) query + min(1,5/3) * (3) rule1{$y:1} + (0 + 1/5) * (21) rule2{$y:1}
-            // With plan(rule2{$x}) = { (...) isa transitive-friendship; } -> { (...) isa friendship; }
+            assertEquals(27.0, plan.allCallsCost());
         }
     }
 

--- a/test/integration/reasoner/planner/RecursivePlannerTest.java
+++ b/test/integration/reasoner/planner/RecursivePlannerTest.java
@@ -211,7 +211,7 @@ public class RecursivePlannerTest {
 
             planSpaceSearch.plan(conjunction, set());
             ReasonerPlanner.Plan plan = planSpaceSearch.getPlan(conjunction, set());
-            assertEquals(429.0, plan.allCallsCost());
+            assertEquals(1377.0, plan.allCallsCost());
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
Add the multiplicative cost of combining the answers to the all-calls costing used in the rule-graph planning

## What are the changes implemented in this PR?
Following up on #6783, we have seen improvements in the TypeDB IAM examples when adding the multiplicative component to the all calls costing. This PR:
* Adds the multiplicative "traversal cost" to the all calls costing
* `@Ignore`s the RecursivePlannerTest since the costs are no longer correct.