### PR TITLE
Upgrade speeDB to 2.6.0

### DIFF
--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -35,7 +35,7 @@
 @maven//:io_cucumber_datatable_3_2_1
 @maven//:io_cucumber_docstring_5_1_3
 @maven//:io_cucumber_tag_expressions_2_0_4
-@maven//:io_github_speedb_io_speedbjni_2_4_1_5
+@maven//:io_github_speedb_io_speedbjni_2_6_0
 @maven//:io_grpc_grpc_api_1_43_0
 @maven//:io_grpc_grpc_context_1_43_0
 @maven//:io_grpc_grpc_core_1_43_0

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "dc35e1d26515102c58e6d44bc23632d953fcc722",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "de3e9f844c9b3f3f13e6288b33e3e326b636a8f7",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():


### PR DESCRIPTION
## What is the goal of this PR?

Upgrade SpeeDB to 2.6.0. This upgrade does not change any configurations. Even so we observe a 3-5% performance improvement in read-heavy workloads.

## What are the changes implemented in this PR?

Upgrade SpeeDB to 2.6.0.