### PR TITLE
Deletes are idempotent instead of throwing

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -292,18 +292,16 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Pattern(17, "Could not infer compatible types for the match pattern:\n '%s'\n, due to the included pattern:\n'%s'.");
         public static final Pattern INFERENCE_INCOHERENT_VALUE_TYPES =
                 new Pattern(18, "Could not infer compatible types for the pattern:\n'%s'\n, due to contradicting attribute value types for:\n'%s'.");
-        public static final Pattern ILLEGAL_INSERT_WITH_ABSTRACT_TYPE =
-                new Pattern(19, "The type '%s' is abstract and cannot be used in insert clauses.");
         public static final Pattern UNRECOGNISED_ANNOTATION =
-                new Pattern(20, "The annotation '%s' is not recognised.");
+                new Pattern(19, "The annotation '%s' is not recognised.");
         public static final Pattern VARIABLE_NAME_CONFLICT =
-                new Pattern(21, "The variable name '%s' was used both for a concept variable and a value variable.");
+                new Pattern(20, "The variable name '%s' was used both for a concept variable and a value variable.");
         public static final Pattern VALUE_VARIABLE_UNASSIGNED =
-                new Pattern(22, "The value variable '%s' is never assigned to.");
+                new Pattern(21, "The value variable '%s' is never assigned to.");
         public static final Pattern VALUE_VARIABLE_DUPLICATE_ASSIGMENT =
-                new Pattern(23, "The value variable '%s' can only have one assignment in the first scope it is used in.");
+                new Pattern(22, "The value variable '%s' can only have one assignment in the first scope it is used in.");
         public static final Pattern VALUE_ASSIGNMENT_CYCLE =
-                new Pattern(24, "A cyclic assignment between value variables was detected: '%s'.");
+                new Pattern(23, "A cyclic assignment between value variables was detected: '%s'.");
 
         private static final String codePrefix = "QRY";
         private static final String messagePrefix = "Invalid Query Pattern";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -412,6 +412,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new ThingWrite(19, "The thing '%s' cannot be deleted, as the provided direct type '%s' is not valid.");
         public static final ThingWrite INVALID_DELETE_HAS =
                 new ThingWrite(20, "Invalid attempt to delete attribute ownership. The thing '%s' does not have attribute '%s'.");
+        public static final ThingWrite HAS_TYPE_MISMATCH =
+                new ThingWrite(20, "The instance of type '%s' cannot own instances of attribute type '%s'.");
         public static final ThingWrite ILLEGAL_IS_CONSTRAINT =
                 new ThingWrite(21, "The 'is' constraint, e.g. used in '%s', is not accepted in an insert/delete query.");
         public static final ThingWrite ATTRIBUTE_VALUE_TOO_MANY =
@@ -428,16 +430,20 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new ThingWrite(27, "Unable to add role player '%s' to the relation, as there is no provided or inferrable role type.");
         public static final ThingWrite ROLE_TYPE_MISMATCH =
                 new ThingWrite(28, "The type '%s' cannot be used as a role type.");
+        public static final ThingWrite PLAYING_TYPE_MISMATCH =
+                new ThingWrite(29, "The instance of type '%s' cannot play the role type '%s'.");
+        public static final ThingWrite RELATING_TYPE_MISMATCH =
+                new ThingWrite(30, "The relation instance of type '%s' cannot relate the role type '%s'.");
         public static final ThingWrite MAX_INSTANCE_REACHED =
-                new ThingWrite(29, "The maximum number of instances for type '%s' has been reached: '%s'");
+                new ThingWrite(31, "The maximum number of instances for type '%s' has been reached: '%s'");
         public static final ThingWrite DELETE_RELATION_CONSTRAINT_TOO_MANY =
-                new ThingWrite(30, "Could not perform delete of role players due to multiple relation constraints being present for relation '%s'.");
+                new ThingWrite(32, "Could not perform delete of role players due to multiple relation constraints being present for relation '%s'.");
         public static final ThingWrite DELETE_ROLEPLAYER_NOT_PRESENT =
-                new ThingWrite(31, "Could not delete roleplayer '%s' as relation '%s' does not relate it.");
+                new ThingWrite(33, "Could not delete roleplayer '%s' as relation '%s' does not relate it.");
         public static final ThingWrite ILLEGAL_VALUE_VARIABLE_IN_DELETE =
-                new ThingWrite(32, "Illegal value variable '%s' found in delete query. Value variables may not be used in delete queries.");
+                new ThingWrite(34, "Illegal value variable '%s' found in delete query. Value variables may not be used in delete queries.");
         public static final ThingWrite ILLEGAL_VALUE_CONSTRAINT_IN_INSERT =
