### PR TITLE
Prune inferred types of variables in then having variabilised 'isa' constraints 

### DIFF
--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -196,6 +196,12 @@ public class Rule {
                     thenVar.retainInferredTypes(whenVarInferredTypes);
                     if (thenVar.inferredTypes().isEmpty()) then.setCoherent(false);
                 });
+        then.variables().stream()
+                .filter(thenVar -> thenVar.isThing() && thenVar.asThing().isa().isPresent() && when.conjunctions().stream().noneMatch(conj -> conj.variable(thenVar.id()) != null))
+                .forEach(thenVar -> {
+                    thenVar.retainInferredTypes(thenVar.asThing().isa().get().type().inferredTypes());
+                    if (thenVar.inferredTypes().isEmpty()) then.setCoherent(false);
+                });
     }
 
     private Disjunction whenPattern(com.vaticle.typeql.lang.pattern.Conjunction<? extends Pattern> conjunction,

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -197,7 +197,8 @@ public class Rule {
                     if (thenVar.inferredTypes().isEmpty()) then.setCoherent(false);
                 });
         then.variables().stream()
-                .filter(thenVar -> thenVar.isThing() && thenVar.asThing().isa().isPresent() && when.conjunctions().stream().noneMatch(conj -> conj.variable(thenVar.id()) != null))
+                .filter(thenVar -> thenVar.isThing() && thenVar.asThing().isa().isPresent() &&
+                        when.conjunctions().stream().noneMatch(conj -> conj.variable(thenVar.id()) != null))
                 .forEach(thenVar -> {
                     thenVar.retainInferredTypes(thenVar.asThing().isa().get().type().inferredTypes());
                     if (thenVar.inferredTypes().isEmpty()) then.setCoherent(false);

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -94,9 +94,8 @@ public class Rule {
 
     private Rule(RuleStructure structure, LogicManager logicMgr) {
         this.structure = structure;
-        this.then = thenPattern(structure.then(), logicMgr);
         this.when = whenPattern(structure.when(), structure.then(), logicMgr);
-        pruneThenResolvedTypes();
+        this.then = thenPattern(structure.then(), logicMgr);
         this.conclusion = Conclusion.create(this);
         this.condition = Condition.create(this);
     }
@@ -186,25 +185,6 @@ public class Rule {
         if (!then.isAnswerable()) throw TypeDBException.of(RULE_THEN_UNANSWERABLE, structure.label(), then);
     }
 
-    /**
-     * Remove inferred types in the `then` pattern that are not valid in the `when` pattern
-     */
-    private void pruneThenResolvedTypes() {
-        then.variables().stream().filter(variable -> variable.id().isName())
-                .forEach(thenVar -> {
-                    Set<Label> whenVarInferredTypes = iterate(when.conjunctions()).flatMap(conj -> iterate(conj.variable(thenVar.id()).inferredTypes())).toSet();
-                    thenVar.retainInferredTypes(whenVarInferredTypes);
-                    if (thenVar.inferredTypes().isEmpty()) then.setCoherent(false);
-                });
-        then.variables().stream()
-                .filter(thenVar -> thenVar.isThing() && thenVar.asThing().isa().isPresent() &&
-                        when.conjunctions().stream().noneMatch(conj -> conj.variable(thenVar.id()) != null))
-                .forEach(thenVar -> {
-                    thenVar.retainInferredTypes(thenVar.asThing().isa().get().type().inferredTypes());
-                    if (thenVar.inferredTypes().isEmpty()) then.setCoherent(false);
-                });
-    }
-
     private Disjunction whenPattern(com.vaticle.typeql.lang.pattern.Conjunction<? extends Pattern> conjunction,
                                     com.vaticle.typeql.lang.pattern.variable.ThingVariable<?> then, LogicManager logicMgr) {
         Disjunction when = Disjunction.create(conjunction.normalise(), VariableRegistry.createFromThings(list(then)));
@@ -214,7 +194,12 @@ public class Rule {
 
     private Conjunction thenPattern(com.vaticle.typeql.lang.pattern.variable.ThingVariable<?> thenVariable, LogicManager logicMgr) {
         Conjunction conj = new Conjunction(VariableRegistry.createFromThings(list(thenVariable)).variables(), list());
-        logicMgr.typeInference().applyCombination(conj, true);
+        Map<Identifier.Variable.Name, Set<Label>> whenTypes = new HashMap<>();
+        iterate(conj.variables()).map(Variable::id).filter(Identifier::isName).forEachRemaining(thenVar -> {
+            Set<Label> whenTypesForVar = iterate(when.conjunctions()).flatMap(cj -> iterate(cj.variable(thenVar).inferredTypes())).toSet();
+            whenTypes.put(thenVar.asName(), whenTypesForVar);
+        });
+        logicMgr.typeInference().applyCombination(conj, whenTypes, true);
         return conj;
     }
 

--- a/logic/tool/TypeInference.java
+++ b/logic/tool/TypeInference.java
@@ -100,7 +100,7 @@ public class TypeInference {
         applyCombination(conjunction, new HashMap<>(), insertable);
     }
 
-    private void applyCombination(Conjunction conjunction, Map<Identifier.Variable.Name, Set<Label>> bounds, boolean insertable) {
+    public void applyCombination(Conjunction conjunction, Map<Identifier.Variable.Name, Set<Label>> bounds, boolean insertable) {
         propagateLabels(conjunction);
         if (!bounds.isEmpty()) applyBounds(conjunction, bounds);
         Map<Retrievable.Name, Set<Label>> inferredTypes = new HashMap<>(bounds);


### PR DESCRIPTION
## What is the goal of this PR?
Improve type-inference for in rules by pruning inferred-types of variables with variabilised `isa` constraints. 

## What are the changes implemented in this PR?
* Variables which had variabilised `isa` constraints did not have their types pruned based on the the types of the said type.
  - e.g. In `$r (...) isa $relation;` , we prune the inferred types of `$r` to those also present in inferred types of `$relation`. 
 