### PR TITLE
Respect archives size cap configuration value

### DIFF
--- a/server/common/Constants.java
+++ b/server/common/Constants.java
@@ -29,4 +29,6 @@ public class Constants {
     public static final Path CONFIG_PATH = getTypedbDir().resolve("server/conf/config.yml");
     public static final String TYPEDB_LOG_FILE = "typedb.log";
     public static final String TYPEDB_LOG_FILE_ARCHIVE_SUFFIX = "-%d{yyyy-MM}.%i.log.gz";
+
+    public static final int TYPEDB_LOG_MAX_HISTORY = 10000;
 }

--- a/server/common/Constants.java
+++ b/server/common/Constants.java
@@ -29,6 +29,5 @@ public class Constants {
     public static final Path CONFIG_PATH = getTypedbDir().resolve("server/conf/config.yml");
     public static final String TYPEDB_LOG_FILE = "typedb.log";
     public static final String TYPEDB_LOG_FILE_ARCHIVE_SUFFIX = "-%d{yyyy-MM}.%i.log.gz";
-
     public static final int TYPEDB_LOG_MAX_HISTORY = 10000;
 }

--- a/server/logging/CoreLogback.java
+++ b/server/logging/CoreLogback.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static com.vaticle.typedb.core.server.common.Constants.TYPEDB_LOG_FILE;
 import static com.vaticle.typedb.core.server.common.Constants.TYPEDB_LOG_FILE_ARCHIVE_SUFFIX;
+import static com.vaticle.typedb.core.server.common.Constants.TYPEDB_LOG_MAX_HISTORY;
 
 public class CoreLogback {
 
@@ -121,6 +122,7 @@ public class CoreLogback {
         long directorySize = outputType.fileSizeCap() + outputType.archivesSizeCap();
         policy.setMaxFileSize(new FileSize(outputType.fileSizeCap()));
         policy.setTotalSizeCap(new FileSize(directorySize));
+        policy.setMaxHistory(TYPEDB_LOG_MAX_HISTORY);
         policy.setParent(appender);
         policy.start();
         appender.setRollingPolicy(policy);


### PR DESCRIPTION
## What is the goal of this PR?

We've added a hardcoded `maxHistory` to the rolling policy for our logging appender. Consequently, our policy now respects the supplied `totalCapSize` which we expose as `log.output.file.archives-size-cap` in our server configuration file.

## What are the changes implemented in this PR?

Added a constant `TYPEDB_LOG_MAX_HISTORY` and it as our maximum history in our logging policy.

## Additional info

We chose 10,000 rather than a larger number (or `Integer.MAX_VALUE`) as we found during that our logging framework behaves strangely when `maxHistory` is set to numbers much larger than 10,000 (e.g. 25,000), deleting archives rather than keeping them.

Fixes https://github.com/vaticle/typedb/issues/6854