-                new ThingWrite(33, "Illegal value constraint found in insert query on variable '%s'. Value variables are only permitted to specify attribute values.");
+                new ThingWrite(35, "Illegal value constraint found in insert query on variable '%s'. Value variables are only permitted to specify attribute values.");
 
         private static final String codePrefix = "THW";
         private static final String messagePrefix = "Invalid Thing Write";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -443,7 +443,9 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final ThingWrite ILLEGAL_VALUE_VARIABLE_IN_DELETE =
                 new ThingWrite(35, "Illegal value variable '%s' found in delete query. Value variables may not be used in delete queries.");
         public static final ThingWrite ILLEGAL_VALUE_CONSTRAINT_IN_INSERT =
-                new ThingWrite(36, "Illegal value constraint found in insert query on variable '%s'. Value variables are only permitted to specify attribute values.");
+                new ThingWrite(36, "Illegal value constraint found in the insert query on variable '%s'. Value variables are only permitted to specify attribute values.");
+        public static final ThingWrite ILLEGAL_UNBOUND_TYPE_VAR_IN_INSERT =
+                new ThingWrite(37, "Type variable '%s' found in the insert query must retrieved by the match previously.");
 
         private static final String codePrefix = "THW";
         private static final String messagePrefix = "Invalid Thing Write";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -283,25 +283,27 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_LABEL =
                 new Pattern(13, "The type variable '%s' has multiple 'label' constraints.");
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_VALUE_TYPE =
-                new Pattern(14, "Tye type variable '%s' has multiple 'value' constraints.");
+                new Pattern(14, "The type variable '%s' has multiple 'value' constraints.");
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_REGEX =
                 new Pattern(15, "The type variable '%s' has multiple 'regex' constraints.");
-        public static final Pattern INCOHERENT_PATTERN =
-                new Pattern(16, "The schema does not allow for data matching the pattern '%s'.");
-        public static final Pattern INCOHERENT_SUB_PATTERN =
-                new Pattern(17, "The schema does not allow for data matching the pattern '%s', due to the included pattern '%s'.");
-        public static final Pattern INCOHERENT_PATTERN_VARIABLE_VALUE =
-                new Pattern(18, "The schema does not allow for data matching the pattern '%s', due to contradicting attribute value types for '%s'.");
+        public static final Pattern INFERENCE_INCOHERENT_MATCH_PATTERN =
+                new Pattern(16, "Could not infer compatible types for the match pattern:\n'%s'.");
+        public static final Pattern INFERENCE_INCOHERENT_MATCH_SUB_PATTERN =
+                new Pattern(17, "Could not infer compatible types for the match pattern:\n '%s'\n, due to the included pattern:\n'%s'.");
+        public static final Pattern INFERENCE_INCOHERENT_VALUE_TYPES =
+                new Pattern(18, "Could not infer compatible types for the pattern:\n'%s'\n, due to contradicting attribute value types for:\n'%s'.");
+        public static final Pattern ILLEGAL_INSERT_WITH_ABSTRACT_TYPE =
+                new Pattern(19, "The type '%s' is abstract and cannot be used in insert clauses.");
         public static final Pattern UNRECOGNISED_ANNOTATION =
-                new Pattern(19, "The annotation '%s' is not recognised.");
+                new Pattern(20, "The annotation '%s' is not recognised.");
         public static final Pattern VARIABLE_NAME_CONFLICT =
-                new Pattern(20, "The variable name '%s' was used both for a concept variable and a value variable.");
+                new Pattern(21, "The variable name '%s' was used both for a concept variable and a value variable.");
         public static final Pattern VALUE_VARIABLE_UNASSIGNED =
-                new Pattern(21, "The value variable '%s' is never assigned to.");
+                new Pattern(22, "The value variable '%s' is never assigned to.");
         public static final Pattern VALUE_VARIABLE_DUPLICATE_ASSIGMENT =
-                new Pattern(22, "The value variable '%s' can only have one assignment in the first scope it is used in.");
+                new Pattern(23, "The value variable '%s' can only have one assignment in the first scope it is used in.");
         public static final Pattern VALUE_ASSIGNMENT_CYCLE =
-                new Pattern(23, "A cyclic assignment between value variables was detected: '%s'.");
+                new Pattern(24, "A cyclic assignment between value variables was detected: '%s'.");
 
         private static final String codePrefix = "QRY";
         private static final String messagePrefix = "Invalid Query Pattern";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -413,37 +413,37 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final ThingWrite INVALID_DELETE_HAS =
                 new ThingWrite(20, "Invalid attempt to delete attribute ownership. The thing '%s' does not have attribute '%s'.");
         public static final ThingWrite HAS_TYPE_MISMATCH =
-                new ThingWrite(20, "The instance of type '%s' cannot own instances of attribute type '%s'.");
+                new ThingWrite(21, "The instance of type '%s' cannot own instances of attribute type '%s'.");
         public static final ThingWrite ILLEGAL_IS_CONSTRAINT =
-                new ThingWrite(21, "The 'is' constraint, e.g. used in '%s', is not accepted in an insert/delete query.");
+                new ThingWrite(22, "The 'is' constraint, e.g. used in '%s', is not accepted in an insert/delete query.");
         public static final ThingWrite ATTRIBUTE_VALUE_TOO_MANY =
