### PR TITLE
Fix concurrency bug with ByteArray hashCode

### DIFF
--- a/common/collection/ByteArray.java
+++ b/common/collection/ByteArray.java
@@ -327,10 +327,11 @@ public abstract class ByteArray implements Comparable<ByteArray> {
     @Override
     public final int hashCode() {
         if (hash == 0) {
-            hash = 1;
+            int arrayHash = 1;
             for (int i = 0; i < length(); i++) {
-                hash = 31 * hash + (int) get(i);
+                arrayHash = 31 * arrayHash + (int) get(i);
             }
+            hash = arrayHash;
         }
         return hash;
     }


### PR DESCRIPTION
## What is the goal of this PR?
Fix concurrency bug with the lazily evaluated hashCode of the ByteArray class
 
## What are the changes implemented in this PR?
* Computes the hashCode in a local variable and assigns to the member variable in one step, avoiding issues where two concurrent calls to hashCode would interfere with each others' computation. 
