### PR TITLE
Disallow deletion of root types

### DIFF
--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -312,6 +312,11 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
         }
 
         @Override
+        public void delete() {
+            throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
+        }
+
+        @Override
         public void setLabel(java.lang.String label) {
             throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
         }
@@ -501,6 +506,11 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
             }
 
             @Override
+            public void delete() {
+                throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
+            }
+
+            @Override
             public void setLabel(java.lang.String label) {
                 throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
             }
@@ -646,6 +656,11 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
             }
 
             @Override
+            public void delete() {
+                throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
+            }
+
+            @Override
             public void setLabel(java.lang.String label) {
                 throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
             }
@@ -788,6 +803,11 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
             public Forwardable<AttributeTypeImpl.Double, Order.Asc> getSubtypesExplicit() {
                 return super.getSubtypeVerticesDirect(DOUBLE)
                         .mapSorted(v -> AttributeTypeImpl.Double.of(graphMgr, v), attrType -> attrType.vertex, ASC);
+            }
+
+            @Override
+            public void delete() {
+                throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
             }
 
             @Override
@@ -965,6 +985,11 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
             }
 
             @Override
+            public void delete() {
+                throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
+            }
+
+            @Override
             public void setLabel(java.lang.String label) {
                 throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
             }
@@ -1117,6 +1142,11 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
             public Forwardable<AttributeTypeImpl.DateTime, Order.Asc> getSubtypesExplicit() {
                 return super.getSubtypeVerticesDirect(DATETIME)
                         .mapSorted(v -> AttributeTypeImpl.DateTime.of(graphMgr, v), attrType -> attrType.vertex, ASC);
+            }
+
+            @Override
+            public void delete() {
+                throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
             }
 
             @Override

--- a/concept/type/impl/EntityTypeImpl.java
+++ b/concept/type/impl/EntityTypeImpl.java
@@ -135,6 +135,11 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
         }
 
         @Override
+        public void delete() {
+            throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
+        }
+
+        @Override
         public void setLabel(String label) {
             throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
         }

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -312,6 +312,11 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
         }
 
         @Override
+        public void delete() {
+            throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
+        }
+
+        @Override
         public void setLabel(String label) {
             throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
         }

--- a/concept/type/impl/RoleTypeImpl.java
+++ b/concept/type/impl/RoleTypeImpl.java
@@ -227,6 +227,11 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
         }
 
         @Override
+        public void delete() {
+            throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
+        }
+
+        @Override
         public void setLabel(String label) {
             throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
         }

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -588,6 +588,11 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
         }
 
         @Override
+        public void delete() {
+            throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
+        }
+
+        @Override
         public void setLabel(String label) {
             throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
         }

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -47,6 +47,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.I
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.SESSION_SCHEMA_VIOLATION;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.INVALID_TYPE_CASTING;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.CYCLIC_TYPE_HIERARCHY;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.ROOT_TYPE_MUTATION;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.TYPE_HAS_BEEN_DELETED;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeWrite.TYPE_REFERENCED_IN_RULES;
 import static com.vaticle.typedb.core.common.parameters.Order.Asc.ASC;
@@ -149,6 +150,7 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
     }
 
     void validateDelete() {
+        if (isRoot()) throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
         FunctionalIterator<RuleStructure> rules = graphMgr.schema().rules().references().get(vertex);
         if (rules.hasNext()) {
             throw exception(TypeDBException.of(TYPE_REFERENCED_IN_RULES, getLabel(), rules.map(RuleStructure::label).toList()));

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,9 +48,9 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "df4923fca02fc953b1e88373befb0a8dcbc353a6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
-    )
+        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
+        commit = "aa03cf16cd9b2b2cf2600778d58763dbdf7e56a3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+)
 
 def vaticle_factory_tracing():
     git_repository(

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,9 +48,9 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
-        commit = "aa03cf16cd9b2b2cf2600778d58763dbdf7e56a3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
-)
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "f98a17c9644a1fdae0c066273fdde2027d5e6299",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+    )
 
 def vaticle_factory_tracing():
     git_repository(

--- a/test/behaviour/concept/type/thingtype/ThingTypeSteps.java
+++ b/test/behaviour/concept/type/thingtype/ThingTypeSteps.java
@@ -55,6 +55,8 @@ public class ThingTypeSteps {
                 return tx().concepts().getAttributeType(typeLabel);
             case RELATION:
                 return tx().concepts().getRelationType(typeLabel);
+            case THING:
+                return tx().concepts().getThingType(typeLabel);
             default:
                 throw TypeDBException.of(UNRECOGNISED_VALUE);
         }
@@ -98,7 +100,7 @@ public class ThingTypeSteps {
                 tx().concepts().putRelationType(typeLabel);
                 break;
             default:
-                throw TypeDBException.of(UNRECOGNISED_VALUE);
+                throw TypeDBException.of(ILLEGAL_ARGUMENT);
         }
     }
 