-                new ThingWrite(22, "Unable to insert attribute '%s' of type '%s' with more than one value operations.");
+                new ThingWrite(23, "Unable to insert attribute '%s' of type '%s' with more than one value operations.");
         public static final ThingWrite ATTRIBUTE_VALUE_MISSING =
-                new ThingWrite(23, "Unable to insert attribute '%s' of type '%s' without a value assigned to the variable.");
+                new ThingWrite(24, "Unable to insert attribute '%s' of type '%s' without a value assigned to the variable.");
         public static final ThingWrite INSERT_RELATION_CONSTRAINT_TOO_MANY =
-                new ThingWrite(24, "Unable to insert relation '%s' as it has more than one relation tuple describing the role players.");
+                new ThingWrite(25, "Unable to insert relation '%s' as it has more than one relation tuple describing the role players.");
         public static final ThingWrite RELATION_CONSTRAINT_MISSING =
-                new ThingWrite(25, "Unable to insert relation '%s' as it is missing the relation tuple describing the role players.");
+                new ThingWrite(26, "Unable to insert relation '%s' as it is missing the relation tuple describing the role players.");
         public static final ThingWrite ROLE_TYPE_AMBIGUOUS =
-                new ThingWrite(26, "Unable to add role player '%s' to the relation, as there are more than one possible role type it could play.");
+                new ThingWrite(27, "Unable to add role player '%s' to the relation, as there are more than one possible role type it could play.");
         public static final ThingWrite ROLE_TYPE_MISSING =
-                new ThingWrite(27, "Unable to add role player '%s' to the relation, as there is no provided or inferrable role type.");
+                new ThingWrite(28, "Unable to add role player '%s' to the relation, as there is no provided or inferrable role type.");
         public static final ThingWrite ROLE_TYPE_MISMATCH =
-                new ThingWrite(28, "The type '%s' cannot be used as a role type.");
+                new ThingWrite(29, "The type '%s' cannot be used as a role type.");
         public static final ThingWrite PLAYING_TYPE_MISMATCH =
-                new ThingWrite(29, "The instance of type '%s' cannot play the role type '%s'.");
+                new ThingWrite(30, "The instance of type '%s' cannot play the role type '%s'.");
         public static final ThingWrite RELATING_TYPE_MISMATCH =
-                new ThingWrite(30, "The relation instance of type '%s' cannot relate the role type '%s'.");
+                new ThingWrite(31, "The relation instance of type '%s' cannot relate the role type '%s'.");
         public static final ThingWrite MAX_INSTANCE_REACHED =
-                new ThingWrite(31, "The maximum number of instances for type '%s' has been reached: '%s'");
+                new ThingWrite(32, "The maximum number of instances for type '%s' has been reached: '%s'");
         public static final ThingWrite DELETE_RELATION_CONSTRAINT_TOO_MANY =
-                new ThingWrite(32, "Could not perform delete of role players due to multiple relation constraints being present for relation '%s'.");
+                new ThingWrite(33, "Could not perform delete of role players due to multiple relation constraints being present for relation '%s'.");
         public static final ThingWrite DELETE_ROLEPLAYER_NOT_PRESENT =
-                new ThingWrite(33, "Could not delete roleplayer '%s' as relation '%s' does not relate it.");
+                new ThingWrite(34, "Could not delete roleplayer '%s' as relation '%s' does not relate it.");
         public static final ThingWrite ILLEGAL_VALUE_VARIABLE_IN_DELETE =
-                new ThingWrite(34, "Illegal value variable '%s' found in delete query. Value variables may not be used in delete queries.");
+                new ThingWrite(35, "Illegal value variable '%s' found in delete query. Value variables may not be used in delete queries.");
         public static final ThingWrite ILLEGAL_VALUE_CONSTRAINT_IN_INSERT =
-                new ThingWrite(35, "Illegal value constraint found in insert query on variable '%s'. Value variables are only permitted to specify attribute values.");
+                new ThingWrite(36, "Illegal value constraint found in insert query on variable '%s'. Value variables are only permitted to specify attribute values.");
 
         private static final String codePrefix = "THW";
         private static final String messagePrefix = "Invalid Thing Write";

--- a/concept/type/ThingType.java
+++ b/concept/type/ThingType.java
@@ -87,6 +87,8 @@ public interface ThingType extends Type {
 
     void unsetPlays(RoleType roleType);
 
+    boolean plays(RoleType roleType);
+
     Forwardable<RoleType, Order.Asc> getPlays();
 
     Forwardable<RoleType, Order.Asc> getPlaysExplicit();

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -407,6 +407,13 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
     }
 
     @Override
