### PR TITLE
Create separate distributions for each OS + Arch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,18 +18,41 @@
 version: 2.1
 orbs:
   win: circleci/windows@2.0.0
+
+  executors:
+    linux-arm64:
+      machine:
+        image: ubuntu-2204:current
+        resource_class: arm.medium
+      working_directory: ~/typedb-console
+
+    linux-x86_64:
+      machine:
+        image: ubuntu-2204:current
+      working_directory: ~/typedb-console
+
+    mac-arm64:
+      macos:
+        xcode: "14.2.0"
+      resource_class: macos.m1.medium.gen1
+      working_directory: ~/typedb-console
+
+    mac-x86_64:
+      macos:
+        xcode: "14.2.0"
+      working_directory: ~/typedb-console
+
+
 commands:
-
-  install-bazel-linux-x86_64:
+  install-bazel-linux:
+    parameters:
+      arch:
+        type: string
     steps:
-      - run: curl -OL https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-amd64
-      - run: sudo mv bazelisk-linux-amd64 /usr/local/bin/bazel
-
-  install-bazel-linux-arm64:
-    steps:
-      - run: curl -OL https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64
-      - run: sudo mv bazelisk-linux-arm64 /usr/local/bin/bazel
-      - run: chmod a+x /usr/local/bin/bazel
+      - run: |
+          curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.arch>>"
+          sudo mv "bazelisk-linux-<<parameters.arch>>" /usr/local/bin/bazel
+          chmod a+x /usr/local/bin/bazel
 
   install-bazel-mac:
     steps:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -151,20 +151,24 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies: [test-assembly-linux-targz]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-targz -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-zip -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //server:deploy-windows-zip -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-targz -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-zip -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-arm64-targz -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-x86_64-targz -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-arm64-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-x86_64-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-windows-x86_64-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-arm64-targz -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-x86_64-targz -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-arm64-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-x86_64-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-x86_64-zip -- snapshot
     deploy-apt-snapshot:
       image: vaticle-ubuntu-22.04
       filter:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -183,6 +183,14 @@ build:
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --define version=$(git rev-parse HEAD) //server:deploy-apt -- snapshot
         bazel run --define version=$(git rev-parse HEAD) //:deploy-apt -- snapshot
+    deploy-brew-snapshot:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: master
+      command: |
+        export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN DEPLOY_BREW_USERNAME=$REPO_GITHUB_USERNAME DEPLOY_BREW_EMAIL=$REPO_GITHUB_EMAIL
+        bazel run --define version=$(cat VERSION) //:deploy-brew -- snapshot
     test-deployment-apt:
       image: vaticle-ubuntu-22.04 # use LTS for apt tests
       filter:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -151,10 +151,10 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies: [test-assembly-linux-targz]
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD

--- a/BUILD
+++ b/BUILD
@@ -67,66 +67,141 @@ permissions = {
 }
 
 artifact_repackage(
-    name = "console-artifact-jars",
-    # Jars produced for all platforms are the same
-    srcs = ["@vaticle_typedb_console_artifact_linux//file"],
+    name = "console-artifact-jars-linux-arm64",
+    srcs = ["@vaticle_typedb_console_artifact_linux-arm64//file"],
     files_to_keep = ["console"],
 )
 
 assemble_targz(
-    name = "assemble-linux-targz",
+    name = "assemble-linux-arm64-targz",
     targets = [
-        ":console-artifact-jars",
-        "//server:server-deps-linux",
+        ":console-artifact-jars-linux-arm64",
+        "//server:server-deps-linux-x86_64",
         "@vaticle_typedb_common//binary:assemble-bash-targz"
     ],
     additional_files = assemble_files,
     empty_directories = empty_directories,
     permissions = permissions,
-    output_filename = "typedb-all-linux",
+    output_filename = "typedb-all-linux-arm64",
 )
 
