### PR TITLE
Relax rule validation to allow unanswerable but coherent rules

### DIFF
--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -50,6 +50,8 @@ import com.vaticle.typedb.core.traversal.TraversalEngine;
 import com.vaticle.typedb.core.traversal.common.Identifier;
 import com.vaticle.typeql.lang.pattern.Pattern;
 import com.vaticle.typeql.lang.pattern.variable.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -84,6 +86,9 @@ import static com.vaticle.typeql.lang.common.TypeQLToken.Schema.WHEN;
 
 
 public class Rule {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Rule.class);
+
 
     // note: as `Rule` is cached between transactions, we cannot hold any transaction-bound objects such as Managers
     private final RuleStructure structure;
@@ -178,11 +183,11 @@ public class Rule {
         for (Conjunction whenBranch : when.conjunctions()) {
             if (!whenBranch.isAnswerable()) {
                 ErrorMessage errorMessage = when.conjunctions().size() > 1 ? RULE_WHEN_UNANSWERABLE_BRANCH : RULE_WHEN_UNANSWERABLE;
-                throw TypeDBException.of(errorMessage, structure.label(), whenBranch);
+                LOG.warn(errorMessage.toString());
             }
         }
         if (!then.isCoherent()) throw TypeDBException.of(RULE_THEN_INCOHERENT, structure.label(), then);
-        if (!then.isAnswerable()) throw TypeDBException.of(RULE_THEN_UNANSWERABLE, structure.label(), then);
+        if (!then.isAnswerable()) LOG.warn(RULE_THEN_UNANSWERABLE.message(structure.label(), then));
     }
 
     private Disjunction whenPattern(com.vaticle.typeql.lang.pattern.Conjunction<? extends Pattern> conjunction,

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -183,7 +183,7 @@ public class Rule {
         for (Conjunction whenBranch : when.conjunctions()) {
             if (!whenBranch.isAnswerable()) {
                 ErrorMessage errorMessage = when.conjunctions().size() > 1 ? RULE_WHEN_UNANSWERABLE_BRANCH : RULE_WHEN_UNANSWERABLE;
-                LOG.warn(errorMessage.toString());
+                LOG.warn(errorMessage.message(structure.label(), whenBranch));
             }
         }
         if (!then.isCoherent()) throw TypeDBException.of(RULE_THEN_INCOHERENT, structure.label(), then);

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -187,7 +187,7 @@ public class Rule {
             }
         }
         if (!then.isCoherent()) throw TypeDBException.of(RULE_THEN_INCOHERENT, structure.label(), then);
-        if (!then.isAnswerable()) LOG.warn(RULE_THEN_UNANSWERABLE.message(structure.label(), then));
+        if (!then.isAnswerable()) throw TypeDBException.of(RULE_THEN_UNANSWERABLE, structure.label(), then);
     }
 
     private Disjunction whenPattern(com.vaticle.typeql.lang.pattern.Conjunction<? extends Pattern> conjunction,


### PR DESCRIPTION
## What is the goal of this PR?

We allow rules to be written in a way that is semantically sensible in the schema, but may not produce any answers (specifically, if `when` types can't have any instances because they are abstract). 

We therefore match the current behaviour of `match` queries: `match $r isa relation;` does not throw any exceptions even if there are no concrete subtypes of `relation`. As a result, after this change, it will be possible to write rules that will never trigger any inferences, since never match any concrete types.

This change allows writing and sharing 'general' rules that work over an abstract schema, only to be specialised at a later part of the development cycle.

Note that a rule `then` must still be written using concrete, insertable types.

## What are the changes implemented in this PR?

We relax rule validation to log a server-side warning if the rule is not answerable, but it is coherent (eg. it makes sense in the schema).