+    public boolean plays(RoleType roleType) {
+        if (isRoot()) return false;
+        assert getSupertype() != null;
+        return graphMgr().schema().playedRoleTypes(vertex).contains(((RoleTypeImpl)roleType).vertex);
+    }
+
+    @Override
     public Forwardable<RoleType, Order.Asc> getPlays() {
         if (isRoot()) return emptySorted();
         assert getSupertype() != null;

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,7 +49,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-        commit = "ec1220cd6d59e1eb21844a7b0e9d2d59e5295721" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "838803532b8487fb59686c0d9e36968b1f19b506" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,7 +49,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "02ffe55e4c8074d9bfbd9a2cee6cd5063c38615d" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "fec37d32029b208905b93b357b2887df2694478c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,8 +48,8 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-        commit = "838803532b8487fb59686c0d9e36968b1f19b506" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "e115a9adad7fbf91d1a7092c6bb56666ae9a9225" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,7 +49,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "fec37d32029b208905b93b357b2887df2694478c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "d480090f59bd6e638dac807f5e9869087401801d" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,7 +49,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "e115a9adad7fbf91d1a7092c6bb56666ae9a9225" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "02ffe55e4c8074d9bfbd9a2cee6cd5063c38615d" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,8 +48,8 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "7cc0605095d445d80df12596b07e3f0726eed856" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
+        commit = "ec1220cd6d59e1eb21844a7b0e9d2d59e5295721" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/query/Deleter.java
+++ b/query/Deleter.java
@@ -46,13 +46,15 @@ import java.util.Set;
 
 import static com.vaticle.factory.tracing.client.FactoryTracingThreadStatic.traceOnThread;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.DELETE_RELATION_CONSTRAINT_TOO_MANY;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.HAS_TYPE_MISMATCH;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_ANONYMOUS_RELATION_IN_DELETE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_ANONYMOUS_VARIABLE_IN_DELETE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_IS_CONSTRAINT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_VALUE_VARIABLE_IN_DELETE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.INVALID_DELETE_HAS;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.INVALID_DELETE_THING;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.INVALID_DELETE_THING_DIRECT;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.PLAYING_TYPE_MISMATCH;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.RELATING_TYPE_MISMATCH;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ROLE_TYPE_MISMATCH;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.THING_IID_NOT_INSERTABLE;
 import static com.vaticle.typedb.core.common.parameters.Arguments.Query.Producer.EXHAUSTIVE;
@@ -150,6 +152,9 @@ public class Deleter {
                 for (HasConstraint hasConstraint : var.has()) {
                     Reference.Name attRef = hasConstraint.attribute().reference().asName();
                     Attribute att = matched.get(attRef).asAttribute();
+                    if (thing.getType().getOwns(att.getType()).isEmpty()) {
+                        throw TypeDBException.of(HAS_TYPE_MISMATCH, thing.getType().getLabel(), att.getType().getLabel());
+                    }
                     if (thing.getHas(att.getType()).anyMatch(a -> a.equals(att))) thing.unsetHas(att);
                 }
             }
@@ -167,6 +172,11 @@ public class Deleter {
                             else roleType = type.asRoleType();
                         } else {
                             roleType = tryInferRoleType(relation, player, rolePlayer);
+                        }
+                        if (relation.getType().getRelates(roleType.getLabel().name()) == null) {
+                            throw TypeDBException.of(RELATING_TYPE_MISMATCH, relation.getType().getLabel(), roleType.getLabel());
+                        } else if (!player.getType().plays(roleType)) {
+                            throw TypeDBException.of(PLAYING_TYPE_MISMATCH, player.getType().getLabel(), roleType.getLabel());
                         }
                         if (relation.getPlayers(roleType).anyMatch(t -> t.equals(player))) {
                             relation.removePlayer(roleType, player);

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -33,8 +33,6 @@ import com.vaticle.typedb.core.concept.type.RoleType;
 import com.vaticle.typedb.core.concept.type.ThingType;
 import com.vaticle.typedb.core.concept.type.Type;
 import com.vaticle.typedb.core.concept.value.Value;
-import com.vaticle.typedb.core.logic.LogicManager;
-import com.vaticle.typedb.core.pattern.Conjunction;
 import com.vaticle.typedb.core.pattern.constraint.common.Predicate;
 import com.vaticle.typedb.core.pattern.constraint.thing.HasConstraint;
 import com.vaticle.typedb.core.pattern.constraint.thing.IsaConstraint;
@@ -83,7 +81,6 @@ import static com.vaticle.typedb.core.concurrent.producer.Producers.produce;
 import static com.vaticle.typedb.core.query.QueryManager.PARALLELISATION_SPLIT_MIN;
 import static com.vaticle.typedb.core.query.common.Util.tryInferRoleType;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Predicate.Equality.EQ;
-import static java.util.Collections.emptyList;
 
 public class Inserter {
 

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -179,180 +179,180 @@ public class Inserter {
         return iterate(iterate(matches).map(matched -> new Operation(conceptMgr, matched, variables).execute()).toList());
     }
 
-public static class Operation {
+    public static class Operation {
 
-    private static final String TRACE_PREFIX = "operation.";
+        private static final String TRACE_PREFIX = "operation.";
 
-    private final ConceptManager conceptMgr;
-    private final ConceptMap matched;
-    private final Set<ThingVariable> variables;
-    private final Map<Retrievable, Thing> inserted;
+        private final ConceptManager conceptMgr;
+        private final ConceptMap matched;
+        private final Set<ThingVariable> variables;
+        private final Map<Retrievable, Thing> inserted;
 
-    Operation(ConceptManager conceptMgr, ConceptMap matched, Set<ThingVariable> variables) {
-        this.conceptMgr = conceptMgr;
-        this.matched = matched;
-        this.variables = variables;
-        this.inserted = new HashMap<>();
-    }
-
-    public ConceptMap execute() {
-        try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "execute")) {
-            variables.forEach(this::insert);
-            matched.forEach((id, concept) -> {
-                if (concept.isThing()) inserted.putIfAbsent(id, concept.asThing());
-            });
-            return new ConceptMap(inserted);
+        Operation(ConceptManager conceptMgr, ConceptMap matched, Set<ThingVariable> variables) {
+            this.conceptMgr = conceptMgr;
+            this.matched = matched;
+            this.variables = variables;
+            this.inserted = new HashMap<>();
         }
-    }
 
-    private boolean matchedContains(Variable var) {
-        return var.reference().isNameConcept() && matched.contains(var.reference().asName().asConcept());
-    }
-
-    public Thing matchedGet(ThingVariable var) {
-        return matched.get(var.reference().asName()).asThing();
-    }
-
-    public Type matchedGet(TypeVariable var) {
-        return matched.get(var.reference().asName()).asType();
-    }
-
-    private Thing insert(ThingVariable var) {
-        try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "insert")) {
-            assert var.id().isRetrievable(); // thing variables are always retrieved
-            Thing thing;
-            Retrievable id = var.id();
-
-            if (id.isName() && (thing = inserted.get(id)) != null) return thing;
-            else if (matchedContains(var) && var.constraints().isEmpty()) return matchedGet(var);
-
-            if (matchedContains(var)) {
-                thing = matchedGet(var);
-                if (var.isa().isPresent() && !thing.getType().equals(getType(var.isa().get().type()))) {
-                    throw TypeDBException.of(THING_ISA_REINSERTION, id, var.isa().get().type());
-                }
-            } else if (var.isa().isPresent()) thing = insertIsa(var.isa().get(), var);
-            else throw TypeDBException.of(THING_ISA_MISSING, id);
-            assert thing != null;
-
-            inserted.put(id, thing);
-            if (var.relation().isPresent()) insertRolePlayers(thing.asRelation(), var);
-            if (!var.has().isEmpty()) insertHas(thing, var.has());
-            return thing;
-        }
-    }
-
-    public Type getType(TypeVariable variable) {
-        if (matchedContains(variable)) {
-            return matchedGet(variable.asType());
-        } else {
-            return getThingType(variable.label().get());
-        }
-    }
-
-    public ThingType getThingType(LabelConstraint labelConstraint) {
-        try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "get_thing_type")) {
-            ThingType thingType = conceptMgr.getThingType(labelConstraint.label());
-            if (thingType == null) throw TypeDBException.of(TYPE_NOT_FOUND, labelConstraint.label());
-            else return thingType.asThingType();
-        }
-    }
-
-    private Thing insertIsa(IsaConstraint isaConstraint, ThingVariable var) {
-        try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "insert_isa")) {
-            Type type = getType(isaConstraint.type());
-            if (!type.isThingType()) {
-                throw TypeDBException.of(THING_INSERT_ISA_NOT_THING_TYPE, type.getLabel());
-            }
-
-            if (type.isEntityType()) {
-                return type.asEntityType().create();
-            } else if (type.isRelationType()) {
-                if (var.relation().isPresent()) return type.asRelationType().create();
-                else throw TypeDBException.of(RELATION_CONSTRAINT_MISSING, var.reference());
-            } else if (type.isAttributeType()) {
-                return insertAttribute(type.asAttributeType(), var);
-            } else if (type.isThingType() && type.isRoot()) {
-                throw TypeDBException.of(ILLEGAL_ABSTRACT_WRITE, Thing.class.getSimpleName(), type.getLabel());
-            } else {
-                assert false;
-                return null;
-            }
-        }
-    }
-
-    private Attribute insertAttribute(AttributeType attributeType, ThingVariable var) {
-        try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "insert_attribute")) {
-            if (var.predicates().size() > 1) {
-                throw TypeDBException.of(ATTRIBUTE_VALUE_TOO_MANY, var.reference(), attributeType.getLabel());
-            } else if (var.predicates().isEmpty()) {
-                throw TypeDBException.of(ATTRIBUTE_VALUE_MISSING, var.reference(), attributeType.getLabel());
-            } else {
-                Predicate<?> predicate = var.predicates().iterator().next().predicate();
-                if (predicate.predicate().equals(EQ) && predicate.isConstant()) {
-                    switch (attributeType.getValueType()) {
-                        case LONG:
-                            return attributeType.asLong().put(predicate.asConstant().asLong().value());
-                        case DOUBLE:
-                            return attributeType.asDouble().put(predicate.asConstant().asDouble().value());
-                        case BOOLEAN:
-                            return attributeType.asBoolean().put(predicate.asConstant().asBoolean().value());
-                        case STRING:
-                            return attributeType.asString().put(predicate.asConstant().asString().value());
-                        case DATETIME:
-                            return attributeType.asDateTime().put(predicate.asConstant().asDateTime().value());
-                        default:
-                            assert false;
-                            return null;
-                    }
-                } else if (predicate.predicate().equals(EQ) && predicate.isValueVar()) {
-                    Value<?> value = matched.get(predicate.asValueVar().value().id()).asValue();
-                    switch (attributeType.getValueType()) {
-                        case LONG:
-                            return attributeType.asLong().put(value.asLong().value());
-                        case DOUBLE:
-                            return attributeType.asDouble().put(value.asDouble().value());
-                        case BOOLEAN:
-                            return attributeType.asBoolean().put(value.asBoolean().value());
-                        case STRING:
-                            return attributeType.asString().put(value.asString().value());
-                        case DATETIME:
-                            return attributeType.asDateTime().put(value.asDateTime().value());
-                        default:
-                            assert false;
-                            return null;
-                    }
-                } else throw TypeDBException.of(ILLEGAL_STATE);
-            }
-        }
-    }
-
-    private void insertRolePlayers(Relation relation, ThingVariable var) {
-        assert var.relation().isPresent();
-        try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "extend_relation")) {
-            if (var.relation().isPresent()) {
-                var.relation().get().players().forEach(rolePlayer -> {
-                    Thing player = insert(rolePlayer.player());
-                    RoleType roleType;
-                    if (rolePlayer.roleType().isPresent() && rolePlayer.roleType().get().id().isName()) {
-                        Type type = getType(rolePlayer.roleType().get());
-                        if (!type.isRoleType()) throw TypeDBException.of(ROLE_TYPE_MISMATCH, type.getLabel());
-                        else roleType = type.asRoleType();
-                    } else {
-                        roleType = tryInferRoleType(relation, player, rolePlayer);
-                    }
-                    relation.addPlayer(roleType, player);
+        public ConceptMap execute() {
+            try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "execute")) {
+                variables.forEach(this::insert);
+                matched.forEach((id, concept) -> {
+                    if (concept.isThing()) inserted.putIfAbsent(id, concept.asThing());
                 });
-            } else { // var.relation().size() > 1
-                throw TypeDBException.of(INSERT_RELATION_CONSTRAINT_TOO_MANY, var.reference());
+                return new ConceptMap(inserted);
+            }
+        }
+
+        private boolean matchedContains(Variable var) {
+            return var.reference().isNameConcept() && matched.contains(var.reference().asName().asConcept());
+        }
+
+        public Thing matchedGet(ThingVariable var) {
+            return matched.get(var.reference().asName()).asThing();
+        }
+
+        public Type matchedGet(TypeVariable var) {
+            return matched.get(var.reference().asName()).asType();
+        }
+
+        private Thing insert(ThingVariable var) {
+            try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "insert")) {
+                assert var.id().isRetrievable(); // thing variables are always retrieved
+                Thing thing;
+                Retrievable id = var.id();
+
+                if (id.isName() && (thing = inserted.get(id)) != null) return thing;
+                else if (matchedContains(var) && var.constraints().isEmpty()) return matchedGet(var);
+
+                if (matchedContains(var)) {
+                    thing = matchedGet(var);
+                    if (var.isa().isPresent() && !thing.getType().equals(getType(var.isa().get().type()))) {
+                        throw TypeDBException.of(THING_ISA_REINSERTION, id, var.isa().get().type());
+                    }
+                } else if (var.isa().isPresent()) thing = insertIsa(var.isa().get(), var);
+                else throw TypeDBException.of(THING_ISA_MISSING, id);
+                assert thing != null;
+
+                inserted.put(id, thing);
+                if (var.relation().isPresent()) insertRolePlayers(thing.asRelation(), var);
+                if (!var.has().isEmpty()) insertHas(thing, var.has());
+                return thing;
+            }
+        }
+
+        public Type getType(TypeVariable variable) {
+            if (matchedContains(variable)) {
+                return matchedGet(variable.asType());
+            } else {
+                return getThingType(variable.label().get());
+            }
+        }
+
+        public ThingType getThingType(LabelConstraint labelConstraint) {
+            try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "get_thing_type")) {
+                ThingType thingType = conceptMgr.getThingType(labelConstraint.label());
+                if (thingType == null) throw TypeDBException.of(TYPE_NOT_FOUND, labelConstraint.label());
+                else return thingType.asThingType();
+            }
+        }
+
+        private Thing insertIsa(IsaConstraint isaConstraint, ThingVariable var) {
+            try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "insert_isa")) {
+                Type type = getType(isaConstraint.type());
+                if (!type.isThingType()) {
+                    throw TypeDBException.of(THING_INSERT_ISA_NOT_THING_TYPE, type.getLabel());
+                }
+
+                if (type.isEntityType()) {
+                    return type.asEntityType().create();
+                } else if (type.isRelationType()) {
+                    if (var.relation().isPresent()) return type.asRelationType().create();
+                    else throw TypeDBException.of(RELATION_CONSTRAINT_MISSING, var.reference());
+                } else if (type.isAttributeType()) {
+                    return insertAttribute(type.asAttributeType(), var);
+                } else if (type.isThingType() && type.isRoot()) {
+                    throw TypeDBException.of(ILLEGAL_ABSTRACT_WRITE, Thing.class.getSimpleName(), type.getLabel());
+                } else {
+                    assert false;
+                    return null;
+                }
+            }
+        }
+
+        private Attribute insertAttribute(AttributeType attributeType, ThingVariable var) {
+            try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "insert_attribute")) {
+                if (var.predicates().size() > 1) {
+                    throw TypeDBException.of(ATTRIBUTE_VALUE_TOO_MANY, var.reference(), attributeType.getLabel());
+                } else if (var.predicates().isEmpty()) {
+                    throw TypeDBException.of(ATTRIBUTE_VALUE_MISSING, var.reference(), attributeType.getLabel());
+                } else {
+                    Predicate<?> predicate = var.predicates().iterator().next().predicate();
+                    if (predicate.predicate().equals(EQ) && predicate.isConstant()) {
+                        switch (attributeType.getValueType()) {
+                            case LONG:
+                                return attributeType.asLong().put(predicate.asConstant().asLong().value());
+                            case DOUBLE:
+                                return attributeType.asDouble().put(predicate.asConstant().asDouble().value());
+                            case BOOLEAN:
+                                return attributeType.asBoolean().put(predicate.asConstant().asBoolean().value());
+                            case STRING:
+                                return attributeType.asString().put(predicate.asConstant().asString().value());
+                            case DATETIME:
+                                return attributeType.asDateTime().put(predicate.asConstant().asDateTime().value());
+                            default:
+                                assert false;
+                                return null;
+                        }
+                    } else if (predicate.predicate().equals(EQ) && predicate.isValueVar()) {
+                        Value<?> value = matched.get(predicate.asValueVar().value().id()).asValue();
+                        switch (attributeType.getValueType()) {
+                            case LONG:
+                                return attributeType.asLong().put(value.asLong().value());
+                            case DOUBLE:
+                                return attributeType.asDouble().put(value.asDouble().value());
+                            case BOOLEAN:
+                                return attributeType.asBoolean().put(value.asBoolean().value());
+                            case STRING:
+                                return attributeType.asString().put(value.asString().value());
+                            case DATETIME:
+                                return attributeType.asDateTime().put(value.asDateTime().value());
+                            default:
+                                assert false;
+                                return null;
+                        }
+                    } else throw TypeDBException.of(ILLEGAL_STATE);
+                }
+            }
+        }
+
+        private void insertRolePlayers(Relation relation, ThingVariable var) {
+            assert var.relation().isPresent();
+            try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "extend_relation")) {
+                if (var.relation().isPresent()) {
+                    var.relation().get().players().forEach(rolePlayer -> {
+                        Thing player = insert(rolePlayer.player());
+                        RoleType roleType;
+                        if (rolePlayer.roleType().isPresent() && rolePlayer.roleType().get().id().isName()) {
+                            Type type = getType(rolePlayer.roleType().get());
+                            if (!type.isRoleType()) throw TypeDBException.of(ROLE_TYPE_MISMATCH, type.getLabel());
+                            else roleType = type.asRoleType();
+                        } else {
+                            roleType = tryInferRoleType(relation, player, rolePlayer);
+                        }
+                        relation.addPlayer(roleType, player);
+                    });
+                } else { // var.relation().size() > 1
+                    throw TypeDBException.of(INSERT_RELATION_CONSTRAINT_TOO_MANY, var.reference());
+                }
+            }
+        }
+
+        private void insertHas(Thing thing, Set<HasConstraint> hasConstraints) {
+            try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "insert_has")) {
+                hasConstraints.forEach(has -> thing.setHas(insert(has.attribute()).asAttribute()));
             }
         }
     }
