### PR TITLE
Optimise queries by introducing concept-level schema cache

### DIFF
--- a/concept/ConceptImpl.java
+++ b/concept/ConceptImpl.java
@@ -46,6 +46,12 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.INV
 
 public abstract class ConceptImpl implements Concept {
 
+    protected final ConceptManager conceptMgr;
+
+    protected ConceptImpl(ConceptManager conceptMgr) {
+        this.conceptMgr = conceptMgr;
+    }
+
     @Override
     public boolean isType() {
         return false;

--- a/concept/thing/Relation.java
+++ b/concept/thing/Relation.java
@@ -45,5 +45,5 @@ public interface Relation extends Thing {
     // TODO: This method should just return FunctionalIterator<Pair<RoleType, Thing>>
     Map<? extends RoleType, List<Thing>> getPlayersByRoleType();
 
-    FunctionalIterator<? extends RoleType> getRelating();
+    FunctionalIterator<RoleType> getRelating();
 }

--- a/concept/thing/Thing.java
+++ b/concept/thing/Thing.java
@@ -140,7 +140,7 @@ public interface Thing extends Concept, Comparable<Thing> {
      *
      * @return an iterator stream of {@code RoleType} types that this {@code Thing} plays.
      */
-    FunctionalIterator<? extends RoleType> getPlaying();
+    FunctionalIterator<RoleType> getPlaying();
 
     /**
      * Get all {@code Relation} instances that this {@code Thing} is playing any of the specified roles in.

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -22,6 +22,7 @@ import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.concept.ConceptManager;
 import com.vaticle.typedb.core.concept.thing.Attribute;
+import com.vaticle.typedb.core.concept.type.AttributeType;
 import com.vaticle.typedb.core.concept.type.ThingType;
 import com.vaticle.typedb.core.concept.type.impl.AttributeTypeImpl;
 import com.vaticle.typedb.core.concept.type.impl.ThingTypeImpl;
@@ -43,7 +44,7 @@ import static com.vaticle.typedb.core.encoding.Encoding.ValueType.STRING;
 public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribute {
 
     AttributeVertex<VALUE> attributeVertex;
-    AttributeTypeImpl attributeType;
+    AttributeType attributeType;
 
     private AttributeImpl(ConceptManager conceptMgr, AttributeVertex<VALUE> vertex) {
         super(conceptMgr, vertex);
@@ -75,10 +76,8 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
     }
 
     @Override
-    public AttributeTypeImpl getType() {
-        if (attributeType == null) {
-            attributeType = AttributeTypeImpl.of(conceptMgr, readableVertex().type());
-        }
+    public AttributeType getType() {
+        if (attributeType == null) attributeType = conceptMgr.convertAttributeType(readableVertex().type());
         return attributeType;
     }
 

--- a/concept/thing/impl/AttributeImpl.java
+++ b/concept/thing/impl/AttributeImpl.java
@@ -20,6 +20,7 @@ package com.vaticle.typedb.core.concept.thing.impl;
 
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
+import com.vaticle.typedb.core.concept.ConceptManager;
 import com.vaticle.typedb.core.concept.thing.Attribute;
 import com.vaticle.typedb.core.concept.type.ThingType;
 import com.vaticle.typedb.core.concept.type.impl.AttributeTypeImpl;
@@ -44,18 +45,18 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
     AttributeVertex<VALUE> attributeVertex;
     AttributeTypeImpl attributeType;
 
-    private AttributeImpl(AttributeVertex<VALUE> vertex) {
-        super(vertex);
+    private AttributeImpl(ConceptManager conceptMgr, AttributeVertex<VALUE> vertex) {
+        super(conceptMgr, vertex);
         this.attributeVertex = vertex;
     }
 
-    public static AttributeImpl<?> of(AttributeVertex<?> vertex) {
+    public static AttributeImpl<?> of(ConceptManager conceptMgr, AttributeVertex<?> vertex) {
         Encoding.ValueType<?> valueType = vertex.valueType();
-        if (valueType == BOOLEAN) return new Boolean(vertex.asBoolean());
-        else if (valueType == LONG) return new Long(vertex.asLong());
-        else if (valueType == DOUBLE) return new Double(vertex.asDouble());
-        else if (valueType == STRING) return new String(vertex.asString());
-        else if (valueType == DATETIME) return new DateTime(vertex.asDateTime());
+        if (valueType == BOOLEAN) return new Boolean(conceptMgr, vertex.asBoolean());
+        else if (valueType == LONG) return new Long(conceptMgr, vertex.asLong());
+        else if (valueType == DOUBLE) return new Double(conceptMgr, vertex.asDouble());
+        else if (valueType == STRING) return new String(conceptMgr, vertex.asString());
+        else if (valueType == DATETIME) return new DateTime(conceptMgr, vertex.asDateTime());
         assert false;
         return null;
     }
@@ -76,21 +77,21 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
     @Override
     public AttributeTypeImpl getType() {
         if (attributeType == null) {
-            attributeType = AttributeTypeImpl.of(readableVertex().graphs(), readableVertex().type());
+            attributeType = AttributeTypeImpl.of(conceptMgr, readableVertex().type());
         }
         return attributeType;
     }
 
     @Override
     public FunctionalIterator<ThingImpl> getOwners() {
-        return readableVertex().ins().edge(HAS).from().map(ThingImpl::of);
+        return readableVertex().ins().edge(HAS).from().map(v -> ThingImpl.of(conceptMgr, v));
     }
 
     @Override
     public FunctionalIterator<ThingImpl> getOwners(ThingType ownerType) {
         return ownerType.getSubtypes().map(ot -> ((ThingTypeImpl) ot).vertex).flatMap(
                 v -> readableVertex().ins().edge(HAS, (PrefixIID.of(v.encoding().instance())), v.iid()).from()
-        ).map(ThingImpl::of);
+        ).map(v -> ThingImpl.of(conceptMgr, v));
     }
 
     @Override
@@ -160,8 +161,8 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     public static class Boolean extends AttributeImpl<java.lang.Boolean> implements Attribute.Boolean {
 
-        public Boolean(AttributeVertex<java.lang.Boolean> vertex) {
-            super(vertex);
+        public Boolean(ConceptManager conceptMgr, AttributeVertex<java.lang.Boolean> vertex) {
+            super(conceptMgr, vertex);
             assert vertex.type().valueType().equals(BOOLEAN);
         }
 
@@ -183,8 +184,8 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     public static class Long extends AttributeImpl<java.lang.Long> implements Attribute.Long {
 
-        public Long(AttributeVertex<java.lang.Long> vertex) {
-            super(vertex);
+        public Long(ConceptManager conceptMgr, AttributeVertex<java.lang.Long> vertex) {
+            super(conceptMgr, vertex);
             assert vertex.type().valueType().equals(LONG);
         }
 
@@ -206,8 +207,8 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     public static class Double extends AttributeImpl<java.lang.Double> implements Attribute.Double {
 
-        public Double(AttributeVertex<java.lang.Double> vertex) {
-            super(vertex);
+        public Double(ConceptManager conceptMgr, AttributeVertex<java.lang.Double> vertex) {
+            super(conceptMgr, vertex);
             assert vertex.type().valueType().equals(DOUBLE);
         }
 
@@ -229,8 +230,8 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     public static class String extends AttributeImpl<java.lang.String> implements Attribute.String {
 
-        public String(AttributeVertex<java.lang.String> vertex) {
-            super(vertex);
+        public String(ConceptManager conceptMgr, AttributeVertex<java.lang.String> vertex) {
+            super(conceptMgr, vertex);
             assert vertex.type().valueType().equals(STRING);
         }
 
@@ -252,8 +253,8 @@ public abstract class AttributeImpl<VALUE> extends ThingImpl implements Attribut
 
     public static class DateTime extends AttributeImpl<java.time.LocalDateTime> implements Attribute.DateTime {
 
-        public DateTime(AttributeVertex<LocalDateTime> vertex) {
-            super(vertex);
+        public DateTime(ConceptManager conceptMgr, AttributeVertex<LocalDateTime> vertex) {
+            super(conceptMgr, vertex);
             assert vertex.type().valueType().equals(DATETIME);
         }
 

--- a/concept/thing/impl/EntityImpl.java
+++ b/concept/thing/impl/EntityImpl.java
@@ -39,7 +39,7 @@ public class EntityImpl extends ThingImpl implements Entity {
 
     @Override
     public EntityType getType() {
-        return conceptMgr.convertThingType(readableVertex().type()).asEntityType();
+        return conceptMgr.convertEntityType(readableVertex().type()).asEntityType();
     }
 
     @Override

--- a/concept/thing/impl/EntityImpl.java
+++ b/concept/thing/impl/EntityImpl.java
@@ -20,6 +20,7 @@ package com.vaticle.typedb.core.concept.thing.impl;
 
 import com.vaticle.typedb.core.concept.ConceptManager;
 import com.vaticle.typedb.core.concept.thing.Entity;
+import com.vaticle.typedb.core.concept.type.EntityType;
 import com.vaticle.typedb.core.concept.type.impl.EntityTypeImpl;
 import com.vaticle.typedb.core.graph.vertex.ThingVertex;
 
@@ -37,8 +38,8 @@ public class EntityImpl extends ThingImpl implements Entity {
     }
 
     @Override
-    public EntityTypeImpl getType() {
-        return EntityTypeImpl.of(conceptMgr, readableVertex().type());
+    public EntityType getType() {
+        return conceptMgr.convertThingType(readableVertex().type()).asEntityType();
     }
 
     @Override

--- a/concept/thing/impl/EntityImpl.java
+++ b/concept/thing/impl/EntityImpl.java
@@ -18,6 +18,7 @@
 
 package com.vaticle.typedb.core.concept.thing.impl;
 
+import com.vaticle.typedb.core.concept.ConceptManager;
 import com.vaticle.typedb.core.concept.thing.Entity;
 import com.vaticle.typedb.core.concept.type.impl.EntityTypeImpl;
 import com.vaticle.typedb.core.graph.vertex.ThingVertex;
@@ -26,18 +27,18 @@ import static com.vaticle.typedb.core.encoding.Encoding.Vertex.Thing.ENTITY;
 
 public class EntityImpl extends ThingImpl implements Entity {
 
-    private EntityImpl(ThingVertex vertex) {
-        super(vertex);
+    private EntityImpl(ConceptManager conceptMgr, ThingVertex vertex) {
+        super(conceptMgr, vertex);
         assert vertex.encoding().equals(ENTITY);
     }
 
-    public static EntityImpl of(ThingVertex vertex) {
-        return new EntityImpl(vertex);
+    public static EntityImpl of(ConceptManager conceptMgr, ThingVertex vertex) {
+        return new EntityImpl(conceptMgr, vertex);
     }
 
     @Override
     public EntityTypeImpl getType() {
-        return EntityTypeImpl.of(readableVertex().graphs(), readableVertex().type());
+        return EntityTypeImpl.of(conceptMgr, readableVertex().type());
     }
 
     @Override

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -219,9 +219,9 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
     }
 
     @Override
-    public FunctionalIterator<? extends RoleType> getPlaying() {
+    public FunctionalIterator<RoleType> getPlaying() {
         return readableVertex().outs().edge(PLAYING).to().map(ThingVertex::type)
-                .map(v -> RoleTypeImpl.of(conceptMgr, v));
+                .map(conceptMgr::convertRoleType);
     }
 
     @Override
@@ -231,7 +231,7 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
                 throw exception(TypeDBException.of(INVALID_ROLE_TYPE_LABEL, scopedLabel));
             }
             String[] label = scopedLabel.split(":");
-            return RoleTypeImpl.of(conceptMgr, readableVertex().graph().type().getType(label[1], label[0]));
+            return conceptMgr.convertRoleType(readableVertex().graph().type().getType(label[1], label[0]));
         }).stream().toArray(RoleType[]::new));
     }
 

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -27,7 +27,6 @@ import com.vaticle.typedb.core.concept.thing.impl.AttributeImpl;
 import com.vaticle.typedb.core.concept.type.AttributeType;
 import com.vaticle.typedb.core.concept.type.RoleType;
 import com.vaticle.typedb.core.encoding.Encoding;
-import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.vertex.AttributeVertex;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 import com.vaticle.typeql.lang.common.TypeQLToken;
@@ -144,7 +143,7 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
         if (isRoot()) return emptySorted();
         else {
             return iterateSorted(graphMgr().schema().ownersOfAttributeType(vertex), ASC)
-                    .mapSorted(v -> ThingTypeImpl.of(conceptMgr, v), thingType -> thingType.vertex, ASC)
+                    .mapSorted(v -> (ThingTypeImpl) conceptMgr.convertThingType(v), thingType -> thingType.vertex, ASC)
                     .filter(thingType -> thingType.getOwns(this)
                             .map(owns -> owns.effectiveAnnotations().containsAll(annotations))
                             .orElse(false)
@@ -156,7 +155,7 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
     public Forwardable<? extends ThingTypeImpl, Order.Asc> getOwnersExplicit(Set<TypeQLToken.Annotation> annotations) {
         if (isRoot()) return emptySorted();
         Forwardable<TypeVertex, Order.Asc> iterator = vertex.ins().edge(OWNS_KEY).from().merge(vertex.ins().edge(OWNS).from());
-        return iterator.mapSorted(v -> ThingTypeImpl.of(conceptMgr, v), thingType -> thingType.vertex, ASC)
+        return iterator.mapSorted(v -> (ThingTypeImpl) conceptMgr.convertThingType(v), thingType -> thingType.vertex, ASC)
                 .filter(thingType -> thingType.getOwnsExplicit(this)
                         .map(owns -> owns.effectiveAnnotations().containsAll(annotations))
                         .orElse(false)

--- a/concept/type/impl/EntityTypeImpl.java
+++ b/concept/type/impl/EntityTypeImpl.java
@@ -21,12 +21,12 @@ package com.vaticle.typedb.core.concept.type.impl;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Forwardable;
 import com.vaticle.typedb.core.common.parameters.Order;
+import com.vaticle.typedb.core.concept.ConceptManager;
 import com.vaticle.typedb.core.concept.thing.Entity;
 import com.vaticle.typedb.core.concept.thing.impl.EntityImpl;
 import com.vaticle.typedb.core.concept.type.AttributeType;
 import com.vaticle.typedb.core.concept.type.EntityType;
 import com.vaticle.typedb.core.concept.type.RoleType;
-import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.vertex.ThingVertex;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 import com.vaticle.typeql.lang.common.TypeQLToken;
@@ -44,27 +44,27 @@ import static com.vaticle.typeql.lang.common.TypeQLToken.Char.SEMICOLON;
 
 public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
 
-    private EntityTypeImpl(GraphManager graphMgr, TypeVertex vertex) {
-        super(graphMgr, vertex);
+    private EntityTypeImpl(ConceptManager conceptMgr, TypeVertex vertex) {
+        super(conceptMgr, vertex);
         if (vertex.encoding() != ENTITY_TYPE) {
             throw exception(TypeDBException.of(TYPE_ROOT_MISMATCH, vertex.label(),
                     ENTITY_TYPE.root().label(), vertex.encoding().root().label()));
         }
     }
 
-    private EntityTypeImpl(GraphManager graphMgr, String label) {
-        super(graphMgr, label, ENTITY_TYPE);
+    private EntityTypeImpl(ConceptManager conceptMgr, String label) {
+        super(conceptMgr, label, ENTITY_TYPE);
         assert !label.equals(ENTITY.label());
     }
 
-    public static EntityTypeImpl of(GraphManager graphMgr, TypeVertex vertex) {
+    public static EntityTypeImpl of(ConceptManager conceptMgr, TypeVertex vertex) {
         if (vertex.label().equals(ENTITY.label())) {
-            return new EntityTypeImpl.Root(graphMgr, vertex);
-        } else return new EntityTypeImpl(graphMgr, vertex);
+            return new EntityTypeImpl.Root(conceptMgr, vertex);
+        } else return new EntityTypeImpl(conceptMgr, vertex);
     }
 
-    public static EntityTypeImpl of(GraphManager graphMgr, String label) {
-        return new EntityTypeImpl(graphMgr, label);
+    public static EntityTypeImpl of(ConceptManager conceptMgr, String label) {
+        return new EntityTypeImpl(conceptMgr, label);
     }
 
     @Override
@@ -75,23 +75,23 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
 
     @Override
     public Forwardable<EntityTypeImpl, Order.Asc> getSubtypes() {
-        return iterateSorted(graphMgr.schema().getSubtypes(vertex), ASC)
-                .mapSorted(v -> of(graphMgr, v), entityType -> entityType.vertex, ASC);
+        return iterateSorted(graphMgr().schema().getSubtypes(vertex), ASC)
+                .mapSorted(v -> of(conceptMgr, v), entityType -> entityType.vertex, ASC);
     }
 
     @Override
     public Forwardable<EntityTypeImpl, Order.Asc> getSubtypesExplicit() {
-        return super.getSubtypesExplicit(v -> of(graphMgr, v));
+        return super.getSubtypesExplicit(v -> of(conceptMgr, v));
     }
 
     @Override
     public Forwardable<EntityImpl, Order.Asc> getInstances() {
-        return instances(EntityImpl::of);
+        return instances(v -> EntityImpl.of(conceptMgr, v));
     }
 
     @Override
     public Forwardable<EntityImpl, Order.Asc> getInstancesExplicit() {
-        return instancesExplicit(EntityImpl::of);
+        return instancesExplicit(v -> EntityImpl.of(conceptMgr, v));
     }
 
     @Override
@@ -102,8 +102,8 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
     @Override
     public EntityImpl create(boolean isInferred) {
         validateCanHaveInstances(Entity.class);
-        ThingVertex.Write instance = graphMgr.data().create(vertex, isInferred);
-        return EntityImpl.of(instance);
+        ThingVertex.Write instance = graphMgr().data().create(vertex, isInferred);
+        return EntityImpl.of(conceptMgr, instance);
     }
 
     @Override
@@ -127,8 +127,8 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
 
     private static class Root extends EntityTypeImpl {
 
-        private Root(GraphManager graphMgr, TypeVertex vertex) {
-            super(graphMgr, vertex);
+        private Root(ConceptManager conceptMgr, TypeVertex vertex) {
+            super(conceptMgr, vertex);
             assert vertex.label().equals(ENTITY.label());
         }
 

--- a/concept/type/impl/EntityTypeImpl.java
+++ b/concept/type/impl/EntityTypeImpl.java
@@ -44,7 +44,7 @@ import static com.vaticle.typeql.lang.common.TypeQLToken.Char.SEMICOLON;
 
 public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
 
-    private EntityTypeImpl(ConceptManager conceptMgr, TypeVertex vertex) {
+    public EntityTypeImpl(ConceptManager conceptMgr, TypeVertex vertex) {
         super(conceptMgr, vertex);
         if (vertex.encoding() != ENTITY_TYPE) {
             throw exception(TypeDBException.of(TYPE_ROOT_MISMATCH, vertex.label(),
@@ -55,12 +55,6 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
     private EntityTypeImpl(ConceptManager conceptMgr, String label) {
         super(conceptMgr, label, ENTITY_TYPE);
         assert !label.equals(ENTITY.label());
-    }
-
-    public static EntityTypeImpl of(ConceptManager conceptMgr, TypeVertex vertex) {
-        if (vertex.label().equals(ENTITY.label())) {
-            return new EntityTypeImpl.Root(conceptMgr, vertex);
-        } else return new EntityTypeImpl(conceptMgr, vertex);
     }
 
     public static EntityTypeImpl of(ConceptManager conceptMgr, String label) {
@@ -77,14 +71,14 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
     public Forwardable<EntityTypeImpl, Order.Asc> getSubtypes() {
         return iterateSorted(graphMgr().schema().getSubtypes(vertex), ASC)
                 .mapSorted(
-                        v -> (EntityTypeImpl) conceptMgr.convertThingType(v).asEntityType(),
+                        v -> (EntityTypeImpl) conceptMgr.convertEntityType(v).asEntityType(),
                         entityType -> entityType.vertex, ASC
                 );
     }
 
     @Override
     public Forwardable<EntityTypeImpl, Order.Asc> getSubtypesExplicit() {
-        return super.getSubtypesExplicit(v -> (EntityTypeImpl) conceptMgr.convertThingType(v).asEntityType());
+        return super.getSubtypesExplicit(v -> (EntityTypeImpl) conceptMgr.convertEntityType(v).asEntityType());
     }
 
     @Override
@@ -128,9 +122,9 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
         builder.append(SEMICOLON).append(NEW_LINE);
     }
 
-    private static class Root extends EntityTypeImpl {
+    public static class Root extends EntityTypeImpl {
 
-        private Root(ConceptManager conceptMgr, TypeVertex vertex) {
+        public Root(ConceptManager conceptMgr, TypeVertex vertex) {
             super(conceptMgr, vertex);
             assert vertex.label().equals(ENTITY.label());
         }

--- a/concept/type/impl/EntityTypeImpl.java
+++ b/concept/type/impl/EntityTypeImpl.java
@@ -76,12 +76,15 @@ public class EntityTypeImpl extends ThingTypeImpl implements EntityType {
     @Override
     public Forwardable<EntityTypeImpl, Order.Asc> getSubtypes() {
         return iterateSorted(graphMgr().schema().getSubtypes(vertex), ASC)
-                .mapSorted(v -> of(conceptMgr, v), entityType -> entityType.vertex, ASC);
+                .mapSorted(
+                        v -> (EntityTypeImpl) conceptMgr.convertThingType(v).asEntityType(),
+                        entityType -> entityType.vertex, ASC
+                );
     }
 
     @Override
     public Forwardable<EntityTypeImpl, Order.Asc> getSubtypesExplicit() {
-        return super.getSubtypesExplicit(v -> of(conceptMgr, v));
+        return super.getSubtypesExplicit(v -> (EntityTypeImpl) conceptMgr.convertThingType(v).asEntityType());
     }
 
     @Override

--- a/concept/type/impl/RelationTypeImpl.java
+++ b/concept/type/impl/RelationTypeImpl.java
@@ -59,7 +59,7 @@ import static java.util.Comparator.comparing;
 
 public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
 
-    private RelationTypeImpl(ConceptManager conceptMgr, TypeVertex vertex) {
+    public RelationTypeImpl(ConceptManager conceptMgr, TypeVertex vertex) {
         super(conceptMgr, vertex);
         if (vertex.encoding() != RELATION_TYPE) {
             throw exception(TypeDBException.of(TYPE_ROOT_MISMATCH, vertex.label(),
@@ -69,11 +69,6 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
 
     private RelationTypeImpl(ConceptManager conceptMgr, String label) {
         super(conceptMgr, label, RELATION_TYPE);
-    }
-
-    public static RelationTypeImpl of(ConceptManager conceptMgr, TypeVertex vertex) {
-        if (vertex.label().equals(RELATION.label())) return new RelationTypeImpl.Root(conceptMgr, vertex);
-        else return new RelationTypeImpl(conceptMgr, vertex);
     }
 
     public static RelationType of(ConceptManager conceptMgr, String label) {
@@ -227,7 +222,7 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
         Optional<RoleTypeImpl> roleType;
         TypeVertex roleTypeVertex = graphMgr().schema().getType(roleLabel, vertex.label());
         if (roleTypeVertex != null) {
-            return conceptMgr.convertRoleType(vertex);
+            return conceptMgr.convertRoleType(roleTypeVertex);
         } else if ((roleType = getRelates().filter(role -> role.getLabel().name().equals(roleLabel)).first()).isPresent()) {
             return roleType.get();
         } else return null;
@@ -305,7 +300,7 @@ public class RelationTypeImpl extends ThingTypeImpl implements RelationType {
 
     public static class Root extends RelationTypeImpl {
 
-        Root(ConceptManager conceptMgr, TypeVertex vertex) {
+        public Root(ConceptManager conceptMgr, TypeVertex vertex) {
             super(conceptMgr, vertex);
             assert vertex.label().equals(RELATION.label());
         }

--- a/concept/type/impl/RoleTypeImpl.java
+++ b/concept/type/impl/RoleTypeImpl.java
@@ -50,7 +50,7 @@ import static com.vaticle.typedb.core.encoding.Encoding.Vertex.Type.Root.ROLE;
 
 public class RoleTypeImpl extends TypeImpl implements RoleType {
 
-    private RoleTypeImpl(ConceptManager conceptMgr, TypeVertex vertex) {
+    public RoleTypeImpl(ConceptManager conceptMgr, TypeVertex vertex) {
         super(conceptMgr, vertex);
         assert vertex.encoding() == ROLE_TYPE;
         if (vertex.encoding() != ROLE_TYPE) {
@@ -61,11 +61,6 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
 
     private RoleTypeImpl(ConceptManager conceptMgr, String label, String relation) {
         super(conceptMgr, label, ROLE_TYPE, relation);
-    }
-
-    public static RoleTypeImpl of(ConceptManager conceptMgr, TypeVertex vertex) {
-        if (vertex.label().equals(ROLE.label())) return new RoleTypeImpl.Root(conceptMgr, vertex);
-        else return new RoleTypeImpl(conceptMgr, vertex);
     }
 
     public static RoleTypeImpl of(ConceptManager conceptMgr, String label, String relation) {
@@ -121,7 +116,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
     @Override
     public Forwardable<ThingTypeImpl, Order.Asc> getPlayerTypes() {
         return iterateSorted(graphMgr().schema().playersOfRoleType(vertex), ASC)
-                .mapSorted(v -> (ThingTypeImpl) conceptMgr.convertType(v), roleType -> roleType.vertex, ASC);
+                .mapSorted(v -> (ThingTypeImpl) conceptMgr.convertThingType(v), roleType -> roleType.vertex, ASC);
     }
 
     @Override
@@ -217,7 +212,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
 
     public static class Root extends RoleTypeImpl {
 
-        Root(ConceptManager conceptMgr, TypeVertex vertex) {
+        public Root(ConceptManager conceptMgr, TypeVertex vertex) {
             super(conceptMgr, vertex);
             assert vertex.label().equals(ROLE.label());
         }

--- a/concept/type/impl/RoleTypeImpl.java
+++ b/concept/type/impl/RoleTypeImpl.java
@@ -22,13 +22,13 @@ import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Forwardable;
 import com.vaticle.typedb.core.common.parameters.Order;
+import com.vaticle.typedb.core.concept.ConceptManager;
 import com.vaticle.typedb.core.concept.thing.Entity;
 import com.vaticle.typedb.core.concept.thing.impl.RelationImpl;
 import com.vaticle.typedb.core.concept.thing.impl.RoleImpl;
 import com.vaticle.typedb.core.concept.thing.impl.ThingImpl;
 import com.vaticle.typedb.core.concept.type.RoleType;
 import com.vaticle.typedb.core.encoding.Encoding;
-import com.vaticle.typedb.core.graph.GraphManager;
 import com.vaticle.typedb.core.graph.vertex.ThingVertex;
 import com.vaticle.typedb.core.graph.vertex.TypeVertex;
 
@@ -49,8 +49,8 @@ import static com.vaticle.typedb.core.encoding.Encoding.Vertex.Type.Root.ROLE;
 
 public class RoleTypeImpl extends TypeImpl implements RoleType {
 
-    private RoleTypeImpl(GraphManager graphMgr, TypeVertex vertex) {
-        super(graphMgr, vertex);
+    private RoleTypeImpl(ConceptManager conceptMgr, TypeVertex vertex) {
+        super(conceptMgr, vertex);
         assert vertex.encoding() == ROLE_TYPE;
         if (vertex.encoding() != ROLE_TYPE) {
             throw exception(TypeDBException.of(TYPE_ROOT_MISMATCH, vertex.label(),
@@ -58,17 +58,17 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
         }
     }
 
-    private RoleTypeImpl(GraphManager graphMgr, String label, String relation) {
-        super(graphMgr, label, ROLE_TYPE, relation);
+    private RoleTypeImpl(ConceptManager conceptMgr, String label, String relation) {
+        super(conceptMgr, label, ROLE_TYPE, relation);
     }
 
-    public static RoleTypeImpl of(GraphManager graphMgr, TypeVertex vertex) {
-        if (vertex.label().equals(ROLE.label())) return new RoleTypeImpl.Root(graphMgr, vertex);
-        else return new RoleTypeImpl(graphMgr, vertex);
+    public static RoleTypeImpl of(ConceptManager conceptMgr, TypeVertex vertex) {
+        if (vertex.label().equals(ROLE.label())) return new RoleTypeImpl.Root(conceptMgr, vertex);
+        else return new RoleTypeImpl(conceptMgr, vertex);
     }
 
-    public static RoleTypeImpl of(GraphManager graphMgr, String label, String relation) {
-        return new RoleTypeImpl(graphMgr, label, relation);
+    public static RoleTypeImpl of(ConceptManager conceptMgr, String label, String relation) {
+        return new RoleTypeImpl(conceptMgr, label, relation);
     }
 
     void setAbstract() {
@@ -86,77 +86,77 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
     @Nullable
     @Override
     public RoleTypeImpl getSupertype() {
-        return vertex.outs().edge(SUB).to().map(t -> RoleTypeImpl.of(graphMgr, t)).firstOrNull();
+        return vertex.outs().edge(SUB).to().map(t -> RoleTypeImpl.of(conceptMgr, t)).firstOrNull();
     }
 
     @Override
     public Forwardable<RoleTypeImpl, Order.Asc> getSupertypes() {
-        return iterateSorted(graphMgr.schema().getSupertypes(vertex), ASC)
-                .mapSorted(v -> of(graphMgr, v), rt -> rt.vertex, ASC);
+        return iterateSorted(graphMgr().schema().getSupertypes(vertex), ASC)
+                .mapSorted(v -> of(conceptMgr, v), rt -> rt.vertex, ASC);
     }
 
     @Override
     public Forwardable<RoleTypeImpl, Order.Asc> getSubtypes() {
-        return iterateSorted(graphMgr.schema().getSubtypes(vertex), ASC)
-                .mapSorted(v -> of(graphMgr, v), rt -> rt.vertex, ASC);
+        return iterateSorted(graphMgr().schema().getSubtypes(vertex), ASC)
+                .mapSorted(v -> of(conceptMgr, v), rt -> rt.vertex, ASC);
     }
 
     @Override
     public Forwardable<RoleTypeImpl, Order.Asc> getSubtypesExplicit() {
-        return super.getSubtypesExplicit(v -> of(graphMgr, v));
+        return super.getSubtypesExplicit(v -> of(conceptMgr, v));
     }
 
     @Override
     public RelationTypeImpl getRelationType() {
-        return RelationTypeImpl.of(graphMgr, vertex.ins().edge(Encoding.Edge.Type.RELATES).from().first().get());
+        return RelationTypeImpl.of(conceptMgr, vertex.ins().edge(Encoding.Edge.Type.RELATES).from().first().get());
     }
 
     @Override
     public Forwardable<RelationTypeImpl, Order.Asc> getRelationTypes() {
-        return iterateSorted(graphMgr.schema().relationsOfRoleType(vertex), ASC)
-                .mapSorted(v -> RelationTypeImpl.of(graphMgr, v), relType -> relType.vertex, ASC);
+        return iterateSorted(graphMgr().schema().relationsOfRoleType(vertex), ASC)
+                .mapSorted(v -> RelationTypeImpl.of(conceptMgr, v), relType -> relType.vertex, ASC);
     }
 
     @Override
     public Forwardable<ThingTypeImpl, Order.Asc> getPlayerTypes() {
-        return iterateSorted(graphMgr.schema().playersOfRoleType(vertex), ASC)
-                .mapSorted(v -> ThingTypeImpl.of(graphMgr, v), roleType -> roleType.vertex, ASC);
+        return iterateSorted(graphMgr().schema().playersOfRoleType(vertex), ASC)
+                .mapSorted(v -> ThingTypeImpl.of(conceptMgr, v), roleType -> roleType.vertex, ASC);
     }
 
     @Override
     public Forwardable<ThingTypeImpl, Order.Asc> getPlayerTypesExplicit() {
         return vertex.ins().edge(Encoding.Edge.Type.PLAYS).from()
-                .mapSorted(v -> ThingTypeImpl.of(graphMgr, v), thingType -> thingType.vertex, ASC);
+                .mapSorted(v -> ThingTypeImpl.of(conceptMgr, v), thingType -> thingType.vertex, ASC);
     }
 
     @Override
     public FunctionalIterator<RelationImpl> getRelationInstances() {
         return getSubtypes().filter(t -> !t.isAbstract())
-                .flatMap(t -> graphMgr.data().getReadable(t.vertex))
+                .flatMap(t -> graphMgr().data().getReadable(t.vertex))
                 .flatMap(v -> v.ins().edge(Encoding.Edge.Thing.Base.RELATING).from())
-                .map(RelationImpl::of);
+                .map(v -> RelationImpl.of(conceptMgr, v));
     }
 
     @Override
     public FunctionalIterator<RelationImpl> getRelationInstancesExplicit() {
-        return graphMgr.data().getReadable(vertex)
+        return graphMgr().data().getReadable(vertex)
                 .flatMap(v -> v.ins().edge(Encoding.Edge.Thing.Base.RELATING).from())
-                .map(RelationImpl::of);
+                .map(v -> RelationImpl.of(conceptMgr, v));
     }
 
     @Override
     public FunctionalIterator<ThingImpl> getPlayerInstances() {
         return getSubtypes().filter(t -> !t.isAbstract())
-                .flatMap(t -> graphMgr.data().getReadable(t.vertex))
+                .flatMap(t -> graphMgr().data().getReadable(t.vertex))
                 .flatMap(v -> v.ins().edge(Encoding.Edge.Thing.Base.PLAYING).from())
-                .map(ThingImpl::of);
+                .map(v -> ThingImpl.of(conceptMgr, v));
     }
 
     @Override
     public FunctionalIterator<ThingImpl> getPlayerInstancesExplicit() {
-        return graphMgr.data().getReadable(vertex)
+        return graphMgr().data().getReadable(vertex)
                 .flatMap(v -> v.ins().edge(Encoding.Edge.Thing.Base.PLAYING).from())
-                .map(ThingImpl::of);
+                .map(v -> ThingImpl.of(conceptMgr, v));
     }
 
     @Override
@@ -175,7 +175,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
 
     private FunctionalIterator<RoleImpl> getInstances() {
         return getSubtypes().filter(t -> !t.isAbstract())
-                .flatMap(t -> graphMgr.data().getReadable(t.vertex))
+                .flatMap(t -> graphMgr().data().getReadable(t.vertex))
                 .map(RoleImpl::of);
     }
 
@@ -210,14 +210,14 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
 
     public RoleImpl create(boolean isInferred) {
         validateCanHaveInstances(Entity.class);
-        ThingVertex.Write instance = graphMgr.data().create(vertex, isInferred);
+        ThingVertex.Write instance = graphMgr().data().create(vertex, isInferred);
         return RoleImpl.of(instance);
     }
 
     public static class Root extends RoleTypeImpl {
 
-        Root(GraphManager graphMgr, TypeVertex vertex) {
-            super(graphMgr, vertex);
+        Root(ConceptManager conceptMgr, TypeVertex vertex) {
+            super(conceptMgr, vertex);
             assert vertex.label().equals(ROLE.label());
         }
 

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -121,21 +121,6 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
         else cache = null;
     }
 
-    public static ThingTypeImpl of(ConceptManager conceptMgr, TypeVertex vertex) {
-        switch (vertex.encoding()) {
-            case ENTITY_TYPE:
-                return EntityTypeImpl.of(conceptMgr, vertex);
-            case ATTRIBUTE_TYPE:
-                return AttributeTypeImpl.of(conceptMgr, vertex);
-            case RELATION_TYPE:
-                return RelationTypeImpl.of(conceptMgr, vertex);
-            case THING_TYPE:
-                return new ThingTypeImpl.Root(conceptMgr, vertex);
-            default:
-                throw conceptMgr.exception(TypeDBException.of(UNRECOGNISED_VALUE));
-        }
-    }
-
     @Override
     public java.lang.String getSyntax() {
         StringBuilder builder = new StringBuilder();
@@ -399,7 +384,7 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
         validateIsNotDeleted();
         setPlays(roleType);
         override(this, PLAYS, roleType, overriddenType, getSupertype().getPlays(),
-                vertex.outs().edge(PLAYS).to().mapSorted(v ->  (RoleTypeImpl) conceptMgr.convertRoleType(v), rt -> rt.vertex, ASC),
+                vertex.outs().edge(PLAYS).to().mapSorted(v -> (RoleTypeImpl) conceptMgr.convertRoleType(v), rt -> rt.vertex, ASC),
                 OVERRIDDEN_PLAYED_ROLE_TYPE_NOT_SUPERTYPE);
     }
 

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -277,8 +277,7 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
     @Override
     public NavigableSet<Owns> getOwns() {
         if (cache != null) {
-            if (cache.owns == null && !isAbstract()) cache.owns = fetchOwns();
-            else if (cache.owns == null) cache.owns = emptyNavigableSet();
+            if (cache.owns == null) cache.owns = fetchOwns();
             return cache.owns;
         } else return fetchOwns();
     }
@@ -881,7 +880,7 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
         @Override
         public String toString() {
             StringBuilder builder = new StringBuilder();
-            builder.append(owner.getLabel());
+            builder.append(owner.getLabel()).append(SPACE);
             getSyntax(builder);
             return builder.toString();
         }

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -73,15 +73,6 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
         vertex.outs().put(SUB, superTypeVertex);
     }
 
-    public static TypeImpl of(ConceptManager conceptMgr, GraphManager graphMgr, TypeVertex vertex) {
-        switch (vertex.encoding()) {
-            case ROLE_TYPE:
-                return RoleTypeImpl.of(conceptMgr, vertex);
-            default:
-                return ThingTypeImpl.of(conceptMgr, vertex);
-        }
-    }
-
     @Override
     public boolean isDeleted() {
         return vertex.isDeleted();
@@ -204,7 +195,7 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
 
     @Override
     public TypeDBException exception(TypeDBException exception) {
-        return graphMgr().exception(exception);
+        return conceptMgr.exception(exception);
     }
 
     @Override

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -24,6 +24,7 @@ import com.vaticle.typedb.core.common.iterator.sorted.SortedIterator.Forwardable
 import com.vaticle.typedb.core.common.parameters.Label;
 import com.vaticle.typedb.core.common.parameters.Order;
 import com.vaticle.typedb.core.concept.ConceptImpl;
+import com.vaticle.typedb.core.concept.ConceptManager;
 import com.vaticle.typedb.core.concept.type.AttributeType;
 import com.vaticle.typedb.core.concept.type.EntityType;
 import com.vaticle.typedb.core.concept.type.RelationType;
@@ -53,32 +54,31 @@ import static com.vaticle.typedb.core.encoding.Encoding.Edge.Type.SUB;
 
 public abstract class TypeImpl extends ConceptImpl implements Type {
 
-    protected final GraphManager graphMgr;
     public final TypeVertex vertex;
 
-    TypeImpl(GraphManager graphMgr, TypeVertex vertex) {
-        this.graphMgr = graphMgr;
+    TypeImpl(ConceptManager conceptMgr, TypeVertex vertex) {
+        super(conceptMgr);
         this.vertex = Objects.requireNonNull(vertex);
     }
 
-    TypeImpl(GraphManager graphMgr, String label, Encoding.Vertex.Type encoding) {
-        this(graphMgr, label, encoding, null);
+    TypeImpl(ConceptManager conceptMgr, String label, Encoding.Vertex.Type encoding) {
+        this(conceptMgr, label, encoding, null);
     }
 
-    TypeImpl(GraphManager graphMgr, String label, Encoding.Vertex.Type encoding, String scope) {
+    TypeImpl(ConceptManager conceptMgr, String label, Encoding.Vertex.Type encoding, String scope) {
+        super(conceptMgr);
         label = TypeQL.parseLabel(label);
-        this.graphMgr = graphMgr;
-        this.vertex = graphMgr.schema().create(encoding, label, scope);
-        TypeVertex superTypeVertex = graphMgr.schema().getType(encoding.root().label(), encoding.root().scope());
+        this.vertex = graphMgr().schema().create(encoding, label, scope);
+        TypeVertex superTypeVertex = graphMgr().schema().getType(encoding.root().label(), encoding.root().scope());
         vertex.outs().put(SUB, superTypeVertex);
     }
 
-    public static TypeImpl of(GraphManager graphMgr, TypeVertex vertex) {
+    public static TypeImpl of(ConceptManager conceptMgr, GraphManager graphMgr, TypeVertex vertex) {
         switch (vertex.encoding()) {
             case ROLE_TYPE:
-                return RoleTypeImpl.of(graphMgr, vertex);
+                return RoleTypeImpl.of(conceptMgr, vertex);
             default:
-                return ThingTypeImpl.of(graphMgr, vertex);
+                return ThingTypeImpl.of(conceptMgr, vertex);
         }
     }
 
@@ -94,7 +94,7 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
 
     @Override
     public long getInstancesCount() {
-        return graphMgr.data().stats().thingVertexTransitiveCount(vertex);
+        return graphMgr().data().stats().thingVertexTransitiveCount(vertex);
     }
 
     @Override
@@ -124,6 +124,10 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
     @Override
     public abstract Forwardable<? extends TypeImpl, Order.Asc> getSubtypesExplicit();
 
+    GraphManager graphMgr() {
+        return conceptMgr.graph();
+    }
+
     void setSuperTypeVertex(TypeVertex superTypeVertex) {
         vertex.outs().edge(SUB, ((TypeImpl) getSupertype()).vertex).delete();
         vertex.outs().put(SUB, superTypeVertex);
@@ -149,7 +153,7 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
 
     void validateDelete() {
         if (isRoot()) throw exception(TypeDBException.of(ROOT_TYPE_MUTATION));
-        FunctionalIterator<RuleStructure> rules = graphMgr.schema().rules().references().get(vertex);
+        FunctionalIterator<RuleStructure> rules = graphMgr().schema().rules().references().get(vertex);
         if (rules.hasNext()) {
             throw exception(TypeDBException.of(TYPE_REFERENCED_IN_RULES, getLabel(), rules.map(RuleStructure::label).toList()));
         }
@@ -200,7 +204,7 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
 
     @Override
     public TypeDBException exception(TypeDBException exception) {
-        return graphMgr.exception(exception);
+        return graphMgr().exception(exception);
     }
 
     @Override

--- a/encoding/Encoding.java
+++ b/encoding/Encoding.java
@@ -633,6 +633,11 @@ public class Encoding {
             if (sourceEncoding.equals(DATETIME)) return (LocalDateTime) sourceValue;
             else throw TypeDBException.of(ILLEGAL_STATE);
         }
+
+        @Override
+        public String toString() {
+            return name;
+        }
     }
 
     public interface Structure {
@@ -735,6 +740,7 @@ public class Encoding {
 
                 private final String label;
                 private final String scope;
+                private final Label properLabel;
 
                 Root(String label) {
                     this(label, null);
@@ -743,6 +749,7 @@ public class Encoding {
                 Root(String label, @Nullable String scope) {
                     this.label = label;
                     this.scope = scope;
+                    this.properLabel = Label.of(label, scope);
                 }
 
                 public String label() {
@@ -754,7 +761,7 @@ public class Encoding {
                 }
 
                 public Label properLabel() {
-                    return Label.of(label, scope);
+                    return properLabel;
                 }
             }
         }


### PR DESCRIPTION
## What is the goal of this PR?

Many data operations rely on the schema easily and performantly available. However, we only cached the schema at the lower "graph" layer - which has no knowledge of semantic constructs like ownerships. 

As of #6775, caching at the Concept layer becomes particularly useful since it introduces constructs to represent ownerships. To avoid re-computing type ownerships, we had already introduced caching in the owner Type. However, the Type itself was repeatedly constructed, negating the usage of this cache. 

This change introducing a schema cache in the Concept Manager, and redirects all constructions of Type concepts via the Concept Manager to leverage the cache. This cache is only active when the schema is read-only.

With this change, we can see heavy write performance of improve by up to 35%, in particular when writing attribute ownerships.

## What are the changes implemented in this PR?

* Introduce a cache in the ConceptManager to avoid re-creating schema Types
* Remove all constructors of shape `Type.of(vertex)` - the Concept Manager now directly creates the appropriate type of Type concept itself.
* Redirect all construction of Types by wrapping vertices to go through the Concept Manager, which allows us to return cached Types
  * To implement this, all Concepts now carry a `ConceptManager` within them, instead of a `GraphManager`