### PR TITLE
Allow type variables in insert and delete clauses

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -402,46 +402,42 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new ThingWrite(14, "Attempted to re-insert pre-existing thing of matched variable '%s' as a new instance (isa) of type '%s'.");
         public static final ThingWrite THING_ISA_MISSING =
                 new ThingWrite(15, "The thing variable '%s' cannot be inserted as a new instance without providing its type (isa).");
-        public static final ThingWrite ILLEGAL_TYPE_VARIABLE_IN_INSERT =
-                new ThingWrite(16, "Illegal type variable '%s' found in insert query. Types can only be referred to by their labels in insert queries or then clauses.");
-        public static final ThingWrite ILLEGAL_TYPE_VARIABLE_IN_DELETE =
-                new ThingWrite(17, "Illegal type variable '%s' found in delete query. Types can only be referred to by their labels in delete queries or then clauses.");
         public static final ThingWrite ILLEGAL_ANONYMOUS_RELATION_IN_DELETE =
-                new ThingWrite(18, "Illegal anonymous relation in delete query: '%s'.  You must match the relation variable by name, and then delete it.");
+                new ThingWrite(16, "Illegal anonymous relation in delete query: '%s'.  You must match the relation variable by name, and then delete it.");
         public static final ThingWrite ILLEGAL_ANONYMOUS_VARIABLE_IN_DELETE =
-                new ThingWrite(19, "Illegal anonymous variable in delete query: '%s'.  You can only delete named variables that were matched.");
+                new ThingWrite(17, "Illegal anonymous variable in delete query: '%s'.  You can only delete named variables that were matched.");
         public static final ThingWrite INVALID_DELETE_THING =
-                new ThingWrite(20, "The thing '%s' cannot be deleted, as the provided type '%s' is not its direct type nor supertype.");
+                new ThingWrite(18, "The thing '%s' cannot be deleted, as the provided type '%s' is not its direct type nor supertype.");
         public static final ThingWrite INVALID_DELETE_THING_DIRECT =
-                new ThingWrite(21, "The thing '%s' cannot be deleted, as the provided direct type '%s' is not valid.");
+                new ThingWrite(19, "The thing '%s' cannot be deleted, as the provided direct type '%s' is not valid.");
         public static final ThingWrite INVALID_DELETE_HAS =
-                new ThingWrite(22, "Invalid attempt to delete attribute ownership. The thing '%s' does not have attribute '%s'.");
+                new ThingWrite(20, "Invalid attempt to delete attribute ownership. The thing '%s' does not have attribute '%s'.");
         public static final ThingWrite ILLEGAL_IS_CONSTRAINT =
-                new ThingWrite(23, "The 'is' constraint, e.g. used in '%s', is not accepted in an insert/delete query.");
+                new ThingWrite(21, "The 'is' constraint, e.g. used in '%s', is not accepted in an insert/delete query.");
         public static final ThingWrite ATTRIBUTE_VALUE_TOO_MANY =
-                new ThingWrite(24, "Unable to insert attribute '%s' of type '%s' with more than one value operations.");
+                new ThingWrite(22, "Unable to insert attribute '%s' of type '%s' with more than one value operations.");
         public static final ThingWrite ATTRIBUTE_VALUE_MISSING =
-                new ThingWrite(25, "Unable to insert attribute '%s' of type '%s' without a value assigned to the variable.");
+                new ThingWrite(23, "Unable to insert attribute '%s' of type '%s' without a value assigned to the variable.");
         public static final ThingWrite INSERT_RELATION_CONSTRAINT_TOO_MANY =
-                new ThingWrite(26, "Unable to insert relation '%s' as it has more than one relation tuple describing the role players.");
+                new ThingWrite(24, "Unable to insert relation '%s' as it has more than one relation tuple describing the role players.");
         public static final ThingWrite RELATION_CONSTRAINT_MISSING =
