### PR TITLE
Fix server hang-ups during shutdown

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -41,8 +41,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Server(2, "The expected data directory '%s' is not writable.");
         public static final Server EXITED_WITH_ERROR =
                 new Server(3, "Exited with error.");
-        public static final Server UNCAUGHT_EXCEPTION =
-                new Server(4, "Uncaught exception thrown at thread '%s':\n'%s'");
+        public static final Server UNCAUGHT_ERROR =
+                new Server(4, "Uncaught error thrown at thread '%s':\n'%s'");
         public static final Server CONFIG_FILE_NOT_FOUND =
                 new Server(5, "Could not find/read the configuration file '%s'.");
         public static final Server UNRECOGNISED_CLI_COMMAND =

--- a/common/exception/TypeDBCheckedException.java
+++ b/common/exception/TypeDBCheckedException.java
@@ -37,12 +37,12 @@ public class TypeDBCheckedException extends Exception {
         this.errorMessage = error;
     }
 
-    private TypeDBCheckedException(Exception e) {
+    private TypeDBCheckedException(Throwable e) {
         super(e);
         errorMessage = null;
     }
 
-    public static TypeDBCheckedException of(Exception e) {
+    public static TypeDBCheckedException of(Throwable e) {
         return new TypeDBCheckedException(e);
     }
 

--- a/reasoner/controller/ConjunctionController.java
+++ b/reasoner/controller/ConjunctionController.java
@@ -97,19 +97,15 @@ public abstract class ConjunctionController<
         assert resolvables.isEmpty();
         resolvables.addAll(registry().logicManager().compile(conjunction));
 
-        iterate(resolvables).filter(Resolvable::isConcludable).map(Resolvable::asConcludable).forEachRemaining(c -> {
-            concludableControllers.put(c, registry().getOrCreateConcludable(c));
-        });
-        iterate(resolvables).filter(Resolvable::isRetrievable).map(Resolvable::asRetrievable).forEachRemaining(r -> {
-            retrievableControllers.put(r, registry().createRetrievable(r));
-        });
-        iterate(resolvables).filter(Resolvable::isNegated).map(Resolvable::asNegated).forEachRemaining(negated -> {
-            try {
-                negationControllers.put(negated, registry().createNegation(negated, conjunction));
-            } catch (TypeDBException e) {
-                terminate(e);
-            }
-        });
+        iterate(resolvables).filter(Resolvable::isConcludable).map(Resolvable::asConcludable).forEachRemaining(c ->
+                concludableControllers.put(c, registry().getOrCreateConcludable(c))
+        );
+        iterate(resolvables).filter(Resolvable::isRetrievable).map(Resolvable::asRetrievable).forEachRemaining(r ->
+                retrievableControllers.put(r, registry().createRetrievable(r))
+        );
+        iterate(resolvables).filter(Resolvable::isNegated).map(Resolvable::asNegated).forEachRemaining(negated ->
+                negationControllers.put(negated, registry().createNegation(negated, conjunction))
+        );
     }
 
     ConjunctionStreamPlan getPlan(Set<Variable.Retrievable> bounds) {
@@ -625,12 +621,12 @@ public abstract class ConjunctionController<
 
             private static boolean boundsRemainSatisfied(CompoundStreamPlan parent, CompoundStreamPlan childToFlatten) {
                 return difference(
-                                childToFlatten.childAt(1).identifierVariables,
-                                union(parent.identifierVariables, childToFlatten.childAt(0).outputVariables))
+                        childToFlatten.childAt(1).identifierVariables,
+                        union(parent.identifierVariables, childToFlatten.childAt(0).outputVariables))
                         .isEmpty() &&
                         union(
-                                        childToFlatten.asCompoundStreamPlan().childAt(1).outputs(),
-                                        childToFlatten.asCompoundStreamPlan().childAt(1).extensions())
+                                childToFlatten.asCompoundStreamPlan().childAt(1).outputs(),
+                                childToFlatten.asCompoundStreamPlan().childAt(1).extensions())
                                 .equals(childToFlatten.outputs());
             }
 

--- a/server/TypeDBServer.java
+++ b/server/TypeDBServer.java
@@ -230,7 +230,10 @@ public class TypeDBServer implements AutoCloseable {
                 logger().info("Closing server");
                 server.shutdown();
                 logger().info("Shutting down server grpc");
-                server.awaitTermination();
+                if (!server.awaitTermination(10, TimeUnit.SECONDS)) {
+                    logger().info("Forcefully shutting down server grpc");
+                    server.shutdownNow();
+                }
                 logger().info("Closing DatabaseMgr");
                 databaseMgr.close();
                 logger().info("Performing finalisation");
@@ -239,6 +242,8 @@ public class TypeDBServer implements AutoCloseable {
             } catch (InterruptedException e) {
                 logger().error(FAILED_AT_STOPPING.message(), e);
                 Thread.currentThread().interrupt();
+            } catch (Throwable e) {
+                logger().error(FAILED_AT_STOPPING.message(), e);
             }
         }
     }

