### PR TITLE
Throw exception when attribute value type is modified

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -472,7 +472,7 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final TypeWrite ATTRIBUTE_VALUE_TYPE_MISSING =
                 new TypeWrite(14, "The attribute type '%s' is missing a value type.");
         public static final TypeWrite ATTRIBUTE_VALUE_TYPE_MODIFIED =
-                new TypeWrite(15, "An attribute value type (in this case '%s') can only be set onto an attribute type (in this case '%s') when it was defined for the first time.");
+                new TypeWrite(15, "An attribute value type (in this case '%s') can only be set onto an attribute type (in this case '%s') when it is defined for the first time.");
         public static final TypeWrite ATTRIBUTE_VALUE_TYPE_UNDEFINED =
                 new TypeWrite(16, "An attribute value type (in this case '%s') cannot be undefined. You can only undefine the attribute type (in this case '%s') itself.");
         public static final TypeWrite ATTRIBUTE_UNSET_ABSTRACT_HAS_SUBTYPES =

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,7 +49,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "c75c64d42725163e62078218207efbcb2b5ed845",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "563c57435f1386e684dc0a0578a773c2aa355307",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
 )
 
 def vaticle_factory_tracing():

--- a/query/Definer.java
+++ b/query/Definer.java
@@ -195,7 +195,7 @@ public class Definer {
                 else if (!supertype.isRoot()) valueType = supertype.asAttributeType().getValueType();
                 else throw TypeDBException.of(ATTRIBUTE_VALUE_TYPE_MISSING, labelConstraint.label());
                 if (thingType == null) thingType = conceptMgr.putAttributeType(labelConstraint.label(), valueType);
-                else if (supertype.isRoot() && !valueType.equals(thingType.asAttributeType().getValueType())) {
+                else if (!valueType.equals(thingType.asAttributeType().getValueType())) {
                     throw TypeDBException.of(ATTRIBUTE_VALUE_TYPE_MODIFIED, valueType, labelConstraint.label());
                 }
                 thingType.asAttributeType().setSupertype(supertype.asAttributeType());

--- a/query/Definer.java
+++ b/query/Definer.java
@@ -195,6 +195,9 @@ public class Definer {
                 else if (!supertype.isRoot()) valueType = supertype.asAttributeType().getValueType();
                 else throw TypeDBException.of(ATTRIBUTE_VALUE_TYPE_MISSING, labelConstraint.label());
                 if (thingType == null) thingType = conceptMgr.putAttributeType(labelConstraint.label(), valueType);
+                else if (supertype.isRoot() && !valueType.equals(thingType.asAttributeType().getValueType())) {
+                    throw TypeDBException.of(ATTRIBUTE_VALUE_TYPE_MODIFIED, valueType, labelConstraint.label());
+                }
                 thingType.asAttributeType().setSupertype(supertype.asAttributeType());
             } else {
                 throw TypeDBException.of(INVALID_DEFINE_SUB, labelConstraint.scopedLabel(), supertype.getLabel());

--- a/test/behaviour/reasoner/BUILD
+++ b/test/behaviour/reasoner/BUILD
@@ -43,10 +43,6 @@ host_compatible_java_library(
         "@maven//:junit_junit",
         "@maven//:io_cucumber_cucumber_java",
     ],
-    runtime_deps = [
-        "//test/behaviour/connection/database:steps",
-        "//test/behaviour/connection/transaction:steps",
-    ],
     visibility = ["//visibility:public"],
 )
 

--- a/test/behaviour/reasoner/ReasonerSteps.java
+++ b/test/behaviour/reasoner/ReasonerSteps.java
@@ -66,15 +66,6 @@ public class ReasonerSteps {
     private static TypeQLMatch typeQLQuery;
     private static List<? extends ConceptMap> answers;
 
-    @Before
-    public synchronized void before() throws IOException {
-        assertNull(databaseMgr);
-        resetDirectory();
-        System.out.println("Connecting to TypeDB ...");
-        databaseMgr = CoreDatabaseManager.open(options);
-        databaseMgr.create(DATABASE);
-    }
-
     @After
     public synchronized void after() {
         if (reasoningTx != null) reasoningTx.close();
@@ -107,6 +98,20 @@ public class ReasonerSteps {
             if (reasoningTx.isOpen()) reasoningTx.close();
             reasoningTx = null;
         }
+    }
+
+    @Given("typedb starts")
+    public void typedb_starts() throws IOException {
+        assertNull(databaseMgr);
+        resetDirectory();
+        System.out.println("Connecting to TypeDB ...");
+        databaseMgr = CoreDatabaseManager.open(options);
+        databaseMgr.create(DATABASE);
+    }
+
+    @Given("open connection")
+    public void open_connection() {
+        // noop
     }
 
     @Given("reasoning schema")

--- a/test/behaviour/reasoner/tests/attribute_attachment/BUILD
+++ b/test/behaviour/reasoner/tests/attribute_attachment/BUILD
@@ -29,8 +29,6 @@ java_test(
         "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection:steps",
-        "//test/behaviour/connection/session:steps",
         "//test/behaviour/config:parameters",
         "//test/behaviour/reasoner:steps",
     ],

--- a/test/behaviour/reasoner/tests/compound_queries/BUILD
+++ b/test/behaviour/reasoner/tests/compound_queries/BUILD
@@ -29,8 +29,6 @@ java_test(
         "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection:steps",
-        "//test/behaviour/connection/session:steps",
         "//test/behaviour/config:parameters",
         "//test/behaviour/reasoner:steps",
     ],

--- a/test/behaviour/reasoner/tests/concept_inequality/BUILD
+++ b/test/behaviour/reasoner/tests/concept_inequality/BUILD
@@ -29,8 +29,6 @@ java_test(
         "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection:steps",
-        "//test/behaviour/connection/session:steps",
         "//test/behaviour/config:parameters",
         "//test/behaviour/reasoner:steps",
     ],

--- a/test/behaviour/reasoner/tests/negation/BUILD
+++ b/test/behaviour/reasoner/tests/negation/BUILD
@@ -29,8 +29,6 @@ java_test(
         "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection:steps",
-        "//test/behaviour/connection/session:steps",
         "//test/behaviour/config:parameters",
         "//test/behaviour/reasoner:steps",
     ],

--- a/test/behaviour/reasoner/tests/recursion/BUILD
+++ b/test/behaviour/reasoner/tests/recursion/BUILD
@@ -29,8 +29,6 @@ java_test(
         "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection:steps",
-        "//test/behaviour/connection/session:steps",
         "//test/behaviour/config:parameters",
         "//test/behaviour/reasoner:steps",
     ],

--- a/test/behaviour/reasoner/tests/relation_inference/BUILD
+++ b/test/behaviour/reasoner/tests/relation_inference/BUILD
@@ -29,8 +29,6 @@ java_test(
         "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection:steps",
-        "//test/behaviour/connection/session:steps",
         "//test/behaviour/config:parameters",
         "//test/behaviour/reasoner:steps",
     ],

--- a/test/behaviour/reasoner/tests/rule_interaction/BUILD
+++ b/test/behaviour/reasoner/tests/rule_interaction/BUILD
@@ -29,8 +29,6 @@ java_test(
         "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection:steps",
-        "//test/behaviour/connection/session:steps",
         "//test/behaviour/config:parameters",
         "//test/behaviour/reasoner:steps",
     ],

--- a/test/behaviour/reasoner/tests/schema_queries/BUILD
+++ b/test/behaviour/reasoner/tests/schema_queries/BUILD
@@ -29,8 +29,6 @@ java_test(
         "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection:steps",
-        "//test/behaviour/connection/session:steps",
         "//test/behaviour/config:parameters",
         "//test/behaviour/reasoner:steps",
     ],

--- a/test/behaviour/reasoner/tests/type_hierarchy/BUILD
+++ b/test/behaviour/reasoner/tests/type_hierarchy/BUILD
@@ -29,8 +29,6 @@ java_test(
         "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection:steps",
-        "//test/behaviour/connection/session:steps",
         "//test/behaviour/config:parameters",
         "//test/behaviour/reasoner:steps",
     ],

--- a/test/behaviour/reasoner/tests/value_predicate/BUILD
+++ b/test/behaviour/reasoner/tests/value_predicate/BUILD
@@ -29,8 +29,6 @@ java_test(
         "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection:steps",
-        "//test/behaviour/connection/session:steps",
         "//test/behaviour/config:parameters",
         "//test/behaviour/reasoner:steps",
     ],

--- a/test/behaviour/reasoner/tests/variable_roles/BUILD
+++ b/test/behaviour/reasoner/tests/variable_roles/BUILD
@@ -30,8 +30,6 @@ java_test(
         "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection:steps",
-        "//test/behaviour/connection/session:steps",
         "//test/behaviour/config:parameters",
         "//test/behaviour/reasoner:steps",
     ],


### PR DESCRIPTION
## What is the goal of this PR?
Throw an exception when a `define` query attempts to modify the an existing the attribute type with a different value type.

## What are the changes implemented in this PR?
* Throw an exception when a `define` query attempts to modify the redefine the attribute type with a different value type.

- fixes #6789 