-                new ThingWrite(27, "Unable to insert relation '%s' as it is missing the relation tuple describing the role players.");
+                new ThingWrite(25, "Unable to insert relation '%s' as it is missing the relation tuple describing the role players.");
         public static final ThingWrite ROLE_TYPE_AMBIGUOUS =
-                new ThingWrite(28, "Unable to add role player '%s' to the relation, as there are more than one possible role type it could play.");
+                new ThingWrite(26, "Unable to add role player '%s' to the relation, as there are more than one possible role type it could play.");
         public static final ThingWrite ROLE_TYPE_MISSING =
-                new ThingWrite(29, "Unable to add role player '%s' to the relation, as there is no provided or inferrable role type.");
+                new ThingWrite(27, "Unable to add role player '%s' to the relation, as there is no provided or inferrable role type.");
         public static final ThingWrite ROLE_TYPE_MISMATCH =
-                new ThingWrite(30, "The type '%s' cannot be used as a role type.");
+                new ThingWrite(28, "The type '%s' cannot be used as a role type.");
         public static final ThingWrite MAX_INSTANCE_REACHED =
-                new ThingWrite(31, "The maximum number of instances for type '%s' has been reached: '%s'");
+                new ThingWrite(29, "The maximum number of instances for type '%s' has been reached: '%s'");
         public static final ThingWrite DELETE_RELATION_CONSTRAINT_TOO_MANY =
-                new ThingWrite(32, "Could not perform delete of role players due to multiple relation constraints being present for relation '%s'.");
+                new ThingWrite(30, "Could not perform delete of role players due to multiple relation constraints being present for relation '%s'.");
         public static final ThingWrite DELETE_ROLEPLAYER_NOT_PRESENT =
-                new ThingWrite(33, "Could not delete roleplayer '%s' as relation '%s' does not relate it.");
+                new ThingWrite(31, "Could not delete roleplayer '%s' as relation '%s' does not relate it.");
         public static final ThingWrite ILLEGAL_VALUE_VARIABLE_IN_DELETE =
-                new ThingWrite(34, "Illegal value variable '%s' found in delete query. Value variables may not be used in delete queries.");
+                new ThingWrite(32, "Illegal value variable '%s' found in delete query. Value variables may not be used in delete queries.");
         public static final ThingWrite ILLEGAL_VALUE_CONSTRAINT_IN_INSERT =
-                new ThingWrite(35, "Illegal value constraint found in insert query on variable '%s'. Value variables are only permitted to specify attribute values.");
+                new ThingWrite(33, "Illegal value constraint found in insert query on variable '%s'. Value variables are only permitted to specify attribute values.");
 
         private static final String codePrefix = "THW";
         private static final String messagePrefix = "Invalid Thing Write";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -396,48 +396,52 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new ThingWrite(11, "Attempted to put an instance of '%s' with value '%s' that does not satisfy the regular expression '%s'.");
         public static final ThingWrite THING_IID_NOT_INSERTABLE =
                 new ThingWrite(12, "The variable '%s' tries to insert iid '%s'. IIDs are prohibited in insert clauses. You may want to query the variable using IID in the match clause.");
+        public static final ThingWrite THING_INSERT_ISA_NOT_THING_TYPE =
+                new ThingWrite(13, "The type '%s' cannot be used for creating an instance as it is not a thing type.");
         public static final ThingWrite THING_ISA_REINSERTION =
-                new ThingWrite(13, "Attempted to re-insert pre-existing thing of matched variable '%s' as a new instance (isa) of type '%s'.");
+                new ThingWrite(14, "Attempted to re-insert pre-existing thing of matched variable '%s' as a new instance (isa) of type '%s'.");
         public static final ThingWrite THING_ISA_MISSING =
-                new ThingWrite(14, "The thing variable '%s' cannot be inserted as a new instance without providing its type (isa).");
+                new ThingWrite(15, "The thing variable '%s' cannot be inserted as a new instance without providing its type (isa).");
         public static final ThingWrite ILLEGAL_TYPE_VARIABLE_IN_INSERT =
