### PR TITLE
Reasoner planner model bypassed reasoning

### DIFF
--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -86,7 +86,7 @@ public class Reasoner {
         this.conceptMgr = conceptMgr;
         this.traversalEng = traversalEng;
         this.logicMgr = logicMgr;
-        this.planner = ReasonerPlanner.create(traversalEng, conceptMgr, logicMgr);
+        this.planner = ReasonerPlanner.create(traversalEng, conceptMgr, logicMgr, context.options().explain());
         this.controllerRegistry = new ControllerRegistry(actor(), traversalEng, conceptMgr, logicMgr, planner, context);
         this.explainablesManager = new ExplainablesManager();
     }

--- a/reasoner/controller/ConcludableController.java
+++ b/reasoner/controller/ConcludableController.java
@@ -31,6 +31,7 @@ import com.vaticle.typedb.core.reasoner.ReasonerConsumer;
 import com.vaticle.typedb.core.reasoner.answer.Explanation;
 import com.vaticle.typedb.core.reasoner.answer.PartialExplanation;
 import com.vaticle.typedb.core.reasoner.common.Traversal;
+import com.vaticle.typedb.core.reasoner.planner.ReasonerPlanner;
 import com.vaticle.typedb.core.reasoner.processor.AbstractProcessor;
 import com.vaticle.typedb.core.reasoner.processor.AbstractRequest;
 import com.vaticle.typedb.core.reasoner.processor.AbstractRequest.Identifier;
@@ -262,7 +263,7 @@ public abstract class ConcludableController<INPUT, OUTPUT,
                             (attribute = bounds.get(concludable.asHas().attribute().id())) != null &&
                             (owner.asThing().hasInferred(attribute.asAttribute()) || owner.asThing().hasNonInferred(attribute.asAttribute()));
                 } else {
-                    return bounds.contains(concludable.generating().get().id());
+                    return ReasonerPlanner.canBypassReasoning(concludable, bounds.concepts().keySet(), false);
                 }
             }
 

--- a/reasoner/controller/ConcludableController.java
+++ b/reasoner/controller/ConcludableController.java
@@ -70,6 +70,11 @@ public abstract class ConcludableController<INPUT, OUTPUT,
         this.conclusionUnifiers = new HashMap<>();
     }
 