-assemble_zip(
-    name = "assemble-mac-zip",
-    targets = ["//server:server-deps-mac", ":console-artifact-jars", "@vaticle_typedb_common//binary:assemble-bash-targz"],
+artifact_repackage(
+    name = "console-artifact-jars-linux-x86_64",
+    srcs = ["@vaticle_typedb_console_artifact_linux-x86_64//file"],
+    files_to_keep = ["console"],
+)
+
+assemble_targz(
+    name = "assemble-linux-x86_64-targz",
+    targets = [
+        ":console-artifact-jars-linux-x86_64",
+        "//server:server-deps-linux-x86_64",
+        "@vaticle_typedb_common//binary:assemble-bash-targz"
+    ],
     additional_files = assemble_files,
     empty_directories = empty_directories,
     permissions = permissions,
-    output_filename = "typedb-all-mac",
+    output_filename = "typedb-all-linux-x86_64",
+)
+
+artifact_repackage(
+    name = "console-artifact-jars-mac-arm64",
+    srcs = ["@vaticle_typedb_console_artifact_mac-arm64//file"],
+    files_to_keep = ["console"],
 )
 
 assemble_zip(
-    name = "assemble-windows-zip",
-    targets = ["//server:server-deps-windows", ":console-artifact-jars", "@vaticle_typedb_common//binary:assemble-bat-targz"],
+    name = "assemble-mac-arm64-zip",
+    targets = [
+        "//server:server-deps-mac-arm64",
+        ":console-artifact-jars-mac-arm64",
+        "@vaticle_typedb_common//binary:assemble-bash-targz",
+    ],
     additional_files = assemble_files,
     empty_directories = empty_directories,
     permissions = permissions,
-    output_filename = "typedb-all-windows",
+    output_filename = "typedb-all-mac-arm64",
+)
+
+artifact_repackage(
+    name = "console-artifact-jars-mac-x86_64",
+    srcs = ["@vaticle_typedb_console_artifact_mac-x86_64//file"],
+    files_to_keep = ["console"],
+)
+
+assemble_zip(
+    name = "assemble-mac-x86_64-zip",
+    targets = [
+        "//server:server-deps-mac-x86_64",
+        ":console-artifact-jars-mac-x86_64",
+        "@vaticle_typedb_common//binary:assemble-bash-targz",
+    ],
+    additional_files = assemble_files,
+    empty_directories = empty_directories,
+    permissions = permissions,
+    output_filename = "typedb-all-mac-x86_64",
+)
+
+artifact_repackage(
+    name = "console-artifact-jars-windows-x86_64",
+    srcs = ["@vaticle_typedb_console_artifact_windows-x86_64//file"],
+    files_to_keep = ["console"],
+)
+
+assemble_zip(
+    name = "assemble-windows-x86_64-zip",
+    targets = [
+        "//server:server-deps-windows-x86_64",
+        ":console-artifact-jars-windows-x86_64",
+        "@vaticle_typedb_common//binary:assemble-bat-targz",
+    ],
+    additional_files = assemble_files,
+    empty_directories = empty_directories,
+    permissions = permissions,
+    output_filename = "typedb-all-windows-x86_64",
 )
 
 deploy_artifact(
-    name = "deploy-linux-targz",
-    target = ":assemble-linux-targz",
+    name = "deploy-linux-arm64-targz",
+    target = ":assemble-linux-arm64-targz",
     artifact_group = "vaticle_typedb",
-    artifact_name = "typedb-all-linux-{version}.tar.gz",
+    artifact_name = "typedb-all-linux-arm64-{version}.tar.gz",
     release = deployment['artifact.release'],
     snapshot = deployment['artifact.snapshot'],
 )
 
 deploy_artifact(
-    name = "deploy-mac-zip",
-    target = ":assemble-mac-zip",
+    name = "deploy-linux-x86_64-targz",
+    target = ":assemble-linux-x86_64-targz",
     artifact_group = "vaticle_typedb",
-    artifact_name = "typedb-all-mac-{version}.zip",
+    artifact_name = "typedb-all-linux-x86_64-{version}.tar.gz",
     release = deployment['artifact.release'],
     snapshot = deployment['artifact.snapshot'],
 )
 
 deploy_artifact(
-    name = "deploy-windows-zip",
-    target = ":assemble-windows-zip",
+    name = "deploy-mac-arm64-zip",
+    target = ":assemble-mac-arm64-zip",
     artifact_group = "vaticle_typedb",
-    artifact_name = "typedb-all-windows-{version}.zip",
+    artifact_name = "typedb-all-mac-arm64-{version}.zip",
+    release = deployment['artifact.release'],
+    snapshot = deployment['artifact.snapshot'],
+)
+
+deploy_artifact(
+    name = "deploy-mac-x86_64-zip",
+    target = ":assemble-mac-x86_64-zip",
+    artifact_group = "vaticle_typedb",
+    artifact_name = "typedb-all-mac-x86_64-{version}.zip",
+    release = deployment['artifact.release'],
+    snapshot = deployment['artifact.snapshot'],
+)
+
+deploy_artifact(
+    name = "deploy-windows-x86_64-zip",
+    target = ":assemble-windows-x86_64-zip",
+    artifact_group = "vaticle_typedb",
+    artifact_name = "typedb-all-windows-x86_64-{version}.zip",
     release = deployment['artifact.release'],
     snapshot = deployment['artifact.snapshot'],
 )
@@ -134,23 +209,32 @@ deploy_artifact(
 assemble_versioned(
     name = "assemble-versioned-all",
     targets = [
-        ":assemble-linux-targz",
-        ":assemble-mac-zip",
-        ":assemble-windows-zip",
-        "//server:assemble-linux-targz",
-        "//server:assemble-mac-zip",
-        "//server:assemble-windows-zip",
+        ":assemble-linux-arm64-targz",
+        ":assemble-linux-x86_64-targz",
+        ":assemble-mac-arm64-zip",
+        ":assemble-mac-x86_64-zip",
+        ":assemble-windows-x86_64-zip",
+        "//server:assemble-linux-arm64-targz",
+        "//server:assemble-linux-x86_64-targz",
+        "//server:assemble-mac-arm64-zip",
+        "//server:assemble-mac-x86_64-zip",
+        "//server:assemble-windows-x86_64-zip",
     ],
 )
 
 assemble_versioned(
     name = "assemble-versioned-mac",
-    targets = [":assemble-mac-zip"],
+    targets = [":assemble-mac-arm64-zip"],
 )
 
 checksum(
-    name = "checksum-mac",
-    archive = ":assemble-versioned-mac",
+    name = "checksum-mac-arm64",
+    archive = ":assemble-mac-arm64-zip",
+)
+
+checksum(
+    name = "checksum-mac-x86_64",
+    archive = ":assemble-mac-x86_64-zip",
 )
 
 deploy_github(
@@ -169,7 +253,10 @@ deploy_brew(
     snapshot = deployment['brew.snapshot'],
     release = deployment['brew.release'],
     formula = "//config/brew:typedb.rb",
-    checksum = "//:checksum-mac",
+    file_substitutions = {
+        "//:checksum-mac-arm64": "{sha256-arm64}",
+        "//:checksum-mac-x86_64": "{sha256-x86_64}",
+    },
     version_file = "//:VERSION"
 )
 
@@ -181,7 +268,7 @@ assemble_apt(
     depends = [
         "openjdk-11-jre",
         "typedb-server (=%{version})",
-        "typedb-console (=%{@vaticle_typedb_console_artifact_linux})",
+        "typedb-console (=%{@vaticle_typedb_console_artifact_linux-x86_64})",
     ],
     workspace_refs = "@vaticle_typedb_workspace_refs//:refs.json",
 )
@@ -207,7 +294,7 @@ release_validate_deps(
 docker_container_image(
     name = "assemble-docker",
     base = "@vaticle_ubuntu_image//image",
-    tars = [":assemble-linux-targz"],
+    tars = [":assemble-linux-x86_64-targz"],
     directory = "opt",
     workdir = "/opt/typedb-all-linux",
     ports = ["1729"],
@@ -282,4 +369,3 @@ filegroup(
         "@vaticle_dependencies//tool/unuseddeps:unused-deps",
     ],
 )
-

--- a/common/BUILD
+++ b/common/BUILD
@@ -35,17 +35,11 @@ native_java_libraries(
         "@maven//:com_google_code_findbugs_jsr305",
         "@maven//:org_slf4j_slf4j_api",
     ],
-    mac_deps = [
-        "@maven//:com_google_ortools_ortools_darwin_x86_64",
-        "@maven//:com_google_ortools_ortools_darwin_aarch64",
-    ],
-    linux_deps = [
-        "@maven//:com_google_ortools_ortools_linux_x86_64",
-        "@maven//:com_google_ortools_ortools_linux_aarch64",
-    ],
-    windows_deps = [
-        "@maven//:com_google_ortools_ortools_win32_x86_64",
-    ],
+    linux_arm64_deps = ["@maven//:com_google_ortools_ortools_linux_aarch64"],
+    linux_x86_64_deps = ["@maven//:com_google_ortools_ortools_linux_x86_64"],
+    mac_arm64_deps = ["@maven//:com_google_ortools_ortools_darwin_aarch64"],
+    mac_x86_64_deps = ["@maven//:com_google_ortools_ortools_darwin_x86_64"],
+    windows_x86_64_deps = ["@maven//:com_google_ortools_ortools_win32_x86_64"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-common:{pom_version}"],
 )
 

--- a/config/brew/typedb.rb
+++ b/config/brew/typedb.rb
@@ -17,10 +17,19 @@
 
 # IMPORTANT: any changes to the formula should be propagated to Homebrew/homebrew-core
 class Typedb < Formula
-  desc "Strongly-typed database with a rich and logical type system"
-  homepage "https://vaticle.com"
-  url "https://github.com/vaticle/typedb/releases/download/{version}/typedb-all-mac-{version}.zip"
-  sha256 "{sha256}"
+  desc "Polymorphic database powered by types"
+  homepage "https://typedb.com"
+
+  on_arm do
+    url "https://github.com/vaticle/typedb/releases/download/{version}/typedb-all-mac-arm64-{version}.zip"
+    sha256 "{sha256-arm64}"
+  end
+
+  on_intel do
+    url "https://github.com/vaticle/typedb/releases/download/{version}/typedb-all-mac-x86_64-{version}.zip"
+    sha256 "{sha256-x86_64}"
+  end
+
   license "AGPL-3.0-or-later"
 
   depends_on "openjdk"

--- a/database/BUILD
+++ b/database/BUILD
@@ -50,22 +50,14 @@ native_java_libraries(
         # External dependencies from Maven
         "@maven//:com_google_ortools_ortools_java",
         "@maven//:com_google_code_findbugs_jsr305",
-        "@maven//:org_slf4j_slf4j_api"
-    ],
-    mac_deps = [
-        "@maven//:com_google_ortools_ortools_darwin_x86_64",
-        "@maven//:com_google_ortools_ortools_darwin_aarch64",
+        "@maven//:org_slf4j_slf4j_api",
         "@maven//:io_github_speedb_io_speedbjni",
     ],
-    linux_deps = [
-        "@maven//:com_google_ortools_ortools_linux_x86_64",
-        "@maven//:com_google_ortools_ortools_linux_aarch64",
-        "@maven//:io_github_speedb_io_speedbjni",
-    ],
-    windows_deps = [
-        "@maven//:com_google_ortools_ortools_win32_x86_64",
-        "@maven//:io_github_speedb_io_speedbjni",
-    ],
+    linux_arm64_deps = ["@maven//:com_google_ortools_ortools_linux_aarch64"],
+    linux_x86_64_deps = ["@maven//:com_google_ortools_ortools_linux_x86_64"],
+    mac_arm64_deps = ["@maven//:com_google_ortools_ortools_darwin_aarch64"],
+    mac_x86_64_deps = ["@maven//:com_google_ortools_ortools_darwin_x86_64"],
+    windows_x86_64_deps = ["@maven//:com_google_ortools_ortools_win32_x86_64"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-database:{pom_version}"],
     visibility = [ "//visibility:public" ]
 )
@@ -75,4 +67,3 @@ checkstyle_test(
     include = glob(["*"]),
     license_type = "agpl-header",
 )
-

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -25,5 +25,5 @@ def vaticle_typedb_console_artifact():
         artifact_name = "typedb-console-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "82c485bf5b61d34d7ad5d5c54a5eac2e1944b46d",
+        commit = "08bd8a56d68a9c7fe4b0b4db97b96dd489fdda44",
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/dmitrii-ubskii/vaticle-dependencies",
-        commit = "54c29b9560883cdc7d4b37873930618f15995539",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "bbaa05b2b5f7afd304c0b070a17d202893c08562",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():
@@ -34,8 +34,8 @@ def vaticle_typeql():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/dmitrii-ubskii/typedb-common",
-        commit = "21a29d0751910d40958eb3e52482f9b1f28d73ca",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        commit = "ae0f1e8b6c7b0d7548ea24787cae080126728e58",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "96c22f01b7b2be9380f59e8d376abc28850f0b74",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/dmitrii-ubskii/vaticle-dependencies",
+        commit = "54c29b9560883cdc7d4b37873930618f15995539",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():
@@ -34,8 +34,8 @@ def vaticle_typeql():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.24.1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/dmitrii-ubskii/typedb-common",
+        commit = "21a29d0751910d40958eb3e52482f9b1f28d73ca",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():
@@ -50,4 +50,4 @@ def vaticle_typedb_behaviour():
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
         commit = "d441a0f994536b60f3a3174ef7d87992d8856ee5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
-)
+    )

--- a/migrator/BUILD
+++ b/migrator/BUILD
@@ -77,14 +77,6 @@ native_java_libraries(
         "@maven//:io_grpc_grpc_stub",
         "@maven//:javax_annotation_javax_annotation_api", # gRPC needs this in order to compile in Java 11 and Java 14
         "@maven//:org_slf4j_slf4j_api",
-    ],
-    mac_deps = [
-        "@maven//:io_github_speedb_io_speedbjni"
-    ],
-    linux_deps = [
-        "@maven//:io_github_speedb_io_speedbjni",
-    ],
-    windows_deps = [
         "@maven//:io_github_speedb_io_speedbjni",
     ],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-migrator:{pom_version}"],

--- a/server/BUILD
+++ b/server/BUILD
@@ -102,48 +102,80 @@ genrule(
 )
 
 java_binary(
-    name = "server-bin-mac",
+    name = "server-bin-linux-arm64",
     main_class = "com.vaticle.typedb.core.server.TypeDBServer",
-    runtime_deps = [":server-mac"],
+    runtime_deps = [":server-linux-arm64"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-server-bin:{pom_version}"],
     data = [":prepare-server-directories"]
 )
 
 java_binary(
-    name = "server-bin-linux",
+    name = "server-bin-linux-x86_64",
     main_class = "com.vaticle.typedb.core.server.TypeDBServer",
-    runtime_deps = [":server-linux"],
+    runtime_deps = [":server-linux-x86_64"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-server-bin:{pom_version}"],
     data = [":prepare-server-directories"]
 )
 
 java_binary(
-    name = "server-bin-windows",
+    name = "server-bin-mac-arm64",
     main_class = "com.vaticle.typedb.core.server.TypeDBServer",
-    runtime_deps = [":server-windows"],
+    runtime_deps = [":server-mac-arm64"],
+    tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-server-bin:{pom_version}"],
+    data = [":prepare-server-directories"]
+)
+
+java_binary(
+    name = "server-bin-mac-x86_64",
+    main_class = "com.vaticle.typedb.core.server.TypeDBServer",
+    runtime_deps = [":server-mac-x86_64"],
+    tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-server-bin:{pom_version}"],
+    data = [":prepare-server-directories"]
+)
+
+java_binary(
+    name = "server-bin-windows-x86_64",
+    main_class = "com.vaticle.typedb.core.server.TypeDBServer",
+    runtime_deps = [":server-windows-x86_64"],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-server-bin:{pom_version}"],
     data = [":prepare-server-directories"]
 )
 
 java_deps(
-    name = "server-deps-mac",
-    target = ":server-bin-mac",
+    name = "server-deps-linux-arm64",
+    target = ":server-bin-linux-arm64",
     java_deps_root = "server/lib/",
     visibility = ["//:__pkg__"],
     maven_name = False,
 )
 
 java_deps(
-    name = "server-deps-linux",
-    target = ":server-bin-linux",
+    name = "server-deps-linux-x86_64",
+    target = ":server-bin-linux-x86_64",
     java_deps_root = "server/lib/",
     visibility = ["//:__pkg__"],
     maven_name = False,
 )
 
 java_deps(
-    name = "server-deps-windows",
-    target = ":server-bin-windows",
+    name = "server-deps-mac-arm64",
+    target = ":server-bin-mac-arm64",
+    java_deps_root = "server/lib/",
+    visibility = ["//:__pkg__"],
+    maven_name = False,
+)
+
+java_deps(
+    name = "server-deps-mac-x86_64",
+    target = ":server-bin-mac-x86_64",
+    java_deps_root = "server/lib/",
+    visibility = ["//:__pkg__"],
+    maven_name = False,
+)
+
+java_deps(
+    name = "server-deps-windows-x86_64",
+    target = ":server-bin-windows-x86_64",
     java_deps_root = "server/lib/",
     visibility = ["//:__pkg__"],
     maven_name = False,
@@ -165,58 +197,96 @@ permissions = {
 }
 
 assemble_targz(
-    name = "assemble-linux-targz",
-    targets = ["server-deps-linux", "@vaticle_typedb_common//binary:assemble-bash-targz"],
+    name = "assemble-linux-arm64-targz",
+    targets = ["server-deps-linux-arm64", "@vaticle_typedb_common//binary:assemble-bash-targz"],
     additional_files = assemble_files,
     empty_directories = empty_directories,
     permissions = permissions,
-    output_filename = "typedb-server-linux",
+    output_filename = "typedb-server-linux-arm64",
+    visibility = ["//:__pkg__", "//test:__subpackages__"]
+)
+
+assemble_targz(
+    name = "assemble-linux-x86_64-targz",
+    targets = ["server-deps-linux-x86_64", "@vaticle_typedb_common//binary:assemble-bash-targz"],
+    additional_files = assemble_files,
+    empty_directories = empty_directories,
+    permissions = permissions,
+    output_filename = "typedb-server-linux-x86_64",
     visibility = ["//:__pkg__", "//test:__subpackages__"]
 )
 
 assemble_zip(
-    name = "assemble-mac-zip",
-    targets = ["server-deps-mac", "@vaticle_typedb_common//binary:assemble-bash-targz"],
+    name = "assemble-mac-arm64-zip",
+    targets = ["server-deps-mac-arm64", "@vaticle_typedb_common//binary:assemble-bash-targz"],
     additional_files = assemble_files,
     empty_directories = empty_directories,
     permissions = permissions,
-    output_filename = "typedb-server-mac",
+    output_filename = "typedb-server-mac-arm64",
     visibility = ["//:__pkg__", "//test:__subpackages__"]
 )
 
 assemble_zip(
-    name = "assemble-windows-zip",
-    targets = ["server-deps-windows", "@vaticle_typedb_common//binary:assemble-bat-targz"],
+    name = "assemble-mac-x86_64-zip",
+    targets = ["server-deps-mac-x86_64", "@vaticle_typedb_common//binary:assemble-bash-targz"],
     additional_files = assemble_files,
     empty_directories = empty_directories,
     permissions = permissions,
-    output_filename = "typedb-server-windows",
+    output_filename = "typedb-server-mac-x86_64",
+    visibility = ["//:__pkg__", "//test:__subpackages__"]
+)
+
+assemble_zip(
+    name = "assemble-windows-x86_64-zip",
+    targets = ["server-deps-windows-x86_64", "@vaticle_typedb_common//binary:assemble-bat-targz"],
+    additional_files = assemble_files,
+    empty_directories = empty_directories,
+    permissions = permissions,
+    output_filename = "typedb-server-windows-x86_64",
     visibility = ["//:__pkg__", "//test:__subpackages__"]
 )
 
 deploy_artifact(
-    name = "deploy-linux-targz",
-    target = ":assemble-linux-targz",
+    name = "deploy-linux-arm64-targz",
+    target = ":assemble-linux-arm64-targz",
     artifact_group = "vaticle_typedb",
-    artifact_name = "typedb-server-linux-{version}.tar.gz",
+    artifact_name = "typedb-server-linux-arm64-{version}.tar.gz",
     release = deployment['artifact.release'],
     snapshot = deployment['artifact.snapshot'],
 )
 
 deploy_artifact(
-    name = "deploy-mac-zip",
-    target = ":assemble-mac-zip",
+    name = "deploy-linux-x86_64-targz",
+    target = ":assemble-linux-x86_64-targz",
     artifact_group = "vaticle_typedb",
-    artifact_name = "typedb-server-mac-{version}.zip",
+    artifact_name = "typedb-server-linux-x86_64-{version}.tar.gz",
     release = deployment['artifact.release'],
     snapshot = deployment['artifact.snapshot'],
 )
 
 deploy_artifact(
-    name = "deploy-windows-zip",
-    target = ":assemble-windows-zip",
+    name = "deploy-mac-arm64-zip",
+    target = ":assemble-mac-arm64-zip",
     artifact_group = "vaticle_typedb",
-    artifact_name = "typedb-server-windows-{version}.zip",
+    artifact_name = "typedb-server-mac-arm64-{version}.zip",
+    release = deployment['artifact.release'],
+    snapshot = deployment['artifact.snapshot'],
+)
+
+deploy_artifact(
+    name = "deploy-mac-x86_64-zip",
+    target = ":assemble-mac-x86_64-zip",
+    artifact_group = "vaticle_typedb",
+    artifact_name = "typedb-server-mac-x86_64-{version}.zip",
+    release = deployment['artifact.release'],
+    snapshot = deployment['artifact.snapshot'],
+)
+
+deploy_artifact(
+    name = "deploy-windows-x86_64-zip",
+    target = ":assemble-windows-x86_64-zip",
+    artifact_group = "vaticle_typedb",
+    artifact_name = "typedb-server-windows-x86_64-{version}.zip",
     release = deployment['artifact.release'],
     snapshot = deployment['artifact.snapshot'],
 )
@@ -231,7 +301,7 @@ assemble_apt(
       "typedb-bin (=%{@vaticle_typedb_common})"
     ],
     workspace_refs = "@vaticle_typedb_workspace_refs//:refs.json",
-    archives = [":server-deps-linux"],
+    archives = [":server-deps-linux-x86_64"],
     installation_dir = "/opt/typedb/core/",
     files = assemble_files,
     empty_dirs = [

--- a/test/assembly/BUILD
+++ b/test/assembly/BUILD
@@ -23,12 +23,20 @@ typedb_java_test(
     name = "assembly",
     test_class = "com.vaticle.typedb.core.test.assembly.AssemblyTest",
     srcs = ["AssemblyTest.java"],
-    server_mac_artifact = "//server:assemble-mac-zip",
-    server_linux_artifact = "//server:assemble-linux-targz",
-    server_windows_artifact = "//server:assemble-windows-zip",
-    console_mac_artifact = "@vaticle_typedb_console_artifact_mac//file",
-    console_linux_artifact = "@vaticle_typedb_console_artifact_linux//file",
-    console_windows_artifact = "@vaticle_typedb_console_artifact_windows//file",
+    server_artifacts = {
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": "//server:assemble-linux-arm64-targz",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "//server:assemble-linux-x86_64-targz",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": "//server:assemble-mac-arm64-zip",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "//server:assemble-mac-x86_64-zip",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "//server:assemble-windows-x86_64-zip",
+    },
+    console_artifacts = {
+        "@vaticle_bazel_distribution//platform:is_linux_arm64": "@vaticle_typedb_console_artifact_linux-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64": "@vaticle_typedb_console_artifact_linux-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64": "@vaticle_typedb_console_artifact_mac-arm64//file",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64": "@vaticle_typedb_console_artifact_mac-x86_64//file",
+        "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_console_artifact_windows-x86_64//file",
+    },
     data = [":console-script"],
 )
 

--- a/test/deployment/BUILD
+++ b/test/deployment/BUILD
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-load("@vaticle_typedb_common//test:rules.bzl", "native_typedb_artifact")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
 java_test(

--- a/test/integration/logic/BUILD
+++ b/test/integration/logic/BUILD
@@ -169,13 +169,13 @@ host_compatible_java_test(
     test_class = "com.vaticle.typedb.core.logic.resolvable.AlphaEquivalenceTest",
     native_libraries_deps = [
         "//:typedb",
+        "//common:common",
         "//database:database",
         "//logic:logic",
         "//pattern:pattern",
     ],
     deps = [
         "//test/integration/util",
-        "//common:common-mac",
         # External dependencies from Vaticle
         "@vaticle_typedb_common//:common",
         "@vaticle_typeql//java/pattern",


### PR DESCRIPTION
## What is the goal of this PR?

We create 5 separate distributions of TypeDB, one per platform:

1. `linux-x86_64`
2. `linux-arm64`
3. `mac-x86_64`
4. `mac-arm64`
5. `windows-x86_64`

Please be aware that this means TypeDB distributions are no longer portable between Intel and Mac variants of the same system - eg. from an Intel mac to an ARM mac. 


## What are the changes implemented in this PR?

* Create separate distributions for each platform (os + arch)
* Update homebrew formulae to handle arm and intel distribution
* Update packaging to only include the jars required for the current platform