-                new ThingWrite(15, "Illegal type variable '%s' found in insert query. Types can only be referred to by their labels in insert queries or then clauses.");
+                new ThingWrite(16, "Illegal type variable '%s' found in insert query. Types can only be referred to by their labels in insert queries or then clauses.");
         public static final ThingWrite ILLEGAL_TYPE_VARIABLE_IN_DELETE =
-                new ThingWrite(16, "Illegal type variable '%s' found in delete query. Types can only be referred to by their labels in delete queries or then clauses.");
+                new ThingWrite(17, "Illegal type variable '%s' found in delete query. Types can only be referred to by their labels in delete queries or then clauses.");
         public static final ThingWrite ILLEGAL_ANONYMOUS_RELATION_IN_DELETE =
-                new ThingWrite(17, "Illegal anonymous relation in delete query: '%s'.  You must match the relation variable by name, and then delete it.");
+                new ThingWrite(18, "Illegal anonymous relation in delete query: '%s'.  You must match the relation variable by name, and then delete it.");
         public static final ThingWrite ILLEGAL_ANONYMOUS_VARIABLE_IN_DELETE =
-                new ThingWrite(18, "Illegal anonymous variable in delete query: '%s'.  You can only delete named variables that were matched.");
+                new ThingWrite(19, "Illegal anonymous variable in delete query: '%s'.  You can only delete named variables that were matched.");
         public static final ThingWrite INVALID_DELETE_THING =
-                new ThingWrite(19, "The thing '%s' cannot be deleted, as the provided type '%s' is not its direct type nor supertype.");
+                new ThingWrite(20, "The thing '%s' cannot be deleted, as the provided type '%s' is not its direct type nor supertype.");
         public static final ThingWrite INVALID_DELETE_THING_DIRECT =
-                new ThingWrite(20, "The thing '%s' cannot be deleted, as the provided direct type '%s' is not valid.");
+                new ThingWrite(21, "The thing '%s' cannot be deleted, as the provided direct type '%s' is not valid.");
         public static final ThingWrite INVALID_DELETE_HAS =
-                new ThingWrite(21, "Invalid attempt to delete attribute ownership. The thing '%s' does not have attribute '%s'.");
+                new ThingWrite(22, "Invalid attempt to delete attribute ownership. The thing '%s' does not have attribute '%s'.");
         public static final ThingWrite ILLEGAL_IS_CONSTRAINT =
-                new ThingWrite(22, "The 'is' constraint, e.g. used in '%s', is not accepted in an insert/delete query.");
+                new ThingWrite(23, "The 'is' constraint, e.g. used in '%s', is not accepted in an insert/delete query.");
         public static final ThingWrite ATTRIBUTE_VALUE_TOO_MANY =
-                new ThingWrite(23, "Unable to insert attribute '%s' of type '%s' with more than one value operations.");
+                new ThingWrite(24, "Unable to insert attribute '%s' of type '%s' with more than one value operations.");
         public static final ThingWrite ATTRIBUTE_VALUE_MISSING =
-                new ThingWrite(24, "Unable to insert attribute '%s' of type '%s' without a value assigned to the variable.");
+                new ThingWrite(25, "Unable to insert attribute '%s' of type '%s' without a value assigned to the variable.");
         public static final ThingWrite INSERT_RELATION_CONSTRAINT_TOO_MANY =
-                new ThingWrite(25, "Unable to insert relation '%s' as it has more than one relation tuple describing the role players.");
+                new ThingWrite(26, "Unable to insert relation '%s' as it has more than one relation tuple describing the role players.");
         public static final ThingWrite RELATION_CONSTRAINT_MISSING =
-                new ThingWrite(26, "Unable to insert relation '%s' as it is missing the relation tuple describing the role players.");
+                new ThingWrite(27, "Unable to insert relation '%s' as it is missing the relation tuple describing the role players.");
         public static final ThingWrite ROLE_TYPE_AMBIGUOUS =