--- a/server/TypeDBServer.java
+++ b/server/TypeDBServer.java
@@ -244,6 +244,8 @@ public class TypeDBServer implements AutoCloseable {
                 Thread.currentThread().interrupt();
             } catch (Throwable e) {
                 logger().error(FAILED_AT_STOPPING.message(), e);
+            } finally {
+                Runtime.getRuntime().halt(1);
             }
         }
     }

--- a/server/TypeDBServer.java
+++ b/server/TypeDBServer.java
@@ -23,6 +23,7 @@ import com.vaticle.factory.tracing.client.FactoryTracing;
 import com.vaticle.factory.tracing.client.FactoryTracingThreadStatic;
 import com.vaticle.typedb.common.concurrent.NamedThreadFactory;
 import com.vaticle.typedb.common.util.Java;
+import com.vaticle.typedb.core.common.exception.TypeDBCheckedException;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import com.vaticle.typedb.core.common.parameters.Options;
 import com.vaticle.typedb.core.concurrent.executor.Executors;
@@ -58,7 +59,6 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILL
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.ALREADY_RUNNING;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.DATA_DIRECTORY_NOT_FOUND;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.DATA_DIRECTORY_NOT_WRITABLE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.EXITED_WITH_ERROR;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.FAILED_AT_STOPPING;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.INCOMPATIBLE_JAVA_RUNTIME;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Server.UNCAUGHT_ERROR;
@@ -115,13 +115,22 @@ public class TypeDBServer implements AutoCloseable {
                         logger().error(UNCAUGHT_ERROR.message(t.getName(), e), e);
                         close();
                         System.exit(1);
-                    } catch (Throwable s) {
-                        // unexpected
+                    } catch (TypeDBCheckedException ex) {
+                        logger().error("Failed to shut down cleanly, performing hard stop.");
+                        Runtime.getRuntime().halt(1);
+                    } catch (Throwable error) {
+                        // another thread will do the close
                     }
                 }
         );
         Runtime.getRuntime().addShutdownHook(
-                NamedThreadFactory.create(TypeDBServer.class, "shutdown").newThread(this::close)
+                NamedThreadFactory.create(TypeDBServer.class, "shutdown").newThread(() -> {
+                    try {
+                        close();
+                    } catch (Throwable error) {
+                        logger().error("Error during shutdown: ", error);
+                    }
+                })
         );
         isOpen = new AtomicBoolean(true);
     }
