### PR TITLE
Fix condition for cyclic-scaling factor

### DIFF
--- a/reasoner/planner/OrderingCoster.java
+++ b/reasoner/planner/OrderingCoster.java
@@ -82,8 +82,8 @@ public class OrderingCoster {
                 // I lean towards the overestimate.
                 Set<Variable> projectionVars = iterate(restrictedResolvableVars).filter(v -> !callMode.mode.contains(v)).toSet();
                 double allAnswersForUnrestrictedMode = answerCountEstimator.localEstimate(conjunctionNode.conjunction(), resolvable, resolvableMode);
-                double cyclicScalingFactor = projectionVars.isEmpty() && allAnswersForUnrestrictedMode != 0 ? 0.0 :
-                        (double) estimator.answerEstimate(projectionVars) / allAnswersForUnrestrictedMode;
+                double cyclicScalingFactor = (projectionVars.isEmpty() || allAnswersForUnrestrictedMode == 0) ? 0.0 :
+                        estimator.answerEstimate(projectionVars) / allAnswersForUnrestrictedMode;
 
                 // Terrible overestimate. Let's take the square-root to be more realistic.
                 if (allAnswersForUnrestrictedMode != 0) {


### PR DESCRIPTION
## What is the goal of this PR?
Fix a condition which determined the value for the cyclic scaling factor. This was leading to NaNs in the computation cost when the answer estimate was 0.

## What are the changes implemented in this PR?
* Corrects the condition in OrderingCoster::createAllCallsCosting