### PR TITLE
Fix filtering of variables in update query

### DIFF
--- a/query/Updater.java
+++ b/query/Updater.java
@@ -71,7 +71,6 @@ public class Updater {
             insertRegistry.variables().forEach(Inserter::validate);
 
             assert query.match().namedVariablesUnbound().containsAll(query.namedDeleteVariablesUnbound());
-
             HashSet<UnboundVariable> filter = new HashSet<>(query.match().namedVariablesUnbound());
             filter.retainAll(query.namedInsertVariablesUnbound());
             filter.addAll(query.namedDeleteVariablesUnbound());

--- a/query/Updater.java
+++ b/query/Updater.java
@@ -71,7 +71,7 @@ public class Updater {
             insertRegistry.variables().forEach(Inserter::validate);
 
             assert query.match().namedVariablesUnbound().containsAll(query.namedDeleteVariablesUnbound());
-            HashSet<UnboundVariable> filter = new HashSet<>(query.match().namedVariablesUnbound());
+            Set<UnboundVariable> filter = new HashSet<>(query.match().namedVariablesUnbound());
             filter.retainAll(query.namedInsertVariablesUnbound());
             filter.addAll(query.namedDeleteVariablesUnbound());
             Matcher matcher = Matcher.create(reasoner, query.match().get(list(filter)));

--- a/query/Updater.java
+++ b/query/Updater.java
@@ -71,8 +71,10 @@ public class Updater {
             insertRegistry.variables().forEach(Inserter::validate);
 
             assert query.match().namedVariablesUnbound().containsAll(query.namedDeleteVariablesUnbound());
-            HashSet<UnboundVariable> filter = new HashSet<>(query.namedDeleteVariablesUnbound());
-            filter.addAll(query.namedInsertVariablesUnbound());
+
+            HashSet<UnboundVariable> filter = new HashSet<>(query.match().namedVariablesUnbound());
+            filter.retainAll(query.namedInsertVariablesUnbound());
+            filter.addAll(query.namedDeleteVariablesUnbound());
             Matcher matcher = Matcher.create(reasoner, query.match().get(list(filter)));
             return new Updater(matcher, conceptMgr, deleteRegistry.things(), insertRegistry.things(), context);
         }


### PR DESCRIPTION
## What is the goal of this PR?

We fix the filtering of variables in insert clause of update queries to allow inserting new entities.

Fixes #6549 

## What are the changes implemented in this PR?

For the output of the `match` query that subsequently feeds into delete and insert, the filters of the `get` are the intersection of the `insert` and the `match` query, as well as the variables in the `delete`. Further, the set of variables in the `delete` query should be a subset of the set of variables in `match` query.