### PR TITLE
Fix assertions in Data Importer

### DIFF
--- a/migrator/data/DataImporter.java
+++ b/migrator/data/DataImporter.java
@@ -248,6 +248,7 @@ public class DataImporter {
                 conceptTracker.recordMapped(originalID, pair.second());
                 if (incompleteIDs.contains(originalID)) conceptTracker.recordIncomplete(originalID);
             });
+            incompleteIDs.clear();
             bufferedToOriginalIDs.clear();
             originalToBufferedIDs.clear();
             completedIDs.forEach(conceptTracker::deleteIncomplete);
@@ -282,9 +283,7 @@ public class DataImporter {
             if ((newIID = originalToBufferedIDs.get(originalID)) == null && (newIID = conceptTracker.getMapped(originalID)) == null) {
                 return null;
             } else {
-                Thing thing = transaction.concepts().getThing(newIID);
-                assert thing != null;
-                return thing;
+                return transaction.concepts().getThing(newIID);
             }
         }
 


### PR DESCRIPTION
## What is the goal of this PR?
Remove one overly-restrictive assert and fix a bug which was triggering another assert.
This bug would not have affected correctness or completeness of the import.

## What are the changes implemented in this PR?
* `getMappedThing` can return null in the case of nested relations, since the relation may only be processed in a later batch.
* clearing incompleteIDs on commit. After committing, the responsibility of incompleteIIDs lies with the conceptTracker