### PR TITLE
Replace RocskDB with SpeeDB

### DIFF
--- a/database/BUILD
+++ b/database/BUILD
@@ -54,17 +54,17 @@ native_java_libraries(
     mac_deps = [
         "@maven//:com_google_ortools_ortools_darwin",
         "@maven//:com_google_ortools_ortools_darwin_java",
-        "@maven//:org_rocksdb_rocksdbjni",
+        "@maven//:io_github_speedb_io_speedbjni_2_4_1",
     ],
     linux_deps = [
         "@maven//:com_google_ortools_ortools_linux_x86_64",
         "@maven//:com_google_ortools_ortools_linux_x86_64_java",
-        "@maven//:org_rocksdb_rocksdbjni",
+        "@maven//:io_github_speedb_io_speedbjni_2_4_1",
     ],
     windows_deps = [
         "@maven//:com_google_ortools_ortools_win32_x86_64",
         "@maven//:com_google_ortools_ortools_win32_x86_64_java",
-        "@maven//:org_rocksdb_rocksdbjni",
+        "@maven//:io_github_speedb_io_speedbjni_2_4_1",
     ],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-database:{pom_version}"],
     visibility = [ "//visibility:public" ]

--- a/database/BUILD
+++ b/database/BUILD
@@ -54,17 +54,17 @@ native_java_libraries(
     mac_deps = [
         "@maven//:com_google_ortools_ortools_darwin",
         "@maven//:com_google_ortools_ortools_darwin_java",
-        "@maven//:io_github_speedb_io_speedbjni_2_4_1",
+        "@maven//:io_github_speedb_io_speedbjni",
     ],
     linux_deps = [
         "@maven//:com_google_ortools_ortools_linux_x86_64",
         "@maven//:com_google_ortools_ortools_linux_x86_64_java",
-        "@maven//:io_github_speedb_io_speedbjni_2_4_1",
+        "@maven//:io_github_speedb_io_speedbjni",
     ],
     windows_deps = [
         "@maven//:com_google_ortools_ortools_win32_x86_64",
         "@maven//:com_google_ortools_ortools_win32_x86_64_java",
-        "@maven//:io_github_speedb_io_speedbjni_2_4_1",
+        "@maven//:io_github_speedb_io_speedbjni",
     ],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-database:{pom_version}"],
     visibility = [ "//visibility:public" ]

--- a/dependencies/maven/artifacts.bzl
+++ b/dependencies/maven/artifacts.bzl
@@ -33,14 +33,13 @@ artifacts = [
     "com.eclipsesource.minimal-json:minimal-json",
     "io.cucumber:cucumber-java",
     "io.cucumber:cucumber-junit",
+    "io.github.speedb-io:speedbjni",
     "io.grpc:grpc-api",
     "io.grpc:grpc-netty",
     "io.grpc:grpc-stub",
     "io.netty:netty-all",
     "io.netty:netty-transport",
     "junit:junit",
-    "org.rocksdb:rocksdbjni",
-    "org.rocksdb:rocksdbjni-dev-mac",
     "org.slf4j:slf4j-api",
     "org.zeroturnaround:zt-exec"
 ]

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -35,6 +35,7 @@
 @maven//:io_cucumber_datatable_3_2_1
 @maven//:io_cucumber_docstring_5_1_3
 @maven//:io_cucumber_tag_expressions_2_0_4
+@maven//:io_github_speedb_io_speedbjni_2_4_1
 @maven//:io_grpc_grpc_api_1_43_0
 @maven//:io_grpc_grpc_context_1_43_0
 @maven//:io_grpc_grpc_core_1_43_0
@@ -100,8 +101,6 @@
 @maven//:org_jetbrains_compose_compiler_compiler_1_3_2
 @maven//:org_mockito_mockito_core_2_6_4
 @maven//:org_objenesis_objenesis_2_5
-@maven//:org_rocksdb_rocksdbjni_6_20_3
-@maven//:org_rocksdb_rocksdbjni_dev_mac_6_20_3
 @maven//:org_slf4j_slf4j_api_1_7_32
 @maven//:org_yaml_snakeyaml_1_25
 @maven//:org_zeroturnaround_zt_exec_1_10

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "c340321b671a013004a309d63d8d08cf83d1d1f1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "5463970c55b4a14defb1c363420bb7f1f2a4df2c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "51fdda8c935d5f9fc34bfdf41b0a6ac1ca77e2ee",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/krishnangovindraj/dependencies",
+        commit = "c340321b671a013004a309d63d8d08cf83d1d1f1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():

--- a/migrator/BUILD
+++ b/migrator/BUILD
@@ -73,13 +73,13 @@ native_java_libraries(
         "@maven//:org_slf4j_slf4j_api",
     ],
     mac_deps = [
-        "@maven//:org_rocksdb_rocksdbjni_dev_mac"
+        "@maven//:io_github_speedb_io_speedbjni_2_4_1"
     ],
     linux_deps = [
-        "@maven//:org_rocksdb_rocksdbjni",
+        "@maven//:io_github_speedb_io_speedbjni_2_4_1",
     ],
     windows_deps = [
-        "@maven//:org_rocksdb_rocksdbjni",
+        "@maven//:io_github_speedb_io_speedbjni_2_4_1",
     ],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-migrator:{pom_version}"],
     visibility = ["//visibility:public"],

--- a/migrator/BUILD
+++ b/migrator/BUILD
@@ -73,13 +73,13 @@ native_java_libraries(
         "@maven//:org_slf4j_slf4j_api",
     ],
     mac_deps = [
-        "@maven//:io_github_speedb_io_speedbjni_2_4_1"
+        "@maven//:io_github_speedb_io_speedbjni"
     ],
     linux_deps = [
-        "@maven//:io_github_speedb_io_speedbjni_2_4_1",
+        "@maven//:io_github_speedb_io_speedbjni",
     ],
     windows_deps = [
-        "@maven//:io_github_speedb_io_speedbjni_2_4_1",
+        "@maven//:io_github_speedb_io_speedbjni",
     ],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-migrator:{pom_version}"],
     visibility = ["//visibility:public"],

--- a/server/BUILD
+++ b/server/BUILD
@@ -127,6 +127,7 @@ java_binary(
     data = [":prepare-server-directories"]
 )
 
+
 java_deps(
     name = "server-deps-mac",
     target = ":server-bin-mac",
@@ -260,4 +261,3 @@ checkstyle_test(
     include = glob(["*", "*/*", "*/*/*"]),
     license_type = "agpl-header",
 )
-

--- a/server/BUILD
+++ b/server/BUILD
@@ -127,7 +127,6 @@ java_binary(
     data = [":prepare-server-directories"]
 )
 
-
 java_deps(
     name = "server-deps-mac",
     target = ":server-bin-mac",


### PR DESCRIPTION
## What is the goal of this PR?
Use SpeeDB in place of RocksDB as the underlying key-value store.

## What are the changes implemented in this PR?
* Update the maven artifact dependencies.
* Propagate the change to the database & server packages.
 
We have decided not to rename references of RocksDB in the code to SpeeDB, because speedb retains the rocksdb interface and the speedb-jni  API retains the rocksdb one (the package, class and function names are identical)
