### PR TITLE
Simplify rule export formatting

### DIFF
--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -247,14 +247,10 @@ public class LogicManager {
     static class RuleExporter {
 
         static void writeRule(StringBuilder builder, Rule rule) {
-            builder.append(String.format("rule %s:\n", rule.getLabel()))
-                    .append(StringBuilders.indent(1))
-                    .append("when\n")
-                    .append(getPatternString(wrapConjunction(rule.getWhenPreNormalised()), 1))
-                    .append("\n")
-                    .append(StringBuilders.indent(1))
-                    .append("then\n")
-                    .append(getPatternString(wrapConjunction(rule.getThenPreNormalised()), 1))
+            builder.append(String.format("rule %s: when ", rule.getLabel()))
+                    .append(getPatternString(wrapConjunction(rule.getWhenPreNormalised()), 0))
+                    .append(" then ")
+                    .append(getPatternString(wrapConjunction(rule.getThenPreNormalised()), 0))
                     .append(StringBuilders.SEMICOLON_NEWLINE_X2);
         }
 
@@ -268,8 +264,8 @@ public class LogicManager {
                 pattern.asConjunction().patterns().forEach(p -> builder
                         .append(getPatternString(p, indent + 1))
                         .append(";\n"));
-                builder.append(StringBuilders.indent(indent))
-                        .append("}");
+                builder.append(StringBuilders.indent(indent));
+                builder.append("}");
                 return builder.toString();
             } else if (pattern.isDisjunction()) {
                 return pattern.asDisjunction().patterns().stream()

--- a/test/integration/migrator/schema.tql
+++ b/test/integration/migrator/schema.tql
@@ -530,13 +530,9 @@ user sub entity,
     plays repo-owner:owner,
     plays team-member:member;
 
-rule performance-trace-rule:
-    when
-    {
-        (analysis: $x, trace: $y) isa performance-trace;
-        (parent: $y, child: $z) isa trace-tree;
-    }
-    then
-    {
-        (analysis: $x, trace: $z) isa performance-trace;
-    };
+rule performance-trace-rule: when {
+    (analysis: $x, trace: $y) isa performance-trace;
+    (parent: $y, child: $z) isa trace-tree;
+} then {
+    (analysis: $x, trace: $z) isa performance-trace;
+};


### PR DESCRIPTION
## What is the goal of this PR?

We reformat rule formatting in schema exports.

Previously, they looked like this:
```
rule conjunction:
    when
    {
        ...;
    }
    then
    {
        ...;
    };

rule disjunction:
    when
    {
        ...;
        {
            ...;
        }
        or
        {
            ...;
        };
    }
    then
    {
        ...;
    };

rule negation:
    when
    {
        ...;
        not
        {
            ...;
        };
    }
    then
    {
        ...;
    };
```

Now, they will look like this:
```
rule conjunction: when {
    ...;
} then {
    ...;
};

rule disjunction: when {
    ...;
    {
        ...;
    }
    or
    {
        ...;
    };
} then {
    ...
};

rule negation: when {
    ...;
    not
    {
        ...;
    };
} then {
    ...;
};
```

This is both shorter and makes it easier to find where the semicolon corresponding to the end of a rule definition is.


## What are the changes implemented in this PR?

* Update the rule export formatter
