### PR TITLE
Add RPC logging for session and transaction creation

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -105,6 +105,9 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Server(34, "Another instance of TypeDB server is already running at this port: '%s'.");
         public static final Server INCOMPATIBLE_JAVA_RUNTIME =
                 new Server(35, "Incompatible Java runtime version: '%s'. Please use Java 11 or above.");
+        public static final Server ERROR_LOGGING_CONNECTIONS =
+                new Server(36, "An error occurred while logging server connection info.");
+
 
         private static final String codePrefix = "SRV";
         private static final String messagePrefix = "Invalid Server Operation";

--- a/server/SessionService.java
+++ b/server/SessionService.java
@@ -62,10 +62,12 @@ public class SessionService implements AutoCloseable {
             if (isOpen.get()) {
                 transactionServices.add(transactionSvc);
                 cancelIdleTimeout();
-                LOG.debug(
-                        "Session '{}' for database '{}' opened transaction. Transactions open in this session: {}.",
-                        UUID(), session.database().name(), transactionServices.size()
-                );
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "Session '{}' for database '{}' opened transaction. Transactions open in this session: {}.",
+                            UUID(), session.database().name(), transactionServices.size()
+                    );
+                }
             } else throw TypeDBException.of(SESSION_CLOSED);
         } finally {
             accessLock.readLock().unlock();

--- a/server/SessionService.java
+++ b/server/SessionService.java
@@ -77,7 +77,12 @@ public class SessionService implements AutoCloseable {
     void closed(TransactionService transactionSvc) {
         transactionServices.remove(transactionSvc);
         mayStartIdleTimeout();
-        LOG.debug("Session '{}' for database '{}' closed.", UUID(), session.database().name());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Session '{}' for database '{}' closed. Transactions open in this session: {}",
+                    UUID(), session.database().name(), transactionServices.size()
+            );
+        }
     }
 
     public boolean isOpen() {

--- a/server/SessionService.java
+++ b/server/SessionService.java
@@ -62,6 +62,10 @@ public class SessionService implements AutoCloseable {
             if (isOpen.get()) {
                 transactionServices.add(transactionSvc);
                 cancelIdleTimeout();
+                LOG.debug(
+                        "Session '{}' for database '{}' opened transaction. Transactions open in this session: {}.",
+                        UUID(), session.database().name(), transactionServices.size()
+                );
             } else throw TypeDBException.of(SESSION_CLOSED);
         } finally {
             accessLock.readLock().unlock();
@@ -71,6 +75,7 @@ public class SessionService implements AutoCloseable {
     void closed(TransactionService transactionSvc) {
         transactionServices.remove(transactionSvc);
         mayStartIdleTimeout();
+        LOG.debug("Session '{}' for database '{}' closed.", UUID(), session.database().name());
     }
 
     public boolean isOpen() {

--- a/server/TypeDBService.java
+++ b/server/TypeDBService.java
@@ -233,10 +233,12 @@ public class TypeDBService extends TypeDBGrpc.TypeDBImplBase {
             sessionSvc.close();
             responder.onNext(closeRes());
             responder.onCompleted();
-            LOG.debug(
-                    "Closed session '{}' to database '{}'. Sessions open on server: {}", sessionID,
-                    sessionSvc.session().database().name(), sessionServices.size()
-            );
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Closed session '{}' for database '{}'. Sessions open on server: {}", sessionID,
+                        sessionSvc.session().database().name(), sessionServices.size()
+                );
+            }
         } catch (RuntimeException e) {
             LOG.error(e.getMessage(), e);
             responder.onError(exception(e));

--- a/server/TypeDBService.java
+++ b/server/TypeDBService.java
@@ -83,6 +83,7 @@ public class TypeDBService extends TypeDBGrpc.TypeDBImplBase {
     }
 
     private void logConnectionStates() {
+        if (sessionServices.isEmpty()) return;
         Map<String, List<String>> databaseConnections = new HashMap<>();
         Instant now = Instant.now();
         sessionServices.forEach((uuid, sessionService) ->

--- a/server/TypeDBService.java
+++ b/server/TypeDBService.java
@@ -211,6 +211,10 @@ public class TypeDBService extends TypeDBGrpc.TypeDBImplBase {
             int duration = (int) Duration.between(start, Instant.now()).toMillis();
             responder.onNext(openRes(sessionSvc.UUID(), duration));
             responder.onCompleted();
+            LOG.debug(
+                    "Opened new session '{}' for database '{}'. Sessions open on server: {}", sessionSvc.UUID(),
+                    request.getDatabase(), sessionServices.size()
+            );
         } catch (RuntimeException e) {
             LOG.error(e.getMessage(), e);
             responder.onError(exception(e));
@@ -227,6 +231,10 @@ public class TypeDBService extends TypeDBGrpc.TypeDBImplBase {
             sessionSvc.close();
             responder.onNext(closeRes());
             responder.onCompleted();
+            LOG.debug(
+                    "Closed session '{}' to database '{}'. Sessions open on server: {}", sessionID,
+                    sessionSvc.session().database().name(), sessionServices.size()
+            );
         } catch (RuntimeException e) {
             LOG.error(e.getMessage(), e);
             responder.onError(exception(e));

--- a/server/TypeDBService.java
+++ b/server/TypeDBService.java
@@ -211,10 +211,12 @@ public class TypeDBService extends TypeDBGrpc.TypeDBImplBase {
             int duration = (int) Duration.between(start, Instant.now()).toMillis();
             responder.onNext(openRes(sessionSvc.UUID(), duration));
             responder.onCompleted();
-            LOG.debug(
-                    "Opened new session '{}' for database '{}'. Sessions open on server: {}", sessionSvc.UUID(),
-                    request.getDatabase(), sessionServices.size()
-            );
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Opened new session '{}' for database '{}'. Sessions open on server: {}", sessionSvc.UUID(),
+                        request.getDatabase(), sessionServices.size()
+                );
+            }
         } catch (RuntimeException e) {
             LOG.error(e.getMessage(), e);
             responder.onError(exception(e));


### PR DESCRIPTION
## What is the goal of this PR?

To monitor production instances of TypeDB and TypeDB enterprise more effectively, when using debug logging the server logs open client connections (each sessions and number of transactions each) at a rate of once per minute. When there are no connections, the server does not log to avoid noise in the idle state.

To enable these logs, set the logger for 'com.vaticle.typedb.core.server` to DEBUG in the TypeDB configuration file.

## What are the changes implemented in this PR?

* Add periodic logging of the global connection state when the server is in DEBUG mode

### Design

We considered alternatives:
1. Not logging the global state each time -- this will not be useful for debugging and monitoring
2. Logging global connection state on client connection -- this makes sense, but probably isn't often enough to be useful
3. Logging at each connection/session/transaction  -- this makes sense, and is consistent, but can get expensive. It also requires transaction open/close to query the _other_ sessions to log their information, which is an awkward control flow

In the end, the best tradeoff of usefulness, performance, usability, and 'correct' control flow by domain was decided to lie in a polling loop that lives at the top-level service.

Note that we ultimately want a client RPC method to query the current server state, which can retrieve network state (sessions/transactions) as well as storage statistics, etc.