### PR TITLE
Shrink distributions by excluding unnecessary native jars

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "25c7ce28f786fc3ef2a3300b7437f84d859816a4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "dc35e1d26515102c58e6d44bc23632d953fcc722",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():

--- a/test/integration/BasicTest.java
+++ b/test/integration/BasicTest.java
@@ -134,7 +134,7 @@ public class BasicTest {
 
     @Test
     public void write_types_concurrently_repeatedly() throws IOException, InterruptedException {
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 50; i++) {
             System.out.println(i + " ---- ");
             write_types_concurrently();
         }
@@ -414,7 +414,7 @@ public class BasicTest {
 
     @Test
     public void write_attributes_successfully_repeatedly() throws IOException {
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 50; i++) {
             System.out.println(i + " ---- ");
             write_attributes_successfully();
         }
@@ -489,7 +489,7 @@ public class BasicTest {
 
     @Test
     public void write_different_attributes_in_parallel_successfully_repeatedly() throws IOException {
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 50; i++) {
             System.out.println(i + " ---- ");
             write_different_attributes_in_parallel_successfully();
         }
@@ -611,7 +611,7 @@ public class BasicTest {
 
     @Test
     public void write_identical_attributes_in_parallel_successfully_repeatedly() throws IOException {
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 50; i++) {
             System.out.println(i + " ---- ");
             write_identical_attributes_in_parallel_successfully();
         }
@@ -713,7 +713,7 @@ public class BasicTest {
 
     @Test
     public void write_and_delete_attributes_concurrently_repeatedly() throws IOException {
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 50; i++) {
             System.out.println(i + " ---- ");
             write_and_delete_attributes_concurrently();
         }


### PR DESCRIPTION
## What is the goal of this PR?

We discover that our distributions were larger than required, since they included every platform's native `or-tools` jars. We now manually exclude native or-tools from maven, and include them per-platform individually. This should reduce artifact size by 30-40 MB.

## What are the changes implemented in this PR?

- Update maven declarations, which now exclude transitive native or-tools dependencies for every platform. We now pull the API jar (`or-tools-java`) without its transitive native dependencies, and declare the required native dependency directly.