-                new ThingWrite(27, "Unable to add role player '%s' to the relation, as there are more than one possible role type it could play.");
+                new ThingWrite(28, "Unable to add role player '%s' to the relation, as there are more than one possible role type it could play.");
         public static final ThingWrite ROLE_TYPE_MISSING =
-                new ThingWrite(28, "Unable to add role player '%s' to the relation, as there is no provided or inferrable role type.");
+                new ThingWrite(29, "Unable to add role player '%s' to the relation, as there is no provided or inferrable role type.");
+        public static final ThingWrite ROLE_TYPE_MISMATCH =
+                new ThingWrite(30, "The type '%s' cannot be used as a role type.");
         public static final ThingWrite MAX_INSTANCE_REACHED =
-                new ThingWrite(29, "The maximum number of instances for type '%s' has been reached: '%s'");
+                new ThingWrite(31, "The maximum number of instances for type '%s' has been reached: '%s'");
         public static final ThingWrite DELETE_RELATION_CONSTRAINT_TOO_MANY =
-                new ThingWrite(30, "Could not perform delete of role players due to multiple relation constraints being present for relation '%s'.");
+                new ThingWrite(32, "Could not perform delete of role players due to multiple relation constraints being present for relation '%s'.");
         public static final ThingWrite DELETE_ROLEPLAYER_NOT_PRESENT =
-                new ThingWrite(31, "Could not delete roleplayer '%s' as relation '%s' does not relate it.");
+                new ThingWrite(33, "Could not delete roleplayer '%s' as relation '%s' does not relate it.");
         public static final ThingWrite ILLEGAL_VALUE_VARIABLE_IN_DELETE =
-                new ThingWrite(32, "Illegal value variable '%s' found in delete query. Value variables may not be used in delete queries.");
+                new ThingWrite(34, "Illegal value variable '%s' found in delete query. Value variables may not be used in delete queries.");
         public static final ThingWrite ILLEGAL_VALUE_CONSTRAINT_IN_INSERT =
-                new ThingWrite(33, "Illegal value constraint found in insert query on variable '%s'. Value variables are only permitted to specify attribute values.");
+                new ThingWrite(35, "Illegal value constraint found in insert query on variable '%s'. Value variables are only permitted to specify attribute values.");
 
         private static final String codePrefix = "THW";
         private static final String messagePrefix = "Invalid Thing Write";

--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -204,6 +204,14 @@ public final class ConceptManager {
         else return null;
     }
 
