### PR TITLE
Implement fast termination for reasoner

### DIFF
--- a/concurrent/actor/Actor.java
+++ b/concurrent/actor/Actor.java
@@ -17,9 +17,6 @@
 
 package com.vaticle.typedb.core.concurrent.actor;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Optional;
@@ -62,8 +59,6 @@ public abstract class Actor<ACTOR extends Actor<ACTOR>> {
     }
 
     public static class Driver<ACTOR extends Actor<ACTOR>> {
-
-        private static final Logger LOG = LoggerFactory.getLogger(Driver.class);
 
         private static final String ERROR_ACTOR_NOT_SETUP =
                 "Attempting to access the Actor, but it is not yet setup. " +

--- a/concurrent/actor/Actor.java
+++ b/concurrent/actor/Actor.java
@@ -82,18 +82,19 @@ public abstract class Actor<ACTOR extends Actor<ACTOR>> {
             return actor.debugName();
         }
 
-        public void terminate(@Nullable Throwable cause) {
-            if (!actor.isTerminated) {
-                executor.submitPreemptive(() -> actor.terminate(cause), (error) -> {
-                    LOG.error("Exception while terminating actor", error);
-                });
-            }
-        }
-
         public void execute(Consumer<ACTOR> consumer) {
             assert actor != null : ERROR_ACTOR_NOT_SETUP;
             if (!actor.isTerminated) {
                 executor.submit(() -> {
+                    if (!actor.isTerminated) consumer.accept(actor);
+                }, actor::exception);
+            }
+        }
+
+        public void executePreemptive(Consumer<ACTOR> consumer) {
+            assert actor != null : ERROR_ACTOR_NOT_SETUP;
+            if (!actor.isTerminated) {
+                executor.submitPreemptive(() -> {
                     if (!actor.isTerminated) consumer.accept(actor);
                 }, actor::exception);
             }

--- a/concurrent/actor/Actor.java
+++ b/concurrent/actor/Actor.java
@@ -91,10 +91,10 @@ public abstract class Actor<ACTOR extends Actor<ACTOR>> {
             }
         }
 
-        public void executePreemptive(Consumer<ACTOR> consumer) {
+        public void executeNext(Consumer<ACTOR> consumer) {
             assert actor != null : ERROR_ACTOR_NOT_SETUP;
             if (!actor.isTerminated) {
-                executor.submitPreemptive(() -> {
+                executor.submitFirst(() -> {
                     if (!actor.isTerminated) consumer.accept(actor);
                 }, actor::exception);
             }

--- a/concurrent/actor/ActorExecutor.java
+++ b/concurrent/actor/ActorExecutor.java
@@ -27,7 +27,6 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.concurrent.BlockingDeque;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -81,7 +80,7 @@ public class ActorExecutor {
         submittedTasks.offer(new Task(runnable, errorHandler));
     }
 
-    public void submitPreemptive(Runnable runnable, Consumer<Throwable> errorHandler) {
+    public void submitFirst(Runnable runnable, Consumer<Throwable> errorHandler) {
         assert active;
         submittedTasks.addFirst(new Task(runnable, errorHandler));
     }
@@ -99,7 +98,7 @@ public class ActorExecutor {
 
     public void stop() throws InterruptedException {
         if (isStopped.compareAndSet(false, true)) {
-            submitPreemptive(() -> active = false, e -> LOG.error("Unexpected error at stopping an ActorExecutor", e));
+            submitFirst(() -> active = false, e -> LOG.error("Unexpected error at stopping an ActorExecutor", e));
             await();
         }
     }
@@ -168,7 +167,7 @@ public class ActorExecutor {
         }
 
         public void cancel() {
-            ActorExecutor.this.submitPreemptive(task::cancel, task.errorHandler);
+            ActorExecutor.this.submitFirst(task::cancel, task.errorHandler);
         }
     }
 

--- a/concurrent/actor/ActorExecutor.java
+++ b/concurrent/actor/ActorExecutor.java
@@ -26,8 +26,9 @@ import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Optional;
 import java.util.PriorityQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -42,7 +43,7 @@ public class ActorExecutor {
 
     private static final Logger LOG = LoggerFactory.getLogger(ActorExecutor.class);
 
-    private final BlockingQueue<Task> submittedTasks;
+    private final BlockingDeque<Task> submittedTasks;
     private final ScheduledTaskQueue scheduledTasks;
     private final AtomicBoolean isStopped;
     private final Supplier<Long> clock;
@@ -52,8 +53,7 @@ public class ActorExecutor {
     public ActorExecutor(ThreadFactory threadFactory, Supplier<Long> clock) {
         this.thread = threadFactory.newThread(this::run);
         this.clock = clock;
-        // TODO: Benchmark and verify that LinkedTransferQueue is actually most performant
-        submittedTasks = new LinkedTransferQueue<>();
+        submittedTasks = new LinkedBlockingDeque<>();
         scheduledTasks = new ScheduledTaskQueue();
         isStopped = new AtomicBoolean(false);
         active = true;
@@ -81,6 +81,11 @@ public class ActorExecutor {
         submittedTasks.offer(new Task(runnable, errorHandler));
     }
 
+    public void submitPreemptive(Runnable runnable, Consumer<Throwable> errorHandler) {
+        assert active;
+        submittedTasks.addFirst(new Task(runnable, errorHandler));
+    }
+
     public FutureTask schedule(Runnable runnable, long scheduleMillis, Consumer<Throwable> errorHandler) {
         assert active;
         FutureTask task = new FutureTask(runnable, scheduleMillis, errorHandler);
@@ -94,7 +99,7 @@ public class ActorExecutor {
 
     public void stop() throws InterruptedException {
         if (isStopped.compareAndSet(false, true)) {
-            submit(() -> active = false, e -> LOG.error("Unexpected error at stopping an ActorExecutor", e));
+            submitPreemptive(() -> active = false, e -> LOG.error("Unexpected error at stopping an ActorExecutor", e));
             await();
         }
     }
@@ -163,7 +168,7 @@ public class ActorExecutor {
         }
 
         public void cancel() {
-            ActorExecutor.this.submit(task::cancel, task.errorHandler);
+            ActorExecutor.this.submitPreemptive(task::cancel, task.errorHandler);
         }
     }
 

--- a/reasoner/controller/AbstractController.java
+++ b/reasoner/controller/AbstractController.java
@@ -125,7 +125,7 @@ public abstract class AbstractController<
     public void terminate(Throwable cause) {
         super.terminate(cause);
         LOG.debug("Controller terminated.", cause);
-        processors.values().forEach(p -> p.executePreemptive(a -> a.terminate(cause)));
+        processors.values().forEach(p -> p.executeNext(a -> a.terminate(cause)));
     }
 
     public static class Context {

--- a/reasoner/controller/AbstractController.java
+++ b/reasoner/controller/AbstractController.java
@@ -125,7 +125,7 @@ public abstract class AbstractController<
     public void terminate(Throwable cause) {
         super.terminate(cause);
         LOG.debug("Controller terminated.", cause);
-        processors.values().forEach(p -> p.terminate(cause));
+        processors.values().forEach(p -> p.executePreemptive(a -> a.terminate(cause)));
     }
 
     public static class Context {

--- a/reasoner/controller/ConcludableController.java
+++ b/reasoner/controller/ConcludableController.java
@@ -83,7 +83,6 @@ public abstract class ConcludableController<INPUT, OUTPUT,
 
     @Override
     public void routeConnectionRequest(REQ req) {
-        if (isTerminated()) return;
         conclusionControllers.get(req.controllerId()).execute(actor -> actor.establishProcessorConnection(req));
     }
 

--- a/reasoner/controller/ConcludableController.java
+++ b/reasoner/controller/ConcludableController.java
@@ -41,6 +41,7 @@ import com.vaticle.typedb.core.reasoner.processor.reactive.RootSink;
 import com.vaticle.typedb.core.reasoner.processor.reactive.Source;
 import com.vaticle.typedb.core.traversal.common.Identifier.Variable;
 
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -149,7 +150,7 @@ public abstract class ConcludableController<INPUT, OUTPUT,
         }
 
         @Override
-        public void terminate(Throwable cause) {
+        public void terminate(@Nullable Throwable cause) {
             super.terminate(cause);
             reasonerConsumer.exception(cause);
         }

--- a/reasoner/controller/ConclusionController.java
+++ b/reasoner/controller/ConclusionController.java
@@ -78,7 +78,6 @@ public abstract class ConclusionController<
 
     @Override
     public void routeConnectionRequest(Request<?, ?> req) {
-        if (isTerminated()) return;
         if (req.isCondition()) {
             conditionController.execute(actor -> actor.establishProcessorConnection(req.asCondition()));
         } else if (req.isMaterialiser()) {

--- a/reasoner/controller/ConjunctionController.java
+++ b/reasoner/controller/ConjunctionController.java
@@ -113,7 +113,6 @@ public abstract class ConjunctionController<
 
     @Override
     public void routeConnectionRequest(Request<?> connectionRequest) {
-        if (isTerminated()) return;
         if (connectionRequest.isRetrievable()) {
             RetrievableRequest req = connectionRequest.asRetrievable();
             FilteredRetrievable controllerView = retrievableControllers.get(req.controllerId());

--- a/reasoner/controller/ControllerRegistry.java
+++ b/reasoner/controller/ControllerRegistry.java
@@ -118,9 +118,9 @@ public class ControllerRegistry {
     public void terminate(Throwable e) {
         if (terminated.compareAndSet(false, true)) {
             terminationCause = TypeDBException.of(REASONING_TERMINATED_WITH_CAUSE, e);
-            controllers.forEach(actor -> actor.execute(r -> r.terminate(terminationCause)));
-            materialisationController.execute(actor -> actor.terminate(terminationCause));
-            controllerContext.processor().monitor().execute(actor -> actor.terminate(terminationCause));
+            controllers.forEach(actor -> actor.terminate(terminationCause));
+            materialisationController.terminate(terminationCause);
+            controllerContext.processor().monitor().terminate(terminationCause);
         }
     }
 

--- a/reasoner/controller/ControllerRegistry.java
+++ b/reasoner/controller/ControllerRegistry.java
@@ -115,12 +115,12 @@ public class ControllerRegistry {
         return logicMgr;
     }
 
-    public void terminate(Throwable e) {
+    public void terminate(Throwable cause) {
         if (terminated.compareAndSet(false, true)) {
-            terminationCause = TypeDBException.of(REASONING_TERMINATED_WITH_CAUSE, e);
-            controllers.forEach(actor -> actor.terminate(terminationCause));
-            materialisationController.terminate(terminationCause);
-            controllerContext.processor().monitor().terminate(terminationCause);
+            terminationCause = TypeDBException.of(REASONING_TERMINATED_WITH_CAUSE, cause);
+            controllers.forEach(actor -> actor.executePreemptive(a -> a.terminate(cause)));
+            materialisationController.executePreemptive(a -> a.terminate(cause));
+            controllerContext.processor().monitor().executePreemptive(a -> a.terminate(cause));
         }
     }
 

--- a/reasoner/controller/ControllerRegistry.java
+++ b/reasoner/controller/ControllerRegistry.java
@@ -118,9 +118,9 @@ public class ControllerRegistry {
     public void terminate(Throwable cause) {
         if (terminated.compareAndSet(false, true)) {
             terminationCause = TypeDBException.of(REASONING_TERMINATED_WITH_CAUSE, cause);
-            controllers.forEach(actor -> actor.executePreemptive(a -> a.terminate(cause)));
-            materialisationController.executePreemptive(a -> a.terminate(cause));
-            controllerContext.processor().monitor().executePreemptive(a -> a.terminate(cause));
+            controllers.forEach(actor -> actor.executeNext(a -> a.terminate(terminationCause)));
+            materialisationController.executeNext(a -> a.terminate(terminationCause));
+            controllerContext.processor().monitor().executeNext(a -> a.terminate(terminationCause));
         }
     }
 

--- a/reasoner/controller/DisjunctionController.java
+++ b/reasoner/controller/DisjunctionController.java
@@ -70,7 +70,6 @@ public abstract class DisjunctionController<
 
     @Override
     public void routeConnectionRequest(Request req) {
-        if (isTerminated()) return;
         getConjunctionController(req.controllerId())
                 .execute(actor -> actor.establishProcessorConnection(req.withMap(c -> merge(c, req.bounds()))));
     }

--- a/reasoner/controller/NegationController.java
+++ b/reasoner/controller/NegationController.java
@@ -71,7 +71,6 @@ public class NegationController extends AbstractController<
 
     @Override
     public void routeConnectionRequest(Request req) {
-        if (isTerminated()) return;
         disjunctionContoller.execute(actor -> actor.establishProcessorConnection(req));
     }
 

--- a/reasoner/processor/AbstractProcessor.java
+++ b/reasoner/processor/AbstractProcessor.java
@@ -54,7 +54,7 @@ public abstract class AbstractProcessor<
     private final Map<Identifier, InputPort<INPUT>> inputPorts;
     private final Map<Identifier, OutputPort<OUTPUT>> outputPorts;
     private final Map<Pair<Identifier, Identifier>, Runnable> pullRetries;
-    private Stream<OUTPUT,OUTPUT> hubReactive;
+    private Stream<OUTPUT, OUTPUT> hubReactive;
     private long reactiveCounter;
 
     protected AbstractProcessor(Driver<PROCESSOR> driver,
@@ -75,7 +75,7 @@ public abstract class AbstractProcessor<
         this.hubReactive = hubReactive;
     }
 
-    protected Stream<OUTPUT,OUTPUT> hubReactive() {
+    protected Stream<OUTPUT, OUTPUT> hubReactive() {
         return hubReactive;
     }
 
@@ -153,18 +153,7 @@ public abstract class AbstractProcessor<
 
     @Override
     public void exception(Throwable e) {
-        if (e instanceof TypeDBException && ((TypeDBException) e).code().isPresent()) {
-            String code = ((TypeDBException) e).code().get();
-            if (code.equals(RESOURCE_CLOSED.code())) {
-                LOG.debug("Processor interrupted by resource close: {}", e.getMessage());
-                controller.terminate(e);
-                return;
-            } else {
-                LOG.debug("Processor interrupted by TypeDB exception: {}", e.getMessage());
-            }
-        }
-        LOG.error("Actor exception", e);
-        controller.terminate(e);
+        controller.executePreemptive(controller -> controller.exception(e));
     }
 
     private long incrementReactiveCounter() {

--- a/reasoner/processor/AbstractProcessor.java
+++ b/reasoner/processor/AbstractProcessor.java
@@ -41,7 +41,6 @@ import java.util.function.Supplier;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_OPERATION;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.RESOURCE_CLOSED;
 
 public abstract class AbstractProcessor<
         INPUT, OUTPUT, REQ extends AbstractRequest<?, ?, INPUT>,
@@ -153,7 +152,7 @@ public abstract class AbstractProcessor<
 
     @Override
     public void exception(Throwable e) {
-        controller.executePreemptive(controller -> controller.exception(e));
+        controller.executeNext(controller -> controller.exception(e));
     }
 
     private long incrementReactiveCounter() {

--- a/reasoner/processor/AbstractProcessor.java
+++ b/reasoner/processor/AbstractProcessor.java
@@ -55,7 +55,6 @@ public abstract class AbstractProcessor<
     private final Map<Identifier, OutputPort<OUTPUT>> outputPorts;
     private final Map<Pair<Identifier, Identifier>, Runnable> pullRetries;
     private Stream<OUTPUT,OUTPUT> hubReactive;
-    private boolean terminated;
     private long reactiveCounter;
 
     protected AbstractProcessor(Driver<PROCESSOR> driver,
@@ -103,12 +102,10 @@ public abstract class AbstractProcessor<
     }
 
     protected void requestConnection(REQ req) {
-        if (isTerminated()) return;
         controller.execute(actor -> actor.routeConnectionRequest(req));
     }
 
     public <RECEIVED_REQ extends AbstractRequest<?, ?, OUTPUT>> void establishConnection(RECEIVED_REQ request) {
-        if (isTerminated()) return;
         OutputPort<OUTPUT> outputPort = createOutputPort();
         outputPort.setInputPort(request.inputPortId(), request.requestingProcessor());
         request.connectViaTransforms(hubReactive(), outputPort);
@@ -160,23 +157,14 @@ public abstract class AbstractProcessor<
             String code = ((TypeDBException) e).code().get();
             if (code.equals(RESOURCE_CLOSED.code())) {
                 LOG.debug("Processor interrupted by resource close: {}", e.getMessage());
-                controller.execute(actor -> actor.exception(e));
+                controller.terminate(e);
                 return;
             } else {
                 LOG.debug("Processor interrupted by TypeDB exception: {}", e.getMessage());
             }
         }
         LOG.error("Actor exception", e);
-        controller.execute(actor -> actor.exception(e));
-    }
-
-    public void terminate(Throwable cause) {
-        LOG.debug("Actor terminated.", cause);
-        this.terminated = true;
-    }
-
-    private boolean isTerminated() {
-        return terminated;
+        controller.terminate(e);
     }
 
     private long incrementReactiveCounter() {

--- a/test/integration/reasoner/controller/ControllerTest.java
+++ b/test/integration/reasoner/controller/ControllerTest.java
@@ -141,9 +141,9 @@ public class ControllerTest {
                 } catch (TypeDBException e) {
                     fail();
                 }
-                Exception e = new RuntimeException();
+                Exception e = new RuntimeException("Intentional kill");
                 registry.terminate(e);
-                Throwable receivedException = answerProducer.exceptions().poll(100, TimeUnit.MILLISECONDS);
+                Throwable receivedException = answerProducer.exceptions().poll(200, TimeUnit.MILLISECONDS);
                 assertEquals(TypeDBException.of(REASONING_TERMINATED_WITH_CAUSE, e), receivedException);
             }
         }


### PR DESCRIPTION
## What is the goal of this PR?

We force each transaction-bound reasoner instance to terminate rapidly when any exception occurs, such as those generated when the transaction is closed while queries are still executing. This fixes a bug where queued up reasoning work would continue running for some time even after transaction close. Previously, scenarios where many queries ran concurrently and over a longer period of time, the incurred resource consumption could add up to bottleneck the entire server.

## What are the changes implemented in this PR?

* Introduce preemption (eg. skip the message queue) in the Actor model, by switching the internal actor queue to be a `BlockingDeque` instead of a `TransferQueue`
* Introduce a new `terminate` API on actors, which should generally be used with the new `Actor.Driver.executeNext()` execution mechanism.
* Tasks submitted to the actor executors automatically check whether they should execute, by checking if the actor that submitted them is terminated or not, allowing the messages in the queue to drain quickly.

### Performance implications:
We did a a few synthetic benchmarks to check whether the replacement of the `LinkedTransferQueue` is much slower than the `LinkedBlockingDeque` and found that:
1. Under no contention (single writer/single reader) the `LinkedTransferQueue` can be faster (variance is higher, but between -10 and +30% faster) compared to the `LinkedTransferDeque`
2. Under any contention, the `Deque` and the `Queue` are actually very comparable, and the `Deque` is sometimes faster.

These tradeoffs are acceptable for our use cases so we proceed with the `Deque` that provides the ability to insert at the start of the queue natively.