### PR TITLE
Relax rule conclusion validation to facilitate rules over abstract types

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -647,8 +647,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new RuleWrite(6, "The rule '%s' has a branch in the when clause '%s' that can never have answers in the current schema.");
         public static final RuleWrite RULE_THEN_INCOHERENT =
                 new RuleWrite(7, "The rule '%s' has a then clause '%s' that can never be satisfied in the current schema.");
-        public static final RuleWrite RULE_THEN_UNANSWERABLE =
-                new RuleWrite(8, "The rule '%s' has a then clause '%s' that can never have answers in the current schema.");
+        public static final RuleWrite RULE_THEN_INSERTS_ABSTRACT_TYPES =
+                new RuleWrite(8, "The rule '%s' has a then clause '%s' which tries to insert instances of types '%s', some of which are abstract.");
         public static final RuleWrite RULE_THEN_INVALID_VALUE_ASSIGNMENT =
                 new RuleWrite(9, "The rule '%s' has a then clause with an invalid assignment of '%s' into a '%s'.");
         public static final RuleWrite MAX_RULE_REACHED =

--- a/logic/tool/TypeInference.java
+++ b/logic/tool/TypeInference.java
@@ -91,7 +91,7 @@ public class TypeInference {
     }
 
     private void applyCombination(Disjunction disjunction, Map<Identifier.Variable.Name, Set<Label>> bounds) {
-        disjunction.conjunctions().forEach(conjunction -> applyCombination(conjunction, bounds, false));
+       disjunction.conjunctions().forEach(conjunction -> applyCombination(conjunction, bounds, false));
     }
 
     public void applyCombination(Conjunction conjunction) {
@@ -194,7 +194,9 @@ public class TypeInference {
             Map<Retrievable, Order> sortOrder = new HashMap<>();
             sortVars.forEach(var -> sortOrder.put(var, Order.Asc.ASC));
             traversal.modifiers().filter(inferenceFilter).sorting(Modifiers.Sorting.create(sortVars, sortOrder));
-            return traversalEng.iterator(traversal).map(vertexMap -> {
+            return traversalEng.iterator(traversal).filter(vertexMap ->
+                !iterate(vertexMap.map().entrySet()).anyMatch(e -> thingInferenceVars().contains(e.getKey()) && e.getValue().asType().isAbstract())
+            ).map(vertexMap -> {
                 Map<Identifier.Variable.Name, Label> labels = new HashMap<>();
                 vertexMap.forEach((id, vertex) -> {
                     if (!inferenceToOriginal.containsKey(id)) return;
@@ -338,7 +340,7 @@ public class TypeInference {
 
         private void registerPredicate(TypeVariable inferenceVar, PredicateConstraint constraint) {
             Set<Encoding.ValueType<?>> predicateValueTypes;
-            Predicate predicate = constraint.predicate();
+            Predicate<?> predicate = constraint.predicate();
             if (predicate.isConstant()) {
                 predicateValueTypes = set(Encoding.ValueType.of(predicate.value().getClass()));
             } else if (predicate.isThingVar()) {


### PR DESCRIPTION
## What is the goal of this PR?

A follow on from #6801 , we finish the rule validation relaxation implemented there. We further relax the 'then' of the rule to operate over concrete  variables, as long as all the type variables that define _which_ instances to create during materialisation are concrete.

For example:
```
define
abstract-person sub entity, abstract, plays friendship:friend; #abstract
friendship sub relation, relates friend;  #non-abstract

rule concrete-relation-over-abstract-players: 
when { 
   $x isa abstract-person;
} then {
   (friend: $x) isa friendship;
};
```

Is now a legal rule to write since the 'friendship' that would be created is an instance of a concrete type.


## What are the changes implemented in this PR?

* Relax rule 'then' validation to only validate that the type provided in 'isa' constraints may not contain abstract types
