### PR TITLE
Replace 'client' terminology with 'driver' terminology

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -158,6 +158,10 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -158,10 +158,6 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD

--- a/README.md
+++ b/README.md
@@ -279,16 +279,16 @@ TypeDB Driver provide stateful objects, Sessions and Transactions, to interact w
 The transactions provide [ACID guarantees](https://typedb.com/docs/typedb/2.x/development/connect#_acid_guarantees), 
 up to snapshot isolation.
 
-TypeDB's Driver API is provided through a gRPC client, providing bi-directional streaming, compression, and strong 
+TypeDB's Driver API is provided through a gRPC driver, providing bi-directional streaming, compression, and strong 
 message typing, that REST APIs could not provide. 
 
 TypeDB Drivers are delivered as libraries in dedicated languages 
 that provide stateful objects, Session and Transactions, for you to interact with the database programmatically.
 
-- [Java](https://typedb.com/docs/clients/2.x/java/java-overview)
-- [Python](https://typedb.com/docs/clients/2.x/python/python-overview)
-- [Node.js](https://typedb.com/docs/clients/2.x/node-js/node-js-overview)
-- [Community drivers](https://typedb.com/docs/clients/2.x/other-languages)
+- [Java](https://typedb.com/docs/drivers/2.x/java/java-overview)
+- [Python](https://typedb.com/docs/drivers/2.x/python/python-overview)
+- [Node.js](https://typedb.com/docs/drivers/2.x/node-js/node-js-overview)
+- [Community drivers](https://typedb.com/docs/drivers/2.x/other-languages)
 
 ## Download and Run TypeDB
 

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -86,7 +86,7 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final Server MISSING_FIELD =
                 new Server(25, "The request message does not contain the required field '%s'.");
         public static final Server PROTOCOL_VERSION_MISMATCH =
-                new Server(26, "A protocol version mismatch was detected. This server supports version '%s' but the driver supports version '%s'. Please use a compatible client to connect.");
+                new Server(26, "A protocol version mismatch was detected. This server supports version '%s' but the driver supports version '%s'. Please use a compatible driver to connect.");
         public static final Server MISSING_CONCEPT =
                 new Server(27, "Concept does not exist.");
         public static final Server BAD_VALUE_TYPE =

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,14 +28,14 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        commit = "848532c3dc9bddeae0ea5dd5111d0bffd41799ac",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        commit = "2.24.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "40f8ab74b34447b59517ce3f027c8700a8aa057a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/dmitrii-ubskii/typedb-common",
+        commit = "d3bd8b0813ce24a4ebe974a43801e431e20c69e6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():
@@ -48,6 +48,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "4a9f0628cab2fcab0b36b02cf391fe50bbcf0972",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
+        commit = "d537e6f0b6bd1d5d2f48ea03648722b6db3f9d8e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
 )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -34,7 +34,7 @@ def vaticle_typeql():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/dmitrii-ubskii/typedb-common",
+        remote = "https://github.com/vaticle/typedb-common",
         tag = "2.24.1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        commit = "2.24.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        tag = "2.24.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,7 +35,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/dmitrii-ubskii/typedb-common",
-        commit = "d3bd8b0813ce24a4ebe974a43801e431e20c69e6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        tag = "2.24.1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():
@@ -48,6 +48,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
-        commit = "d537e6f0b6bd1d5d2f48ea03648722b6db3f9d8e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "d441a0f994536b60f3a3174ef7d87992d8856ee5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
 )

--- a/server/TypeDBService.java
+++ b/server/TypeDBService.java
@@ -126,10 +126,10 @@ public class TypeDBService extends TypeDBGrpc.TypeDBImplBase {
                                StreamObserver<ConnectionProto.Connection.Open.Res> responder) {
         try {
             if (request.getVersion() != VersionProto.Version.VERSION) {
-                int clientProtocolVersion = request.getVersion() == VersionProto.Version.UNSPECIFIED ?
+                int driverProtocolVersion = request.getVersion() == VersionProto.Version.UNSPECIFIED ?
                         0 : request.getVersion().getNumber();
                 TypeDBException error = TypeDBException.of(
-                        PROTOCOL_VERSION_MISMATCH, VersionProto.Version.VERSION.getNumber(), clientProtocolVersion
+                        PROTOCOL_VERSION_MISMATCH, VersionProto.Version.VERSION.getNumber(), driverProtocolVersion
                 );
                 responder.onError(exception(error));
                 LOG.error(error.getMessage(), error);


### PR DESCRIPTION
## What is the goal of this PR?

We replace the term 'cluster' with 'enterprise', to reflect the new consistent terminology used through Vaticle. We also replace 'client' with 'driver', where appropriate.

## What are the changes implemented in this PR?

* Update error messages and README to no longer refer to TypeDB Clients, and use the new terminology of TypeDB Drivers