-
-    private void insertHas(Thing thing, Set<HasConstraint> hasConstraints) {
-        try (FactoryTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "insert_has")) {
-            hasConstraints.forEach(has -> thing.setHas(insert(has.attribute()).asAttribute()));
-        }
-    }
-}
 }

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -33,6 +33,8 @@ import com.vaticle.typedb.core.concept.type.RoleType;
 import com.vaticle.typedb.core.concept.type.ThingType;
 import com.vaticle.typedb.core.concept.type.Type;
 import com.vaticle.typedb.core.concept.value.Value;
+import com.vaticle.typedb.core.logic.LogicManager;
+import com.vaticle.typedb.core.pattern.Conjunction;
 import com.vaticle.typedb.core.pattern.constraint.common.Predicate;
 import com.vaticle.typedb.core.pattern.constraint.thing.HasConstraint;
 import com.vaticle.typedb.core.pattern.constraint.thing.IsaConstraint;
@@ -81,6 +83,7 @@ import static com.vaticle.typedb.core.concurrent.producer.Producers.produce;
 import static com.vaticle.typedb.core.query.QueryManager.PARALLELISATION_SPLIT_MIN;
 import static com.vaticle.typedb.core.query.common.Util.tryInferRoleType;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Predicate.Equality.EQ;
