### PR TITLE
Expose number of outstanding tasks in ActorExecutor

### DIFF
--- a/concurrent/actor/ActorExecutor.java
+++ b/concurrent/actor/ActorExecutor.java
@@ -103,6 +103,10 @@ public class ActorExecutor {
         }
     }
 
+    public int outstandingTaskCount() {
+        return submittedTasks.size();
+    }
+
     @NotThreadSafe
     private static class Task implements Comparable<Task> {
 


### PR DESCRIPTION
## What is the goal of this PR?
We expose the number of outstanding tasks in an actor executor's queue. This allows us to drop retries messages on TypeDB enterprise to a pile-up of redundant work.

## What are the changes implemented in this PR?
* Exposes `ActorExecutor.submittedTasks.size()` through `ActorExecutor.outstandingTaskCount()`