@@ -159,6 +161,10 @@ public class ThingTypeSteps {
                 RelationType relationSuperType = tx().concepts().getRelationType(superLabel);
                 tx().concepts().getRelationType(typeLabel).setSupertype(relationSuperType);
                 break;
+            case THING:
+                ThingType thingSuperType = tx().concepts().getThingType(superLabel);
+                tx().concepts().getThingType(typeLabel).setSupertype(thingSuperType);
+                break;
         }
     }
 
@@ -176,6 +182,10 @@ public class ThingTypeSteps {
             case RELATION:
                 RelationType relationSuperType = tx().concepts().getRelationType(superLabel);
                 assertThrows(() -> tx().concepts().getRelationType(typeLabel).setSupertype(relationSuperType));
+                break;
+            case THING:
+                ThingType thingSuperType = tx().concepts().getThingType(superLabel);
+                assertThrows(() -> tx().concepts().getThingType(typeLabel).setSupertype(thingSuperType));
                 break;
         }
     }

--- a/test/behaviour/concept/type/thingtype/ThingTypeSteps.java
+++ b/test/behaviour/concept/type/thingtype/ThingTypeSteps.java
@@ -33,6 +33,7 @@ import io.cucumber.java.en.When;
 import java.util.List;
 import java.util.Set;
 
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.UNRECOGNISED_VALUE;
 import static com.vaticle.typedb.core.common.test.Util.assertThrows;
 import static com.vaticle.typedb.core.test.behaviour.config.Parameters.RootLabel;
@@ -161,10 +162,8 @@ public class ThingTypeSteps {
                 RelationType relationSuperType = tx().concepts().getRelationType(superLabel);
                 tx().concepts().getRelationType(typeLabel).setSupertype(relationSuperType);
                 break;
-            case THING:
-                ThingType thingSuperType = tx().concepts().getThingType(superLabel);
-                tx().concepts().getThingType(typeLabel).setSupertype(thingSuperType);
-                break;
+            default:
+                throw TypeDBException.of(ILLEGAL_ARGUMENT);
         }
     }
 
@@ -183,10 +182,8 @@ public class ThingTypeSteps {
                 RelationType relationSuperType = tx().concepts().getRelationType(superLabel);
                 assertThrows(() -> tx().concepts().getRelationType(typeLabel).setSupertype(relationSuperType));
                 break;
-            case THING:
-                ThingType thingSuperType = tx().concepts().getThingType(superLabel);
-                assertThrows(() -> tx().concepts().getThingType(typeLabel).setSupertype(thingSuperType));
-                break;
+            default:
+                throw TypeDBException.of(ILLEGAL_ARGUMENT);
         }
     }
 

--- a/test/behaviour/config/Parameters.java
+++ b/test/behaviour/config/Parameters.java
@@ -52,7 +52,7 @@ public class Parameters {
         return LocalDateTime.parse(dateTime, formatter);
     }
 
-    @ParameterType("entity|attribute|relation")
+    @ParameterType("entity|attribute|relation|thing")
     public RootLabel root_label(String type) {
         return RootLabel.of(type);
     }
@@ -130,7 +130,8 @@ public class Parameters {
     public enum RootLabel {
         ENTITY("entity"),
         ATTRIBUTE("attribute"),
-        RELATION("relation");
+        RELATION("relation"),
+        THING("thing");
 
         private final String label;
 


### PR DESCRIPTION
## What is the goal of this PR?

We override `delete()` for all `..Type.Root` classes to throw error `[TYW01] Root types are immutable.`

## What are the changes implemented in this PR?

Side note: `undefine entity sub thing;` and similar queries fail already, because despite `entity` being a subtype of `thing`, root entity type's `getSupertypes()` method (which is used to validate type deletion) only returns the root type itself. The query fails with error `TYW38` `The type 'entity' cannot be undefined, as the provided supertype 'thing' is not a valid supertype.`