+import static java.util.Collections.emptyList;
 
 public class Inserter {
 
@@ -113,7 +116,6 @@ public class Inserter {
                 assert !filter.isEmpty();
                 matcher = Matcher.create(reasoner, match.get(filter));
             }
-
             return new Inserter(matcher, conceptMgr, registry.things(), context);
         }
     }

--- a/query/Matcher.java
+++ b/query/Matcher.java
@@ -101,6 +101,10 @@ public class Matcher {
         return new Group.Aggregator(group, query);
     }
 
+    public Disjunction disjunction() {
+        return disjunction;
+    }
+
     public FunctionalIterator<? extends ConceptMap> execute() {
         assert context != null;
         return execute(context);

--- a/query/Updater.java
+++ b/query/Updater.java
@@ -67,14 +67,14 @@ public class Updater {
             VariableRegistry deleteRegistry = VariableRegistry.createFromThings(query.deleteVariables(), false);
             deleteRegistry.variables().forEach(Deleter::validate);
 
-            VariableRegistry insertRegistry = VariableRegistry.createFromThings(query.insertVariables());
-            insertRegistry.variables().forEach(Inserter::validate);
-
             assert query.match().namedVariablesUnbound().containsAll(query.namedDeleteVariablesUnbound());
             Set<UnboundVariable> filter = new HashSet<>(query.match().namedVariablesUnbound());
             filter.retainAll(query.namedInsertVariablesUnbound());
             filter.addAll(query.namedDeleteVariablesUnbound());
             Matcher matcher = Matcher.create(reasoner, query.match().get(list(filter)));
+
+            VariableRegistry insertRegistry = VariableRegistry.createFromThings(query.insertVariables());
+            insertRegistry.variables().forEach(var -> Inserter.validate(var, matcher));
             return new Updater(matcher, conceptMgr, deleteRegistry.things(), insertRegistry.things(), context);
         }
     }

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -60,8 +60,8 @@ import java.util.Set;
 import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.INCOHERENT_PATTERN;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.INCOHERENT_SUB_PATTERN;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.INFERENCE_INCOHERENT_MATCH_PATTERN;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.INFERENCE_INCOHERENT_MATCH_SUB_PATTERN;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingRead.SORT_ATTRIBUTE_NOT_COMPARABLE;
 import static com.vaticle.typedb.core.common.iterator.Iterators.cartesian;
 import static com.vaticle.typedb.core.common.iterator.Iterators.empty;