+    public Type getType(Label label) {
+        TypeVertex vertex = graphMgr.schema().getType(label);
+        if (vertex != null) {
+            if (label.scope().isPresent()) return convertRoleType(vertex);
+            else return convertThingType(vertex);
+        } else return null;
+    }
+
     public ThingType getThingType(String label) {
         TypeVertex vertex = graphMgr.schema().getType(label);
         if (vertex != null) return convertThingType(vertex);

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,7 +49,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "90b4addcd71a398e9e52e322021c49310e66a47a" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "7cc0605095d445d80df12596b07e3f0726eed856" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -258,7 +258,6 @@ public class Inserter {
 
         private Thing insertIsa(IsaConstraint isaConstraint, ThingVariable var) {
             try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "insert_isa")) {
-                assert isaConstraint.type().label().isPresent();
                 Type type = getType(isaConstraint.type());
                 if (!type.isThingType()) {
                     throw TypeDBException.of(THING_INSERT_ISA_NOT_THING_TYPE, type.getLabel());

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -31,6 +31,7 @@ import com.vaticle.typedb.core.concept.thing.Thing;
 import com.vaticle.typedb.core.concept.type.AttributeType;
 import com.vaticle.typedb.core.concept.type.RoleType;
 import com.vaticle.typedb.core.concept.type.ThingType;
+import com.vaticle.typedb.core.concept.type.Type;
 import com.vaticle.typedb.core.concept.value.Value;
 import com.vaticle.typedb.core.pattern.constraint.common.Predicate;
 import com.vaticle.typedb.core.pattern.constraint.thing.HasConstraint;
@@ -61,11 +62,12 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.A
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ATTRIBUTE_VALUE_TOO_MANY;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_ABSTRACT_WRITE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_IS_CONSTRAINT;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_TYPE_VARIABLE_IN_INSERT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_VALUE_CONSTRAINT_IN_INSERT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.INSERT_RELATION_CONSTRAINT_TOO_MANY;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.RELATION_CONSTRAINT_MISSING;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ROLE_TYPE_MISMATCH;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.THING_IID_NOT_INSERTABLE;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.THING_INSERT_ISA_NOT_THING_TYPE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.THING_ISA_MISSING;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.THING_ISA_REINSERTION;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.TYPE_NOT_FOUND;
@@ -77,7 +79,7 @@ import static com.vaticle.typedb.core.concurrent.executor.Executors.async1;
 import static com.vaticle.typedb.core.concurrent.producer.Producers.async;
 import static com.vaticle.typedb.core.concurrent.producer.Producers.produce;
 import static com.vaticle.typedb.core.query.QueryManager.PARALLELISATION_SPLIT_MIN;
-import static com.vaticle.typedb.core.query.common.Util.getRoleType;
+import static com.vaticle.typedb.core.query.common.Util.tryInferRoleType;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Predicate.Equality.EQ;
 
 public class Inserter {
@@ -118,16 +120,15 @@ public class Inserter {
 
     public static void validate(Variable var) {
         try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "validate")) {
-            if (var.isType()) validate(var.asType());
-            else if (var.isThing()) validate(var.asThing());
+//            if (var.isType()) validate(var.asType());
+            if (var.isThing()) validate(var.asThing());
             else if (var.isValue()) validate(var.asValue());
-            else throw TypeDBException.of(ILLEGAL_STATE);
         }
     }
 
-    private static void validate(TypeVariable var) {
-        if (!var.reference().isLabel()) throw TypeDBException.of(ILLEGAL_TYPE_VARIABLE_IN_INSERT, var.reference());
-    }
+//    private static void validate(TypeVariable var) {
+//        if (!var.reference().isLabel()) throw TypeDBException.of(ILLEGAL_TYPE_VARIABLE_IN_INSERT, var.reference());
+//    }
 
     private static void validate(ThingVariable var) {
         Identifier id = var.id();
@@ -202,12 +203,16 @@ public class Inserter {
             }
         }
 
-        private boolean matchedContains(ThingVariable var) {
+        private boolean matchedContains(Variable var) {
             return var.reference().isNameConcept() && matched.contains(var.reference().asName().asConcept());
         }
 
         public Thing matchedGet(ThingVariable var) {
             return matched.get(var.reference().asName()).asThing();
+        }
+
+        public Type matchedGet(TypeVariable var) {
+            return matched.get(var.reference().asName()).asType();
         }
 
         private Thing insert(ThingVariable var) {
@@ -221,7 +226,7 @@ public class Inserter {
 
                 if (matchedContains(var)) {
                     thing = matchedGet(var);
-                    if (var.isa().isPresent() && !thing.getType().equals(getThingType(var.isa().get().type().label().get()))) {
+                    if (var.isa().isPresent() && !thing.getType().equals(getType(var.isa().get().type()))) {
                         throw TypeDBException.of(THING_ISA_REINSERTION, id, var.isa().get().type());
                     }
                 } else if (var.isa().isPresent()) thing = insertIsa(var.isa().get(), var);
@@ -232,6 +237,14 @@ public class Inserter {
                 if (var.relation().isPresent()) insertRolePlayers(thing.asRelation(), var);
                 if (!var.has().isEmpty()) insertHas(thing, var.has());
                 return thing;
+            }
+        }
+
+        public Type getType(TypeVariable variable) {
+            if (matchedContains(variable)) {
+                return matchedGet(variable.asType());
+            } else {
+                return getThingType(variable.label().get());
             }
         }
 
@@ -246,17 +259,20 @@ public class Inserter {
         private Thing insertIsa(IsaConstraint isaConstraint, ThingVariable var) {
             try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "insert_isa")) {
                 assert isaConstraint.type().label().isPresent();
-                ThingType thingType = getThingType(isaConstraint.type().label().get());
+                Type type = getType(isaConstraint.type());
+                if (!type.isThingType()) {
+                    throw TypeDBException.of(THING_INSERT_ISA_NOT_THING_TYPE, type.getLabel());
+                }
 
-                if (thingType.isEntityType()) {
-                    return thingType.asEntityType().create();
-                } else if (thingType.isRelationType()) {
-                    if (var.relation().isPresent()) return thingType.asRelationType().create();
+                if (type.isEntityType()) {
+                    return type.asEntityType().create();
+                } else if (type.isRelationType()) {
+                    if (var.relation().isPresent()) return type.asRelationType().create();
                     else throw TypeDBException.of(RELATION_CONSTRAINT_MISSING, var.reference());
-                } else if (thingType.isAttributeType()) {
-                    return insertAttribute(thingType.asAttributeType(), var);
-                } else if (thingType.isThingType() && thingType.isRoot()) {
-                    throw TypeDBException.of(ILLEGAL_ABSTRACT_WRITE, Thing.class.getSimpleName(), thingType.getLabel());
+                } else if (type.isAttributeType()) {
+                    return insertAttribute(type.asAttributeType(), var);
+                } else if (type.isThingType() && type.isRoot()) {
+                    throw TypeDBException.of(ILLEGAL_ABSTRACT_WRITE, Thing.class.getSimpleName(), type.getLabel());
                 } else {
                     assert false;
                     return null;
@@ -316,7 +332,14 @@ public class Inserter {
                 if (var.relation().isPresent()) {
                     var.relation().get().players().forEach(rolePlayer -> {
                         Thing player = insert(rolePlayer.player());
-                        RoleType roleType = getRoleType(relation, player, rolePlayer);
+                        RoleType roleType;
+                        if (rolePlayer.roleType().isPresent() && rolePlayer.roleType().get().id().isName()) {
+                            Type type = getType(rolePlayer.roleType().get());
+                            if (!type.isRoleType()) throw TypeDBException.of(ROLE_TYPE_MISMATCH, type.getLabel());
+                            else roleType = type.asRoleType();
+                        } else {
+                            roleType = tryInferRoleType(relation, player, rolePlayer);
+                        }
                         relation.addPlayer(roleType, player);
                     });
                 } else { // var.relation().size() > 1

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -120,15 +120,10 @@ public class Inserter {
 
     public static void validate(Variable var) {
         try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "validate")) {
-//            if (var.isType()) validate(var.asType());
             if (var.isThing()) validate(var.asThing());
             else if (var.isValue()) validate(var.asValue());
         }
     }
-
-//    private static void validate(TypeVariable var) {
-//        if (!var.reference().isLabel()) throw TypeDBException.of(ILLEGAL_TYPE_VARIABLE_IN_INSERT, var.reference());
-//    }
 
     private static void validate(ThingVariable var) {
         Identifier id = var.id();

--- a/query/common/Util.java
+++ b/query/common/Util.java
@@ -39,7 +39,7 @@ public class Util {
 
     private static final String TRACE_PREFIX = "util.";
 
-    public static RoleType getRoleType(Relation relation, Thing player, RelationConstraint.RolePlayer rolePlayer) {
+    public static RoleType tryInferRoleType(Relation relation, Thing player, RelationConstraint.RolePlayer rolePlayer) {
         try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "get_role_type")) {
             RoleType roleType;
             Set<? extends RoleType> inferred;


### PR DESCRIPTION
## What is the goal of this PR?

We allow using type variables in delete and insert clauses. This allows much more expressivity when doing deletes, in particular allowing disjunctions over types in the `match`, which are then operated over in turn in the `delete` clause to clean up relations or attributes.

This change resolves https://github.com/vaticle/typedb/issues/6755

## What are the changes implemented in this PR?

* Allow type variables or labels to be used in insert queries and delete queries
* Update behaviour tests to test both insert and delete queries with variabilisied types