+    public static boolean canBypassReasoning(Concludable concludable, Set<com.vaticle.typedb.core.traversal.common.Identifier.Variable.Retrievable> boundVariables, boolean isExplainEnabled) {
+        return !isExplainEnabled && !concludable.isHas() &&
+                concludable.generating().isPresent() && boundVariables.contains(concludable.generating().get().id());
+    }
+
     @Override
     public void setUpUpstreamControllers() {
         iterate(registry().logicManager().applicableRules(concludable).entrySet()).forEachRemaining(ruleAndUnifiers -> {
@@ -85,11 +90,6 @@ public abstract class ConcludableController<INPUT, OUTPUT,
     @Override
     public void routeConnectionRequest(REQ req) {
         conclusionControllers.get(req.controllerId()).execute(actor -> actor.establishProcessorConnection(req));
-    }
-
-    public static boolean canBypassReasoning(Concludable concludable, Set<com.vaticle.typedb.core.traversal.common.Identifier.Variable.Retrievable> boundVariables, boolean isExplainEnabled) {
-        return !isExplainEnabled && !concludable.isHas() &&
-                concludable.generating().isPresent() && boundVariables.contains(concludable.generating().get().id());
     }
 
     public static class Match extends ConcludableController<Map<Variable, Concept>, ConceptMap, Processor.Match.Request,

--- a/reasoner/planner/ReasonerPlanner.java
+++ b/reasoner/planner/ReasonerPlanner.java
@@ -46,17 +46,19 @@ public abstract class ReasonerPlanner {
     final ConceptManager conceptMgr;
     final TraversalEngine traversalEng;
     final LogicManager logicMgr;
+    private final boolean explain;
     final CommonCache<CallMode, Plan> planCache;
 
-    public ReasonerPlanner(TraversalEngine traversalEng, ConceptManager conceptMgr, LogicManager logicMgr) {
+    public ReasonerPlanner(TraversalEngine traversalEng, ConceptManager conceptMgr, LogicManager logicMgr, boolean explain) {
         this.traversalEng = traversalEng;
         this.conceptMgr = conceptMgr;
         this.logicMgr = logicMgr;
+        this.explain = explain;
         this.planCache = new CommonCache<>();
     }
 
-    public static ReasonerPlanner create(TraversalEngine traversalEng, ConceptManager conceptMgr, LogicManager logicMgr) {
-        return RecursivePlanner.create(traversalEng, conceptMgr, logicMgr);
+    public static ReasonerPlanner create(TraversalEngine traversalEng, ConceptManager conceptMgr, LogicManager logicMgr, boolean explain) {
+        return RecursivePlanner.create(traversalEng, conceptMgr, logicMgr, explain);
     }
 
     static Set<Variable> estimateableVariables(Set<Variable> variables) {
@@ -132,7 +134,7 @@ public abstract class ReasonerPlanner {
         Set<CallMode> calls = new HashSet<>();
 
         // Don't trigger reasoning if we can just look it up
-        if (!concludable.isHas() && concludable.generating().isPresent() && mode.contains(concludable.generating().get())) {
+        if (!explain && !concludable.isHas() && concludable.generating().isPresent() && mode.contains(concludable.generating().get())) {
             return calls;
         }
 

--- a/reasoner/planner/ReasonerPlanner.java
+++ b/reasoner/planner/ReasonerPlanner.java
@@ -130,11 +130,16 @@ public abstract class ReasonerPlanner {
                 .allMatch(constraint -> constraint.isThing() && constraint.asThing().isValue());
     }
 
+    public static boolean canBypassReasoning(Concludable concludable, Set<com.vaticle.typedb.core.traversal.common.Identifier.Variable.Retrievable> boundVariables, boolean isExplainEnabled) {
+        return !isExplainEnabled && !concludable.isHas() &&
+                concludable.generating().isPresent() && boundVariables.contains(concludable.generating().get().id());
+    }
+
     public Set<CallMode> triggeredCalls(Concludable concludable, Set<Variable> mode, @Nullable Set<ResolvableConjunction> dependencyFilter) {
         Set<CallMode> calls = new HashSet<>();
 
         // Don't trigger reasoning if we can just look it up
-        if (!explain && !concludable.isHas() && concludable.generating().isPresent() && mode.contains(concludable.generating().get())) {
+        if (canBypassReasoning(concludable, iterate(mode).map(v -> v.id().asRetrievable()).toSet(), explain)) {
             return calls;
         }
 

--- a/reasoner/planner/ReasonerPlanner.java
+++ b/reasoner/planner/ReasonerPlanner.java
@@ -130,6 +130,12 @@ public abstract class ReasonerPlanner {
 
     public Set<CallMode> triggeredCalls(Concludable concludable, Set<Variable> mode, @Nullable Set<ResolvableConjunction> dependencyFilter) {
         Set<CallMode> calls = new HashSet<>();
+
+        // We don't trigger reasoning if the relation variable is bound
+        if (!concludable.isHas() && concludable.generating().isPresent() && mode.contains(concludable.generating().get())) {
+            return calls;
+        }
+
         for (Map.Entry<Rule, Set<Unifier>> entry : logicMgr.applicableRules(concludable).entrySet()) {
             for (Rule.Condition.ConditionBranch conditionBranch : entry.getKey().condition().branches()) {
                 ResolvableConjunction ruleConjunction = conditionBranch.conjunction();

--- a/reasoner/planner/ReasonerPlanner.java
+++ b/reasoner/planner/ReasonerPlanner.java
@@ -131,7 +131,7 @@ public abstract class ReasonerPlanner {
     public Set<CallMode> triggeredCalls(Concludable concludable, Set<Variable> mode, @Nullable Set<ResolvableConjunction> dependencyFilter) {
         Set<CallMode> calls = new HashSet<>();
 
-        // We don't trigger reasoning if the relation variable is bound
+        // Don't trigger reasoning if we can just look it up
         if (!concludable.isHas() && concludable.generating().isPresent() && mode.contains(concludable.generating().get())) {
             return calls;
         }

--- a/reasoner/planner/RecursivePlanner.java
+++ b/reasoner/planner/RecursivePlanner.java
@@ -42,16 +42,16 @@ public class RecursivePlanner extends ReasonerPlanner {
     final OrderingCoster orderingCoster;
     private final Map<CallMode, Set<LocalAllCallsCosting>> callModeCostings;
 
-    protected RecursivePlanner(TraversalEngine traversalEng, ConceptManager conceptMgr, LogicManager logicMgr) {
-        super(traversalEng, conceptMgr, logicMgr);
+    protected RecursivePlanner(TraversalEngine traversalEng, ConceptManager conceptMgr, LogicManager logicMgr, boolean explain) {
+        super(traversalEng, conceptMgr, logicMgr, explain);
         this.conjunctionGraph = new ConjunctionGraph(logicMgr);
         this.answerCountEstimator = new AnswerCountEstimator(logicMgr, traversalEng.graph(), this.conjunctionGraph);
         this.callModeCostings = new HashMap<>();
         this.orderingCoster = new OrderingCoster(this, answerCountEstimator, conjunctionGraph);
     }
 
-    public static RecursivePlanner create(TraversalEngine traversalEng, ConceptManager conceptMgr, LogicManager logicMgr) {
-        return new RecursivePlanner(traversalEng, conceptMgr, logicMgr);
+    public static RecursivePlanner create(TraversalEngine traversalEng, ConceptManager conceptMgr, LogicManager logicMgr, boolean explain) {
+        return new RecursivePlanner(traversalEng, conceptMgr, logicMgr, explain);
     }
 
     @Override

--- a/test/integration/reasoner/planner/ReasonerPlannerTest.java
+++ b/test/integration/reasoner/planner/ReasonerPlannerTest.java
@@ -168,7 +168,7 @@ public class ReasonerPlannerTest {
 
         {
             initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
-            ReasonerPlanner planner = ReasonerPlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic());
+            ReasonerPlanner planner = ReasonerPlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic(), false);
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{ (from: $x, to: $y) isa path; }", transaction.logic()));
             planner.plan(conjunction, set());
             verifyPlan(planner, conjunction, set(), Collections.list("c"));
@@ -177,7 +177,7 @@ public class ReasonerPlannerTest {
 
         {
             initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
-            ReasonerPlanner planner = ReasonerPlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic());
+            ReasonerPlanner planner = ReasonerPlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic(), false);
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{ $x isa node, has nid 0; (from: $x, to: $y) isa path; }", transaction.logic()));
             planner.plan(conjunction, set());
             verifyPlan(planner, conjunction, set(), Collections.list("r", "c"));
@@ -186,7 +186,7 @@ public class ReasonerPlannerTest {
 
         {
             initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
-            ReasonerPlanner planner = ReasonerPlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic());
+            ReasonerPlanner planner = ReasonerPlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic(), false);
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{ $y isa node, has nid 0; (from: $x, to: $y) isa path; }", transaction.logic()));
             planner.plan(conjunction, set());
             verifyPlan(planner, conjunction, set(), Collections.list("r", "c"));
@@ -195,7 +195,7 @@ public class ReasonerPlannerTest {
 
         {
             initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
-            ReasonerPlanner planner = ReasonerPlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic());
+            ReasonerPlanner planner = ReasonerPlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic(), false);
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{ $x isa node, has nid 0; $y isa node, has nid 1; (from: $x, to: $y) isa path; }", transaction.logic()));
             planner.plan(conjunction, set());
             verifyPlan(planner, conjunction, set(), Collections.list("r", "r", "c"));

--- a/test/integration/reasoner/planner/RecursivePlannerTest.java
+++ b/test/integration/reasoner/planner/RecursivePlannerTest.java
@@ -104,7 +104,7 @@ public class RecursivePlannerTest {
     @Test
     public void test_single_retrieval() {
         initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
-        RecursivePlanner planSpaceSearch = RecursivePlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic());
+        RecursivePlanner planSpaceSearch = RecursivePlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic(), false);
         ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{ $p isa person; }", transaction.logic()));
         planSpaceSearch.plan(conjunction, set());
         ReasonerPlanner.Plan plan = planSpaceSearch.getPlan(conjunction, set());
@@ -116,7 +116,7 @@ public class RecursivePlannerTest {
         // Still just answer counts. Improve if we have an improved estimate for retrievables
         initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
 
-        RecursivePlanner planSpaceSearch = RecursivePlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic());
+        RecursivePlanner planSpaceSearch = RecursivePlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic(), false);
         {   // Query only count of $p, where $p isa man;
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{ $p isa man, has name $n; }", transaction.logic()));
             planSpaceSearch.plan(conjunction, set());
@@ -150,7 +150,7 @@ public class RecursivePlannerTest {
         session.close();
 
         initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
-        RecursivePlanner planSpaceSearch = RecursivePlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic());
+        RecursivePlanner planSpaceSearch = RecursivePlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic(), false);
         {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{ $p has name $n; }", transaction.logic()));
             planSpaceSearch.plan(conjunction, set());
@@ -185,7 +185,7 @@ public class RecursivePlannerTest {
         session.close();
 
         initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
-        RecursivePlanner planSpaceSearch = RecursivePlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic());
+        RecursivePlanner planSpaceSearch = RecursivePlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic(), false);
         {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{(friendor: $x, friendee: $y) isa transitive-friendship; }", transaction.logic()));
             planSpaceSearch.plan(conjunction, set());
@@ -205,7 +205,7 @@ public class RecursivePlannerTest {
         session.close();
 
         initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
-        RecursivePlanner planSpaceSearch = RecursivePlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic());
+        RecursivePlanner planSpaceSearch = RecursivePlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic(), false);
         {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{(friendor: $x, friendee: $y) isa friendship; }", transaction.logic()));
 
@@ -251,7 +251,7 @@ public class RecursivePlannerTest {
         session.close();
 
         initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
-        RecursivePlanner planSpaceSearch = RecursivePlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic());
+        RecursivePlanner planSpaceSearch = RecursivePlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic(), false);
         {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{(friendor: $x, friendee: $y) isa transitive-friendship; }", transaction.logic()));
             planSpaceSearch.plan(conjunction, set());
@@ -286,7 +286,7 @@ public class RecursivePlannerTest {
         session.close();
 
         initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
-        RecursivePlanner planner = RecursivePlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic());
+        RecursivePlanner planner = RecursivePlanner.create(transaction.traversal(), transaction.concepts(), transaction.logic(), false);
         {
             ResolvableConjunction conjunction = ResolvableConjunction.of(resolvedConjunction("{$x has name \"Jim\"; (friendor: $x, friendee: $y) isa transitive-friendship; }", transaction.logic()));
             planner.plan(conjunction, set());


### PR DESCRIPTION
## What is the goal of this PR?
Model the fact that the reasoner will bypass reasoning when it is safe to do so.

## What are the changes implemented in this PR?
* Add a method in ReasonerPlanner.triggeredCalls to check if reasoning can be bypassed.
* Make the reasoner planned & concludable controller call this method.
  - Requires the reasoner planner to know if `explain` is enabled - Add constructor parameter & propagate.