@@ -138,9 +138,9 @@ public class Reasoner {
         if (!disjunction.isCoherent()) {
             Set<Conjunction> causes = incoherentConjunctions(disjunction);
             if (set(disjunction.conjunctions()).equals(causes)) {
-                throw TypeDBException.of(INCOHERENT_PATTERN, disjunction);
+                throw TypeDBException.of(INFERENCE_INCOHERENT_MATCH_PATTERN, disjunction);
             } else {
-                throw TypeDBException.of(INCOHERENT_SUB_PATTERN, disjunction, causes);
+                throw TypeDBException.of(INFERENCE_INCOHERENT_MATCH_SUB_PATTERN, disjunction, causes);
             }
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

We move partially towards the 'assert-style' deletion outlined in #6882 to allow idempotent deletion. Previously, deletes would throw when trying to delete a previously-removed/non-existent connection.

We now guarantee that all deletes will continue even if trying to delete a relationship, ownership, role player, or concept that doesn't exist (ie. was previously deleted).

For example, the following is now valid:
```
match 
$x has $a, has $b; $b = $a;
delete
$x has $a;
```
Because the same attribute would be generated twice by the `match`, the second delete would fail and throw an error. This is now an idempotent operation, which will continue without an error.

We also introduce a new operation to disallow a new class of semantically unsafe queries. We add an explicit 'runtime' type check before performing the idempotent delete operation. This means the following semantically invalid query will still throw an exception when any data matches:
```
match
$x isa person;
$id isa company-id;
delete
$x has $id;
```

## What are the changes implemented in this PR?

* Relax delete semantics to allow idempotent deletion
* Add a 'runtime' type check that before trying to perform any delete-if-present operation, can throw a meaningful error if a connection being deleted is not allowed in the schema at all.