### PR TITLE
Remove iterators where simple loops would suffice

### DIFF
--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -312,7 +312,7 @@ public final class ConceptManager {
         ).<Thing>map(v -> ThingImpl.of(this, v)).toLists(PARALLELISATION_SPLIT_MINIMUM, PARALLELISATION_FACTOR);
         assert !lists.isEmpty();
         if (lists.size() == 1) {
-            iterate(lists.get(0)).forEachRemaining(Thing::validate);
+            for (Thing thing : lists.get(0)) thing.validate();
         } else {
             ProducerIterator<Void> validationIterator = produce(async(iterate(lists).map(
                     list -> iterate(list).map(t -> {

--- a/database/CoreDatabase.java
+++ b/database/CoreDatabase.java
@@ -530,8 +530,9 @@ public class CoreDatabase implements TypeDB.Database {
         private Set<CoreTransaction.Data> commitMayConflict(CoreTransaction.Data txn) {
             if (!txn.dataStorage.hasTrackedWrite()) return set();
             Set<CoreTransaction.Data> mayConflict = new HashSet<>(committing);
-            iterate(committed).filter(committed -> committed.snapshotEnd().get() > txn.snapshotStart())
-                    .forEachRemaining(mayConflict::add);
+            for (CoreTransaction.Data committedTxn : committed) {
+                if (committedTxn.snapshotEnd().get() > txn.snapshotStart()) mayConflict.add(committedTxn);
+            }
             return mayConflict;
         }
 

--- a/database/RocksConfiguration.java
+++ b/database/RocksConfiguration.java
@@ -23,11 +23,10 @@ import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.BloomFilter;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
-import org.rocksdb.DataBlockIndexType;
 import org.rocksdb.HashSkipListMemTableConfig;
 import org.rocksdb.IndexType;
 import org.rocksdb.LRUCache;
-import org.rocksdb.MemTableConfig;
+import org.rocksdb.SkipListMemTableConfig;
 import org.rocksdb.Statistics;
 import org.rocksdb.UInt64AddOperator;
 
@@ -104,18 +103,18 @@ public class RocksConfiguration {
          * Even a moderate block cache has a huge performance impact -- disabled vs enabled (800MB) block cache leads to a 20% reduction
          * in load time. However, there is a memory cost of about 2x the set cache size for using the cache size. So for example,
          * setting a 1GB block cache will lead to 2GB of ram usage during operation, from empirical tests.
-         *
+         * <p>
          * From various sources (https://smalldatum.blogspot.com/2016/09/tuning-rocksdb-block-cache.html is an explicit guideline)
          * when most data/working data subset doesn't fit into memory, it is best to give the block cache around 20% of the total memory,
          * and let the OS use the remaining space to prefetch and buffer pages read from disk.
-         *
+         * <p>
          * This guide also has a comment outlining that the compressed cache is not commonly used and note widely tested,
          * and it is better to let the OS handle pre-fetching pages from disk.
-         *
+         * <p>
          * Note: the ClockCache exposed in the JNI does not work: setting a 1GB clock cache still leads to an 8MB cache size.
          * In addition, the ClockCache should not be used in production, due to a critical bug that is known:
          * https://github.com/facebook/rocksdb/wiki/Block-Cache.
-         *
+         * <p>
          * We set aside a portion of the cache for high-priority blocks such as index/bloom filter structures, otherwise we get
          * unacceptable cache thrashing and a performance drop.
          */
@@ -136,17 +135,19 @@ public class RocksConfiguration {
         /**
          * By default RocksDB uses 1 thread for flush and 1 thread for compaction. We can give RocksDB permission to use many threads
          * for background jobs (eg. compaction and flush) with `maxBackgroundJobs`.
-         *
+         * <p>
          * To help relieve write stalls due to compaction at the higher levels (L0 -> L1 is single threaded), we can allow subcompactions
          * by setting max subcompaction threads to a value higher than 0 as well.
-         *
+         * <p>
          * To enable higher memtable throughput we can set `concurrentMemtableWrite` to `true`, along with a `enableWriteThreadAdaptiveYield`,
          * though we have not provably seen much benefit from these.
          */
         private void configureWriteConcurrency(DBOptions options) {
-            options.setMaxSubcompactions(CoreDatabaseManager.MAX_THREADS)
-                    .setMaxBackgroundCompactions(CoreDatabaseManager.MAX_THREADS)
+            options
+                    .setMaxSubcompactions(CoreDatabaseManager.MAX_THREADS)
+//                    .setMaxBackgroundCompactions(CoreDatabaseManager.MAX_THREADS)
                     .setMaxBackgroundJobs(CoreDatabaseManager.MAX_THREADS)
+                    .setIncreaseParallelism(CoreDatabaseManager.MAX_THREADS)
                     .setEnableWriteThreadAdaptiveYield(true)
                     .setAllowConcurrentMemtableWrite(false);
         }
@@ -170,7 +171,7 @@ public class RocksConfiguration {
         /**
          * WARNING: we can break backward compatibility or corrupt user data by changing these options and using them
          * with existing databases
-         *
+         * <p>
          * The default CF contains vertices. We optimise for point lookups with whole key bloom filters
          * Since this will contain attributes we make larger write buffers
          */
@@ -203,7 +204,7 @@ public class RocksConfiguration {
          */
         org.rocksdb.ColumnFamilyOptions fixedStartEdgeCFOptions() {
             org.rocksdb.ColumnFamilyOptions options = new org.rocksdb.ColumnFamilyOptions();
-            writeOptimisedWriteBuffers(options);
+            prefixOptimisedWriteBuffers(options);
             configureSST(options);
             configureCompression(options);
             configurePrefixExtractor(options, Key.Partition.FIXED_START_EDGE.fixedStartBytes().get());
@@ -213,7 +214,7 @@ public class RocksConfiguration {
 
         org.rocksdb.ColumnFamilyOptions optimisationEdgeCFOptions() {
             org.rocksdb.ColumnFamilyOptions options = new org.rocksdb.ColumnFamilyOptions();
-            readOptimisedWriteBuffers(options);
+            prefixOptimisedWriteBuffers(options);
             configureSST(options);
             configureCompression(options);
             configurePrefixExtractor(options, Key.Partition.OPTIMISATION_EDGE.fixedStartBytes().get());
@@ -223,7 +224,7 @@ public class RocksConfiguration {
 
         org.rocksdb.ColumnFamilyOptions metadataCFOptions() {
             org.rocksdb.ColumnFamilyOptions options = new org.rocksdb.ColumnFamilyOptions();
-            readOptimisedWriteBuffers(options);
+            writeOptimisedWriteBuffers(options);
             configureSST(options);
             configureCompression(options);
             configureMergeOperator(options);
@@ -252,37 +253,36 @@ public class RocksConfiguration {
 
         /**
          * Much of this information comes from: https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide
-         *
+         * <p>
          * Write buffers determine how much unsorted, uncompacted data is kept in memory before being flushed to L0.
-         *
+         * <p>
          * Tradeoff: the more we can delay compaction and accumulate writes in the write buffer, the faster our pure write speed.
          * However, through this process we lose reads, since the data is unsorted.
-         *
+         * <p>
          * We increase the default 64Mb to 128MB write buffer, and set the number of write buffers maximum to 4 from the default of 2.
          * This means we can have up to 512MB of unsorted data in memory in this cf. This gives a decent tradeoff between write speed, memory usage,
          * and read speed. The more write buffers there are, the slower reads: for each read, all write buffers have to be checked.
-         *
+         * <p>
          * To achieve the best performance, we should match the size of L1 with the size of L0. To do this we should set
          * `maxBytesForLevelBase` to the number of write buffers * size of memtable. This makes L0 -> L1 compactions fast as possible,
          * which is a single-threaded operation that doesn't scale very well. So in addition, the larger we make L0/L1, the
          * more we rely on the single-threaded compaction during contious loading/mixed read-write operation.
-         *
+         * <p>
          * According to the option documentation (https://javadoc.io/static/org.rocksdb/rocksdbjni/6.25.3/org/rocksdb/Options.html)
          * `maxWriteBufferNumberToMaintain`, is used to control how long _old_ write buffers are retained for conflict checking
          * open snapshots against past writes. Given that in TypeDB we perform our own consistency checks,
          * we do not need to keep any at all, freeing up memory. So, we should always set it to 0.
-         *
+         * <p>
          * With 4x128MB write buffers, with concurrent memtable writes and adaptive yield, during a bulk load we saw only
          * 25 seconds of stalling in 8 hours of data loading. Stalls are also only really seen when doing straight writes,
          * without mixed reads (the norm).
          */
         private void writeOptimisedWriteBuffers(ColumnFamilyOptions options) {
             configureWriteBuffersAndL1(options, 64 * MB, 2);
-            options.setMemTableConfig(new HashSkipListMemTableConfig()
-                    .setBucketCount(1_000_000));
+            options.setMemTableConfig(new SkipListMemTableConfig());
         }
 
-        private void readOptimisedWriteBuffers(ColumnFamilyOptions options) {
+        private void prefixOptimisedWriteBuffers(ColumnFamilyOptions options) {
             configureWriteBuffersAndL1(options, 64 * MB, 2);
             options.setMemTableConfig(new HashSkipListMemTableConfig().setBucketCount(1_000_000));
         }
@@ -301,10 +301,10 @@ public class RocksConfiguration {
          * By default, RocksDB will use a 64MB SST size, constant on each level (we could set a multiplier `targetFileSizeMultiplier`,
          * but we use RocksDB defaults here). We can use `targetFileSizeBase` to set the SST size for L0. This affects compaction
          * and bloom filters if we set them (larger SST = higher false positive rate in bloom filters).
-         *
+         * <p>
          * With a 64MB SST file, and 50 byte keys on average and no compression, an SST will contain on average 1.2 million keys.
          * With 4x compression (like from LZ4), we fit 5 million keys into a 64MB SST.
-         *
+         * <p>
          * Note: with 64MB SST files, if we have a max_open_files from the OS of 1024, we can only end up with a 64GB data set, etc.
          * As such, we should clearly tell the users to configure the max open files to be around 48k (~ enough for 3TB of data)
          */
@@ -316,25 +316,25 @@ public class RocksConfiguration {
 
         /**
          * Without much evidence to support the best file size, we follow RocksDB's default of 64MB SST files.
-         *
+         * <p>
          * Compression
          * We tested with various compression levels. Not having any compression leads to an approximately 5x write amplification
          * when comparing an uncompressed CSV source to the database size. However, a compressed CSV compared to an uncompressed
          * database is a 20x write amplification!
-         *
+         * <p>
          * There are many compression options available in RocksDB. The best "heavy" compression is ZLIB, and the best "light"
          * compression is LZ4. ZLIB comes with a heavy penalty of about 20% performance, and compresses data by 7x.
          * LZ4 has no noticable cost, and compresses data by about 3x, and great compression and decompression speeds (https://github.com/lz4/lz4).
-         *
+         * <p>
          * It may actually be true for us that compression on some level pays for itself in terms of cost: the OS will keep
          * pages from memory cached under the hood. If the data is compressed, more data can be kept in memory by the OS,
          * leading to less disk access and faster overall performance. This hasn't been observed yet, but may already be in play
          * which leads to LZ4 compression having "no" visible performance impact.
-         *
+         * <p>
          * We end up using the same settings as RockSet (https://rockset.com/blog/how-we-use-rocksdb-at-rockset/), by setting
          * no compression on L0 and L1, where a many smaller sets of data flow through rapidly before being written into lower levels,
          * and using lightweight LZ4 compression below that (levels 2 to 7).
-         *
+         * <p>
          * Following RocksDB advise at https://github.com/facebook/rocksdb/wiki/Space-Tuning, we should disable
          * index compression, to make sure indexes are always rapidly accessible (at the expense of some CPU and memory).
          */
@@ -358,7 +358,7 @@ public class RocksConfiguration {
          * ReadOptions.setAutoPrefixMode(true). However, this is not available in RocksDBJNI yet! So we have to
          * manually disable by using ReadOptions.setTotalOrderSeek(true) when iteratoring over a shorter prefix than
          * the bloom prefix extractor.
-         *
+         * <p>
          * We can change the prefix extractor on reboot, and old prefix filters will be ignored by RocksDB automatically
          */
         private void configurePrefixExtractor(ColumnFamilyOptions options, int prefixLength) {
@@ -369,7 +369,7 @@ public class RocksConfiguration {
          * The default RocksDB block size is 4KB. We increase it to 16KB - the larger the data blocks, the smaller the overall size
          * of indexes in the database. However, if the block is too large, doing a point lookup of a particular key can cost more
          * if it is not already in memory, since we have to fetch the entire 16KB block first!
-         *
+         * <p>
          * The rough formula for index size is `~= (database size / block size) * avg key size`.  See https://github.com/facebook/rocksdb/issues/719
          * for the source of the equation. In general, we see that around 1% of data size is index size, and the index should live in memory.
          * The larger the block size, the less memory we require for index structures.
@@ -383,18 +383,18 @@ public class RocksConfiguration {
 
         /**
          * A bloom filter has a similar performance impact (~20%) to a block cache, but the memory cost grows linearly for optimal performance.
-         *
+         * <p>
          * We can estimate the footprint of bloom filters with: `num_keys * per_key_bloom_size`. In a test, we loaded 150 million
          * concepts, which turned into 1.7 billion keys, into a 22GB rocks database with LZ4 compression. The size of the bloom
          * with 10 bits per key is filter is predicted to be 17 billion bits ~= 2 billion bytes = 2 GB of data. The actual test
          * gave 1.8GB of space for bloom filters, so this is a good predictor.
-         *
+         * <p>
          * Note that in a compressed 22GB rocks database, we end up with 5-10% of data as bloom filter.
-         *
+         * <p>
          * _There is a huge penalty_ if the bloom filters do not entirely fit into memory. However, to avoid a ballooning memory
          * footprint, we want to restrict the filters to fit into a predictable memory size. This is done with
          * `cacheIndexAndFilterBlocksWithHighPriority`, and setting aside a part of the block cache for filter/index blocks.
-         *
+         * <p>
          * However, if the cache is not large enough, we get a 10x performance drop. To help with this, Rocks introduced filter
          * partitioning, which introduces an index over the bloom filters. To utilise this, one must also set
          * `indexType(kTwoLevelIndexSearch)` with `partitionFilters`. Using this, along with `cacheIndexAndFilterBlocksWithHighPriority` and
@@ -402,14 +402,14 @@ public class RocksConfiguration {
          * we can keep good performance when the bloom filters don't ALL fit in memory, and only the partitions do.
          * With these settings, we find a minimal performance drop when memory startings being restricted to a
          * reasonable level.
-         *
+         * <p>
          * *Bloom filter efficiency*: with "full" bloom filters, where one filter is compute per SST, and 64MB files,
          * and LZ4 compression that gives a 4x compression ratio, we end up with about 5 million keys per file.
          * With 10 bits per key we end up with 50 mil bits = 6 mil bytes = 6MB bloom filter per file (10%, empirically
          * confirmed). Using online calculators, we can confirm 10 bits per keys gives a good false positive rate 1%.
          * So if we do enable bloom filters, 10 bits per key given 10 million keys per SST is a good tradeoff. 8 bits per key
          * leads to 5MB filter, and a 2% false positive rate, which is still good.
-         *
+         * <p>
          * *Prefix filter*: we see a solid performance increase (> 10%) when enabling bloom filters for prefixes compared
          * to just full-key filters.
          * Note: prefix extractors are defined directly on Options, not tableOptions
@@ -430,7 +430,7 @@ public class RocksConfiguration {
 //            // ensure that the bloom filter partitioning index, plus the data index live in the cache always
 //            rocksDBTableOptions.setPinTopLevelIndexAndFilter(true);
 //            // L0 index/filter should always be in memory, and is small
-//            rocksDBTableOptions.setPinL0FilterAndIndexBlocksInCache(false);
+            rocksDBTableOptions.setPinL0FilterAndIndexBlocksInCache(true);
             // use reserved section of block cache for blooms/index - cause massive thrashing if not using the high priority cache section
             // WARNING: must configure block cache with a reserved region for high priority blocks
             rocksDBTableOptions.setCacheIndexAndFilterBlocksWithHighPriority(true);

--- a/database/RocksConfiguration.java
+++ b/database/RocksConfiguration.java
@@ -23,16 +23,15 @@ import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.BloomFilter;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
-import org.rocksdb.HashSkipListMemTableConfig;
 import org.rocksdb.IndexType;
 import org.rocksdb.LRUCache;
-import org.rocksdb.SkipListMemTableConfig;
 import org.rocksdb.Statistics;
 import org.rocksdb.UInt64AddOperator;
 
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.core.common.collection.Bytes.KB;
 import static com.vaticle.typedb.core.common.collection.Bytes.MB;
+import static org.rocksdb.CompressionType.LZ4_COMPRESSION;
 import static org.rocksdb.CompressionType.NO_COMPRESSION;
 
 public class RocksConfiguration {
@@ -103,18 +102,18 @@ public class RocksConfiguration {
          * Even a moderate block cache has a huge performance impact -- disabled vs enabled (800MB) block cache leads to a 20% reduction
          * in load time. However, there is a memory cost of about 2x the set cache size for using the cache size. So for example,
          * setting a 1GB block cache will lead to 2GB of ram usage during operation, from empirical tests.
-         * <p>
+         *
          * From various sources (https://smalldatum.blogspot.com/2016/09/tuning-rocksdb-block-cache.html is an explicit guideline)
          * when most data/working data subset doesn't fit into memory, it is best to give the block cache around 20% of the total memory,
          * and let the OS use the remaining space to prefetch and buffer pages read from disk.
-         * <p>
+         *
          * This guide also has a comment outlining that the compressed cache is not commonly used and note widely tested,
          * and it is better to let the OS handle pre-fetching pages from disk.
-         * <p>
+         *
          * Note: the ClockCache exposed in the JNI does not work: setting a 1GB clock cache still leads to an 8MB cache size.
          * In addition, the ClockCache should not be used in production, due to a critical bug that is known:
          * https://github.com/facebook/rocksdb/wiki/Block-Cache.
-         * <p>
+         *
          * We set aside a portion of the cache for high-priority blocks such as index/bloom filter structures, otherwise we get
          * unacceptable cache thrashing and a performance drop.
          */
@@ -135,21 +134,17 @@ public class RocksConfiguration {
         /**
          * By default RocksDB uses 1 thread for flush and 1 thread for compaction. We can give RocksDB permission to use many threads
          * for background jobs (eg. compaction and flush) with `maxBackgroundJobs`.
-         * <p>
+         *
          * To help relieve write stalls due to compaction at the higher levels (L0 -> L1 is single threaded), we can allow subcompactions
          * by setting max subcompaction threads to a value higher than 0 as well.
-         * <p>
+         *
          * To enable higher memtable throughput we can set `concurrentMemtableWrite` to `true`, along with a `enableWriteThreadAdaptiveYield`,
          * though we have not provably seen much benefit from these.
          */
         private void configureWriteConcurrency(DBOptions options) {
-            options
-                    .setMaxSubcompactions(CoreDatabaseManager.MAX_THREADS)
-//                    .setMaxBackgroundCompactions(CoreDatabaseManager.MAX_THREADS)
-                    .setMaxBackgroundJobs(CoreDatabaseManager.MAX_THREADS)
-                    .setIncreaseParallelism(CoreDatabaseManager.MAX_THREADS)
+            options.setMaxSubcompactions(CoreDatabaseManager.MAX_THREADS).setMaxBackgroundJobs(CoreDatabaseManager.MAX_THREADS)
                     .setEnableWriteThreadAdaptiveYield(true)
-                    .setAllowConcurrentMemtableWrite(false);
+                    .setAllowConcurrentMemtableWrite(true);
         }
 
         /**
@@ -171,7 +166,7 @@ public class RocksConfiguration {
         /**
          * WARNING: we can break backward compatibility or corrupt user data by changing these options and using them
          * with existing databases
-         * <p>
+         *
          * The default CF contains vertices. We optimise for point lookups with whole key bloom filters
          * Since this will contain attributes we make larger write buffers
          */
@@ -180,7 +175,7 @@ public class RocksConfiguration {
             writeOptimisedWriteBuffers(options);
             configureSST(options);
             configureCompression(options);
-            options.setTableFormatConfig(tableOptions(true, true, false));
+            options.setTableFormatConfig(tableOptions(true, true));
             return options;
         }
 
@@ -194,7 +189,7 @@ public class RocksConfiguration {
             writeOptimisedWriteBuffers(options);
             configureSST(options);
             configureCompression(options);
-            options.setTableFormatConfig(tableOptions(false, false, false));
+            options.setTableFormatConfig(tableOptions(false, false));
             return options;
         }
 
@@ -204,27 +199,27 @@ public class RocksConfiguration {
          */
         org.rocksdb.ColumnFamilyOptions fixedStartEdgeCFOptions() {
             org.rocksdb.ColumnFamilyOptions options = new org.rocksdb.ColumnFamilyOptions();
-            prefixOptimisedWriteBuffers(options);
+            writeOptimisedWriteBuffers(options);
             configureSST(options);
             configureCompression(options);
             configurePrefixExtractor(options, Key.Partition.FIXED_START_EDGE.fixedStartBytes().get());
-            options.setTableFormatConfig(tableOptions(true, false, true));
+            options.setTableFormatConfig(tableOptions(true, false));
             return options;
         }
 
         org.rocksdb.ColumnFamilyOptions optimisationEdgeCFOptions() {
             org.rocksdb.ColumnFamilyOptions options = new org.rocksdb.ColumnFamilyOptions();
-            prefixOptimisedWriteBuffers(options);
+            readOptimisedWriteBuffers(options);
             configureSST(options);
             configureCompression(options);
             configurePrefixExtractor(options, Key.Partition.OPTIMISATION_EDGE.fixedStartBytes().get());
-            options.setTableFormatConfig(tableOptions(true, false, true));
+            options.setTableFormatConfig(tableOptions(true, false));
             return options;
         }
 
         org.rocksdb.ColumnFamilyOptions metadataCFOptions() {
             org.rocksdb.ColumnFamilyOptions options = new org.rocksdb.ColumnFamilyOptions();
-            writeOptimisedWriteBuffers(options);
+            readOptimisedWriteBuffers(options);
             configureSST(options);
             configureCompression(options);
             configureMergeOperator(options);
@@ -240,51 +235,49 @@ public class RocksConfiguration {
             return options;
         }
 
-        private BlockBasedTableConfig tableOptions(boolean enableFilter, boolean enableWholeKeyFilter, boolean enablePrefixExtractor) {
+        private BlockBasedTableConfig tableOptions(boolean enableFilter, boolean enableWholeKeyFilter) {
             assert enableFilter || !enableWholeKeyFilter;
             BlockBasedTableConfig rocksDBTableOptions = new BlockBasedTableConfig();
             configureBlocks(rocksDBTableOptions);
             rocksDBTableOptions.setEnableIndexCompression(false);
             rocksDBTableOptions.setBlockCache(blockCache);
-            if (enableFilter) configureBloomFilter(rocksDBTableOptions, enablePrefixExtractor);
+            if (enableFilter) configureBloomFilter(rocksDBTableOptions);
             rocksDBTableOptions.setWholeKeyFiltering(enableWholeKeyFilter);
             return rocksDBTableOptions;
         }
 
         /**
          * Much of this information comes from: https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide
-         * <p>
+         *
          * Write buffers determine how much unsorted, uncompacted data is kept in memory before being flushed to L0.
-         * <p>
+         *
          * Tradeoff: the more we can delay compaction and accumulate writes in the write buffer, the faster our pure write speed.
          * However, through this process we lose reads, since the data is unsorted.
-         * <p>
+         *
          * We increase the default 64Mb to 128MB write buffer, and set the number of write buffers maximum to 4 from the default of 2.
          * This means we can have up to 512MB of unsorted data in memory in this cf. This gives a decent tradeoff between write speed, memory usage,
          * and read speed. The more write buffers there are, the slower reads: for each read, all write buffers have to be checked.
-         * <p>
+         *
          * To achieve the best performance, we should match the size of L1 with the size of L0. To do this we should set
          * `maxBytesForLevelBase` to the number of write buffers * size of memtable. This makes L0 -> L1 compactions fast as possible,
          * which is a single-threaded operation that doesn't scale very well. So in addition, the larger we make L0/L1, the
          * more we rely on the single-threaded compaction during contious loading/mixed read-write operation.
-         * <p>
+         *
          * According to the option documentation (https://javadoc.io/static/org.rocksdb/rocksdbjni/6.25.3/org/rocksdb/Options.html)
          * `maxWriteBufferNumberToMaintain`, is used to control how long _old_ write buffers are retained for conflict checking
          * open snapshots against past writes. Given that in TypeDB we perform our own consistency checks,
          * we do not need to keep any at all, freeing up memory. So, we should always set it to 0.
-         * <p>
+         *
          * With 4x128MB write buffers, with concurrent memtable writes and adaptive yield, during a bulk load we saw only
          * 25 seconds of stalling in 8 hours of data loading. Stalls are also only really seen when doing straight writes,
          * without mixed reads (the norm).
          */
         private void writeOptimisedWriteBuffers(ColumnFamilyOptions options) {
-            configureWriteBuffersAndL1(options, 64 * MB, 2);
-            options.setMemTableConfig(new SkipListMemTableConfig());
+            configureWriteBuffersAndL1(options, 128 * MB, 4);
         }
 
-        private void prefixOptimisedWriteBuffers(ColumnFamilyOptions options) {
+        private void readOptimisedWriteBuffers(ColumnFamilyOptions options) {
             configureWriteBuffersAndL1(options, 64 * MB, 2);
-            options.setMemTableConfig(new HashSkipListMemTableConfig().setBucketCount(1_000_000));
         }
 
         private void configureWriteBuffersAndL1(ColumnFamilyOptions options, long writeBufferSize, int writeBuffersMaxCount) {
@@ -301,10 +294,10 @@ public class RocksConfiguration {
          * By default, RocksDB will use a 64MB SST size, constant on each level (we could set a multiplier `targetFileSizeMultiplier`,
          * but we use RocksDB defaults here). We can use `targetFileSizeBase` to set the SST size for L0. This affects compaction
          * and bloom filters if we set them (larger SST = higher false positive rate in bloom filters).
-         * <p>
+         *
          * With a 64MB SST file, and 50 byte keys on average and no compression, an SST will contain on average 1.2 million keys.
          * With 4x compression (like from LZ4), we fit 5 million keys into a 64MB SST.
-         * <p>
+         *
          * Note: with 64MB SST files, if we have a max_open_files from the OS of 1024, we can only end up with a 64GB data set, etc.
          * As such, we should clearly tell the users to configure the max open files to be around 48k (~ enough for 3TB of data)
          */
@@ -316,33 +309,33 @@ public class RocksConfiguration {
 
         /**
          * Without much evidence to support the best file size, we follow RocksDB's default of 64MB SST files.
-         * <p>
+         *
          * Compression
          * We tested with various compression levels. Not having any compression leads to an approximately 5x write amplification
          * when comparing an uncompressed CSV source to the database size. However, a compressed CSV compared to an uncompressed
          * database is a 20x write amplification!
-         * <p>
+         *
          * There are many compression options available in RocksDB. The best "heavy" compression is ZLIB, and the best "light"
          * compression is LZ4. ZLIB comes with a heavy penalty of about 20% performance, and compresses data by 7x.
          * LZ4 has no noticable cost, and compresses data by about 3x, and great compression and decompression speeds (https://github.com/lz4/lz4).
-         * <p>
+         *
          * It may actually be true for us that compression on some level pays for itself in terms of cost: the OS will keep
          * pages from memory cached under the hood. If the data is compressed, more data can be kept in memory by the OS,
          * leading to less disk access and faster overall performance. This hasn't been observed yet, but may already be in play
          * which leads to LZ4 compression having "no" visible performance impact.
-         * <p>
+         *
          * We end up using the same settings as RockSet (https://rockset.com/blog/how-we-use-rocksdb-at-rockset/), by setting
          * no compression on L0 and L1, where a many smaller sets of data flow through rapidly before being written into lower levels,
          * and using lightweight LZ4 compression below that (levels 2 to 7).
-         * <p>
+         *
          * Following RocksDB advise at https://github.com/facebook/rocksdb/wiki/Space-Tuning, we should disable
          * index compression, to make sure indexes are always rapidly accessible (at the expense of some CPU and memory).
          */
         private void configureCompression(ColumnFamilyOptions options) {
             options
                     // best performance-space tradeoff: apply lightweight LZ4 compression to levels that change less
-                    .setCompressionPerLevel(list(NO_COMPRESSION, NO_COMPRESSION, NO_COMPRESSION, NO_COMPRESSION,
-                            NO_COMPRESSION, NO_COMPRESSION, NO_COMPRESSION));
+                    .setCompressionPerLevel(list(NO_COMPRESSION, NO_COMPRESSION, LZ4_COMPRESSION, LZ4_COMPRESSION,
+                            LZ4_COMPRESSION, LZ4_COMPRESSION, LZ4_COMPRESSION));
         }
 
         /**
@@ -358,7 +351,7 @@ public class RocksConfiguration {
          * ReadOptions.setAutoPrefixMode(true). However, this is not available in RocksDBJNI yet! So we have to
          * manually disable by using ReadOptions.setTotalOrderSeek(true) when iteratoring over a shorter prefix than
          * the bloom prefix extractor.
-         * <p>
+         *
          * We can change the prefix extractor on reboot, and old prefix filters will be ignored by RocksDB automatically
          */
         private void configurePrefixExtractor(ColumnFamilyOptions options, int prefixLength) {
@@ -369,32 +362,32 @@ public class RocksConfiguration {
          * The default RocksDB block size is 4KB. We increase it to 16KB - the larger the data blocks, the smaller the overall size
          * of indexes in the database. However, if the block is too large, doing a point lookup of a particular key can cost more
          * if it is not already in memory, since we have to fetch the entire 16KB block first!
-         * <p>
+         *
          * The rough formula for index size is `~= (database size / block size) * avg key size`.  See https://github.com/facebook/rocksdb/issues/719
          * for the source of the equation. In general, we see that around 1% of data size is index size, and the index should live in memory.
          * The larger the block size, the less memory we require for index structures.
          */
         private void configureBlocks(BlockBasedTableConfig rocksDBTableOptions) {
             // hardcode block size and format version to avoid relying on RocksDB defaults that could change
-            rocksDBTableOptions.setBlockSize(4 * KB);
+            rocksDBTableOptions.setBlockSize(16 * KB);
             rocksDBTableOptions.setFormatVersion(5);
             rocksDBTableOptions.setIndexBlockRestartInterval(16);
         }
 
         /**
          * A bloom filter has a similar performance impact (~20%) to a block cache, but the memory cost grows linearly for optimal performance.
-         * <p>
+         *
          * We can estimate the footprint of bloom filters with: `num_keys * per_key_bloom_size`. In a test, we loaded 150 million
          * concepts, which turned into 1.7 billion keys, into a 22GB rocks database with LZ4 compression. The size of the bloom
          * with 10 bits per key is filter is predicted to be 17 billion bits ~= 2 billion bytes = 2 GB of data. The actual test
          * gave 1.8GB of space for bloom filters, so this is a good predictor.
-         * <p>
+         *
          * Note that in a compressed 22GB rocks database, we end up with 5-10% of data as bloom filter.
-         * <p>
+         *
          * _There is a huge penalty_ if the bloom filters do not entirely fit into memory. However, to avoid a ballooning memory
          * footprint, we want to restrict the filters to fit into a predictable memory size. This is done with
          * `cacheIndexAndFilterBlocksWithHighPriority`, and setting aside a part of the block cache for filter/index blocks.
-         * <p>
+         *
          * However, if the cache is not large enough, we get a 10x performance drop. To help with this, Rocks introduced filter
          * partitioning, which introduces an index over the bloom filters. To utilise this, one must also set
          * `indexType(kTwoLevelIndexSearch)` with `partitionFilters`. Using this, along with `cacheIndexAndFilterBlocksWithHighPriority` and
@@ -402,35 +395,32 @@ public class RocksConfiguration {
          * we can keep good performance when the bloom filters don't ALL fit in memory, and only the partitions do.
          * With these settings, we find a minimal performance drop when memory startings being restricted to a
          * reasonable level.
-         * <p>
+         *
          * *Bloom filter efficiency*: with "full" bloom filters, where one filter is compute per SST, and 64MB files,
          * and LZ4 compression that gives a 4x compression ratio, we end up with about 5 million keys per file.
          * With 10 bits per key we end up with 50 mil bits = 6 mil bytes = 6MB bloom filter per file (10%, empirically
          * confirmed). Using online calculators, we can confirm 10 bits per keys gives a good false positive rate 1%.
          * So if we do enable bloom filters, 10 bits per key given 10 million keys per SST is a good tradeoff. 8 bits per key
          * leads to 5MB filter, and a 2% false positive rate, which is still good.
-         * <p>
+         *
          * *Prefix filter*: we see a solid performance increase (> 10%) when enabling bloom filters for prefixes compared
          * to just full-key filters.
          * Note: prefix extractors are defined directly on Options, not tableOptions
          */
-        private void configureBloomFilter(BlockBasedTableConfig rocksDBTableOptions, boolean enablePrefixExtractor) {
+        private void configureBloomFilter(BlockBasedTableConfig rocksDBTableOptions) {
             // bloom filter is important for good random-read performance
             rocksDBTableOptions.setFilterPolicy(new BloomFilter(10, false));
             // partition bloom filters to avoid needing to have all bloom filters reside in memory - only index over blooms must
-            rocksDBTableOptions.setPartitionFilters(false);
-            // we must use TwoLevel search to make partitioned filters take effect, and hash search to make prefixes be used
-            if (enablePrefixExtractor) rocksDBTableOptions.setIndexType(IndexType.kHashSearch);
-            else rocksDBTableOptions.setIndexType(IndexType.kBinarySearch);
-
+            rocksDBTableOptions.setPartitionFilters(true);
+            // WARNING: this must be set to make partitioned filters take effect
+            rocksDBTableOptions.setIndexType(IndexType.kTwoLevelIndexSearch);
+            rocksDBTableOptions.setOptimizeFiltersForMemory(true);
+            // ensure that the bloom filter partitioning index, plus the data index live in the cache always
+            rocksDBTableOptions.setPinTopLevelIndexAndFilter(true);
+            // L0 index/filter should always be in memory, and is small
+            rocksDBTableOptions.setPinL0FilterAndIndexBlocksInCache(true);
             // to cap memory usage, we must pin filter blocks and indexes in memory
             rocksDBTableOptions.setCacheIndexAndFilterBlocks(true);
-
-//            rocksDBTableOptions.setOptimizeFiltersForMemory(true);
-//            // ensure that the bloom filter partitioning index, plus the data index live in the cache always
-//            rocksDBTableOptions.setPinTopLevelIndexAndFilter(true);
-//            // L0 index/filter should always be in memory, and is small
-            rocksDBTableOptions.setPinL0FilterAndIndexBlocksInCache(true);
             // use reserved section of block cache for blooms/index - cause massive thrashing if not using the high priority cache section
             // WARNING: must configure block cache with a reserved region for high priority blocks
             rocksDBTableOptions.setCacheIndexAndFilterBlocksWithHighPriority(true);

--- a/database/RocksConfiguration.java
+++ b/database/RocksConfiguration.java
@@ -148,7 +148,7 @@ public class RocksConfiguration {
                     .setMaxBackgroundCompactions(CoreDatabaseManager.MAX_THREADS)
                     .setMaxBackgroundJobs(CoreDatabaseManager.MAX_THREADS)
                     .setEnableWriteThreadAdaptiveYield(true)
-                    .setAllowConcurrentMemtableWrite(true);
+                    .setAllowConcurrentMemtableWrite(false);
         }
 
         /**
@@ -341,8 +341,8 @@ public class RocksConfiguration {
         private void configureCompression(ColumnFamilyOptions options) {
             options
                     // best performance-space tradeoff: apply lightweight LZ4 compression to levels that change less
-                    .setCompressionPerLevel(list(NO_COMPRESSION, NO_COMPRESSION, LZ4_COMPRESSION, LZ4_COMPRESSION,
-                            LZ4_COMPRESSION, LZ4_COMPRESSION, LZ4_COMPRESSION));
+                    .setCompressionPerLevel(list(NO_COMPRESSION, NO_COMPRESSION, NO_COMPRESSION, NO_COMPRESSION,
+                            NO_COMPRESSION, NO_COMPRESSION, NO_COMPRESSION));
         }
 
         /**

--- a/graph/TypeGraph.java
+++ b/graph/TypeGraph.java
@@ -586,11 +586,14 @@ public class TypeGraph {
      */
     public void commit() {
         assert storage.isSchema();
-        iterate(typesByIID.values()).filter(v -> v.status().equals(Encoding.Status.BUFFERED)).forEachRemaining(v -> {
-            VertexIID.Type newIID = VertexIID.Type.generate(storage.asSchema().schemaKeyGenerator(), v.encoding());
-            committedIIDs.put(v.iid(), newIID);
-            v.iid(newIID);
-        }); // typeByIID no longer contains valid mapping from IID to TypeVertex
+        for (TypeVertex vertex : typesByIID.values()) {
+            if (vertex.status() == Encoding.Status.BUFFERED) {
+                VertexIID.Type newIID = VertexIID.Type.generate(storage.asSchema().schemaKeyGenerator(), vertex.encoding());
+                committedIIDs.put(vertex.iid(), newIID);
+                vertex.iid(newIID);
+            }
+        }
+        // typeByIID no longer contains valid mapping from IID to TypeVertex
         typesByIID.values().forEach(TypeVertex::commit);
         rules.commit();
         clear(); // we now flush the indexes after commit, and we do not expect this Graph.Type to be used again

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -99,7 +99,7 @@ public class Conjunction implements Pattern, Cloneable {
 
     private Map<Identifier.Variable, Variable> parseToMap(Set<Variable> variables) {
         HashMap<Identifier.Variable, Variable> map = new HashMap<>();
-        iterate(variables).forEachRemaining(v -> map.put(v.id(), v));
+        variables.forEach(v -> map.put(v.id(), v));
         return unmodifiableMap(map);
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We remove unncessary usages of iterator objects to do for-each loops that were convenient, since they are marginally slower. This is a pretty minor optimisation, but also very easy to implement in several hot paths.

## What are the changes implemented in this PR?

* Remove usages of `iterate(collection).forEachRemaining` in places where it is easy to replace them with simpler language constructs such as for-loops combined with if statements