### PR TITLE
Allow TypeDB migrator to operate over an empty database

### DIFF
--- a/TypeDB.java
+++ b/TypeDB.java
@@ -58,6 +58,8 @@ public interface TypeDB {
 
         String name();
 
+        boolean isEmpty();
+
         boolean contains(UUID sessionID);
 
         Session session(UUID sessionID);

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -164,18 +164,20 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Database(3, "Attempted to use database manager when it has been closed.");
         public static final Database DATABASE_EXISTS =
                 new Database(4, "The database with the name '%s' already exists.");
+        public static final Database DATABASE_NOT_EMPTY =
+                new Database(5, "The existing database with the name '%s' is not empty.");
         public static final Database DATABASE_NOT_FOUND =
-                new Database(5, "The database with the name '%s' does not exist.");
+                new Database(6, "The database with the name '%s' does not exist.");
         public static final Database DATABASE_DELETED =
-                new Database(6, "Database with the name '%s' has been deleted.");
+                new Database(7, "Database with the name '%s' has been deleted.");
         public static final Database DATABASE_CLOSED =
-                new Database(7, "Attempted to open a new session from the database '%s' that has been closed.");
+                new Database(8, "Attempted to open a new session from the database '%s' that has been closed.");
         public static final Database DATABASE_NAME_RESERVED =
-                new Database(8, "Database name must not start with an underscore.");
+                new Database(9, "Database name must not start with an underscore.");
         public static final Database ROCKS_LOGGER_SHUTDOWN_TIMEOUT =
-                new Database(9, "Background RocksDB properties logger shutdown timed out.");
+                new Database(10, "Background RocksDB properties logger shutdown timed out.");
         public static final Database STATISTICS_CORRECTOR_SHUTDOWN_TIMEOUT =
-                new Database(10, "Background statistics corrector shutdowne timed out.");
+                new Database(11, "Background statistics corrector shutdown timed out.");
 
         private static final String codePrefix = "DBS";
         private static final String messagePrefix = "Invalid Database Operation";

--- a/database/CoreDatabase.java
+++ b/database/CoreDatabase.java
@@ -26,6 +26,7 @@ import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.iterator.FunctionalIterator;
 import com.vaticle.typedb.core.common.parameters.Arguments;
 import com.vaticle.typedb.core.common.parameters.Options;
+import com.vaticle.typedb.core.concept.type.Type;
 import com.vaticle.typedb.core.concurrent.executor.Executors;
 import com.vaticle.typedb.core.encoding.Encoding;
 import com.vaticle.typedb.core.encoding.iid.VertexIID;
@@ -413,6 +414,13 @@ public class CoreDatabase implements TypeDB.Database {
     @Override
     public String name() {
         return name;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        try (TypeDB.Session session = databaseMgr.session(name, SCHEMA); TypeDB.Transaction tx = session.transaction(READ)) {
+            return tx.concepts().getRootThingType().getSubtypes().allMatch(Type::isRoot);
+        }
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

We relax the Importer to operate not only over a non-existent database that is created on the fly, but also over a pre-existing and empty database. This is required because TypeDB Enterprise must create the database first, triggering a leader election, before doing the import against the primary replica.

## What are the changes implemented in this PR?

* Implement `CoreDatabase.isEmpty()`
* Allow `DatabaseImporter` to run over an empty or non-existent database