### PR TITLE
Update SpeeDB to 2.4.1.3 to support native Linux ARM64 deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,9 +79,24 @@ jobs:
 workflows:
   typedb:
     jobs:
-      - test-assembly-mac-zip-x86_64
-      - test-assembly-mac-zip-arm64
-      - test-assembly-linux-zip-arm64
+      - test-assembly-mac-zip-x86_64:
+          filters:
+            branches:
+              only:
+                - master
+                - development
+      - test-assembly-mac-zip-arm64:
+          filters:
+            branches:
+              only:
+                - master
+                - development
+      - test-assembly-linux-zip-arm64:
+          filters:
+            branches:
+              only:
+                - master
+                - development
       - test-assembly-windows-zip:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
       - run: brew install bazelisk
 
 jobs:
-  test-assembly-mac-zip-x86_64:
+  test-assembly-mac-x86_64-zip:
     macos:
       xcode: "14.2.0"
     working_directory: ~/typedb
@@ -45,7 +45,7 @@ jobs:
       - install-bazel-mac
       - run: bazel test //test/assembly:assembly --test_output=errors
 
-  test-assembly-mac-zip-arm64:
+  test-assembly-mac-arm64-zip:
     macos:
       xcode: "14.2.0"
     resource_class: macos.m1.medium.gen1
@@ -55,7 +55,7 @@ jobs:
       - install-bazel-mac
       - run: bazel test //test/assembly:assembly --test_output=errors
 
-  test-assembly-linux-zip-arm64:
+  test-assembly-linux-arm64-zip:
     machine:
       image: ubuntu-2004:current
       resource_class: arm.medium
@@ -79,19 +79,19 @@ jobs:
 workflows:
   typedb:
     jobs:
-      - test-assembly-mac-zip-x86_64:
+      - test-assembly-mac-x86_64-zip:
           filters:
             branches:
               only:
                 - master
                 - development
-      - test-assembly-mac-zip-arm64:
+      - test-assembly-mac-arm64-zip:
           filters:
             branches:
               only:
                 - master
                 - development
-      - test-assembly-linux-zip-arm64:
+      - test-assembly-linux-arm64-zip:
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,24 +79,9 @@ jobs:
 workflows:
   typedb:
     jobs:
-      - test-assembly-mac-zip-x86_64:
-          filters:
-            branches:
-              only:
-                - master
-                - development
-      - test-assembly-mac-zip-arm64:
-          filters:
-            branches:
-              only:
-                - master
-                - development
-#      - test-assembly-linux-zip-arm64:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - development
+      - test-assembly-mac-zip-x86_64
+      - test-assembly-mac-zip-arm64
+      - test-assembly-linux-zip-arm64
       - test-assembly-windows-zip:
           filters:
             branches:

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -35,7 +35,7 @@
 @maven//:io_cucumber_datatable_3_2_1
 @maven//:io_cucumber_docstring_5_1_3
 @maven//:io_cucumber_tag_expressions_2_0_4
-@maven//:io_github_speedb_io_speedbjni_2_4_1_2
+@maven//:io_github_speedb_io_speedbjni_2_4_1_3
 @maven//:io_grpc_grpc_api_1_43_0
 @maven//:io_grpc_grpc_context_1_43_0
 @maven//:io_grpc_grpc_core_1_43_0

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -35,7 +35,7 @@
 @maven//:io_cucumber_datatable_3_2_1
 @maven//:io_cucumber_docstring_5_1_3
 @maven//:io_cucumber_tag_expressions_2_0_4
-@maven//:io_github_speedb_io_speedbjni_2_4_1
+@maven//:io_github_speedb_io_speedbjni_2_4_1_2
 @maven//:io_grpc_grpc_api_1_43_0
 @maven//:io_grpc_grpc_context_1_43_0
 @maven//:io_grpc_grpc_core_1_43_0

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "aef28991a07fe6342fe8a49aa42c4d95c67bcc54",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "0625a6d6ff089fb50f7cb73ae3ce105c12ebc844",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "ae1a6508083d4917fb0e460336d203ac527250ea",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "aef28991a07fe6342fe8a49aa42c4d95c67bcc54",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():


### PR DESCRIPTION
## What is the goal of this PR?

We discover that SpeeDB, unlike RocksDB, did not yet support Linux `arm64` architectures, which are used widely in embedded and Rasberry Pi type systems. To fix this, we use a new release of SpeeDB that includes the Linux ARM64 artifact in its fat JAR.

## What are the changes implemented in this PR?

* Update SpeeDB to 2.4.1.3, which supports Linux ARM64 architectures
