### PR TITLE
Fix Windows x86-64 distribution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,10 +97,9 @@ workflows:
               only:
                 - master
                 - development
-      - test-assembly-windows-zip:
-          filters:
-            branches:
-              only:
-                - master
-                - development
-
+      - test-assembly-windows-zip
+#          filters:
+#            branches:
+#              only:
+#                - master
+#                - development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,9 +97,9 @@ workflows:
               only:
                 - master
                 - development
-      - test-assembly-windows-zip
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - development
+      - test-assembly-windows-zip:
+          filters:
+            branches:
+              only:
+                - master
+                - development

--- a/.circleci/windows/dependencies.config
+++ b/.circleci/windows/dependencies.config
@@ -19,7 +19,7 @@
 -->
 
 <packages>
-    <package id="bazel" version="5.3.0"/>
+    <package id="bazelisk" version="1.17.0"/>
     <package id="python" version="3.7.4"/>
     <package id="openjdk11" version="11.0.9.11"/>
 </packages>

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -35,7 +35,7 @@
 @maven//:io_cucumber_datatable_3_2_1
 @maven//:io_cucumber_docstring_5_1_3
 @maven//:io_cucumber_tag_expressions_2_0_4
-@maven//:io_github_speedb_io_speedbjni_2_4_1_3
+@maven//:io_github_speedb_io_speedbjni_2_4_1_4
 @maven//:io_grpc_grpc_api_1_43_0
 @maven//:io_grpc_grpc_context_1_43_0
 @maven//:io_grpc_grpc_core_1_43_0

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "0625a6d6ff089fb50f7cb73ae3ce105c12ebc844",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "35b737c0be841c8c8174bdb22cdf13612d9c2962",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():


### PR DESCRIPTION
## What is the goal of this PR?

We upgrade SpeeDB to 2.4.1.4, which includes fixed support for Windows x86-64.

## What are the changes implemented in this PR?

* Upgrade SpeeDB to 2.4.1.4
* Replace bazel with bazelisk in the choco install requirements for CircleCI windows tests