@@ -217,73 +226,70 @@ public class TypeDBServer implements AutoCloseable {
             server.awaitTermination();
         } catch (InterruptedException e) {
             // server is terminated
-            close();
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    @Override
-    public synchronized void close() {
-        if (isOpen.compareAndSet(true, false)) {
             try {
-                logger().info("");
-                logger().info("Shutting down {}...", name());
-                assert typeDBService != null;
-                typeDBService.close();
-                server.shutdown();
-                logger().info("Shutting down network layer...");
-                if (!server.awaitTermination(10, TimeUnit.SECONDS)) {
-                    server.shutdownNow();
-                }
-                logger().info("Shutting down storage layer...");
-                databaseMgr.close();
-                System.runFinalization();
-                logger().info("{} has been shutdown.", name());
-            } catch (Throwable e) {
-                logger().error(FAILED_AT_STOPPING.message(), e);
-                logger().info("Performing hard exit.");
+                close();
+                System.exit(0);
+            } catch (TypeDBCheckedException ex) {
+                logger().error("Failed to shut down cleanly, performing hard stop.");
+                Runtime.getRuntime().halt(1);
+            } catch (Throwable error) {
+                logger().error("Unexpected error during shutdown, performing hard stop.", error);
                 Runtime.getRuntime().halt(1);
             }
         }
     }
 
-    public static void main(String[] args) {
-        try {
-            printASCIILogo();
-
-            CoreConfigParser configParser = new CoreConfigParser();
-            ArgsParser<CoreSubcommand> argsParser = new ArgsParser<CoreSubcommand>()
-                    .subcommand(new CoreSubcommandParser.Server(configParser))
-                    .subcommand(new CoreSubcommandParser.Import())
-                    .subcommand(new CoreSubcommandParser.Export());
-            Optional<CoreSubcommand> subcmd = argsParser.parse(args);
-            if (subcmd.isEmpty()) {
-                LOG.error(UNRECOGNISED_CLI_COMMAND.message(String.join(" ", args)));
-                LOG.error(argsParser.usage());
-                System.exit(1);
-            } else {
-                if (subcmd.get().isServer()) {
-                    CoreSubcommand.Server subcmdServer = subcmd.get().asServer();
-                    if (subcmdServer.isHelp()) System.out.println(argsParser.help());
-                    else if (subcmdServer.isVersion()) System.out.println("Version: " + Version.VERSION);
-                    else runServer(subcmdServer);
-                } else if (subcmd.get().isImport()) {
-                    runImport(subcmd.get().asImport());
-                } else if (subcmd.get().isExport()) {
-                    runExport(subcmd.get().asExport());
-                } else throw TypeDBException.of(ILLEGAL_STATE);
+    @Override
+    public synchronized void close() throws TypeDBCheckedException {
+        if (isOpen.compareAndSet(true, false)) {
+            try {
+                logger().info("");
+                logger().info("Closing {} instance...", name());
+                assert typeDBService != null;
+                typeDBService.close();
+                logger().info("Stopping network layer...");
+                server.shutdown();
+                if (!server.awaitTermination(10, TimeUnit.SECONDS)) {
+                    server.shutdownNow();
+                }
+                logger().info("Stopping storage layer...");
+                databaseMgr.close();
+                System.runFinalization();
+                logger().info("{} instance has been closed.", name());
+            } catch (Throwable e) {
+                logger().error(FAILED_AT_STOPPING.message(), e);
+                throw TypeDBCheckedException.of(e);
             }
-        } catch (Exception e) {
-            if (e instanceof TypeDBException) {
-                LOG.error(e.getMessage());
-            } else {
-                LOG.error(e.getMessage(), e);
-                LOG.error(EXITED_WITH_ERROR.message());
-            }
-            System.exit(1);
         }
+    }
 
-        System.exit(0);
+    public static void main(String[] args) throws IOException {
+        printASCIILogo();
+
+        CoreConfigParser configParser = new CoreConfigParser();
+        ArgsParser<CoreSubcommand> argsParser = new ArgsParser<CoreSubcommand>()
+                .subcommand(new CoreSubcommandParser.Server(configParser))
+                .subcommand(new CoreSubcommandParser.Import())
+                .subcommand(new CoreSubcommandParser.Export());
+        Optional<CoreSubcommand> subcmd = argsParser.parse(args);
+        if (subcmd.isEmpty()) {
+            LOG.error(UNRECOGNISED_CLI_COMMAND.message(String.join(" ", args)));
+            LOG.error(argsParser.usage());
+            System.exit(1);
+        } else {
+            if (subcmd.get().isServer()) {
+                CoreSubcommand.Server subcmdServer = subcmd.get().asServer();
+                if (subcmdServer.isHelp()) System.out.println(argsParser.help());
+                else if (subcmdServer.isVersion()) {
+                    System.out.println("Version: " + Version.VERSION);
+                    System.exit(0);
+                } else runServer(subcmdServer);
+            } else if (subcmd.get().isImport()) {
+                runImport(subcmd.get().asImport());
+            } else if (subcmd.get().isExport()) {
+                runExport(subcmd.get().asExport());
+            } else throw TypeDBException.of(ILLEGAL_STATE);
+        }
     }
 
     private static void runServer(CoreSubcommand.Server subcmdServer) {

--- a/server/TypeDBServer.java
+++ b/server/TypeDBServer.java
@@ -229,9 +229,6 @@ public class TypeDBServer implements AutoCloseable {
             try {
                 close();
                 System.exit(0);
-            } catch (TypeDBCheckedException ex) {
-                logger().error("Failed to shut down cleanly, performing hard stop.");
-                Runtime.getRuntime().halt(1);
             } catch (Throwable error) {
                 logger().error("Unexpected error during shutdown, performing hard stop.", error);
                 Runtime.getRuntime().halt(1);


### PR DESCRIPTION
## What is the goal of this PR?

Under exceptional circumstances, such as when the server runs out of memory, the server could fail to shut down. We modify the server shutdown process and unexpected exception handler to shutdown in several stages, in the most severe case halting the JVM runtime immediately.

## What are the changes implemented in this PR?

Implement graceful and forceful shutdown from within the process:

1. If an unexpected exception occurs, we try to perform the server `close()`. Only 1 thread is allowed to do this one time, and if it fails to do so it throws a checked exception. The caller of `close()` is expected to handle this case and force a halt of the JVM
2. If the user hits ctrl+c, we add a shutdown hook to gracefully close the server, but do nothing if it fails to since the JVM is already shutting down

During the server `close()`, we also now force the grpc server layer to shut down in 10 seconds.
