### PR TITLE
Deploy x86-64 and arm64 apt distributions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,14 @@ executors:
 
 
 commands:
+
+  install-bazel-linux-x86_64:
+    steps:
+      - run: |
+          curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-amd64"
+          sudo mv "bazelisk-linux-arm64" /usr/local/bin/bazel
+          chmod a+x /usr/local/bin/bazel
+
   install-bazel-linux-arm64:
     steps:
       - run: |
@@ -83,6 +91,14 @@ jobs:
       - install-bazel-linux-arm64
       - run: bazel test //test/assembly:assembly --test_output=errors
 
+  test-assembly-linux-x86_64-zip:
+    executor: linux-x86_64
+    working_directory: ~/typedb
+    steps:
+      - checkout
+      - install-bazel-linux-x86_64
+      - run: bazel test //test/assembly:assembly --test_output=errors
+
   test-assembly-windows-zip:
     executor:
       name: win/default
@@ -104,6 +120,12 @@ workflows:
                 - master
                 - development
       - test-assembly-mac-arm64-zip:
+          filters:
+            branches:
+              only:
+                - master
+                - development
+      - test-assembly-linux-x86_64-zip:
           filters:
             branches:
               only:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -132,7 +132,7 @@ build:
         bazel test //test/benchmark/reasoner/iam/complex:test-large-data --test_output=streamed
         bazel test //test/benchmark/reasoner/iam/complex:test-real-queries --test_output=streamed
     test-assembly-linux-targz:
-      image: vaticle-ubuntu-22.04
+      image: vaticle-ubuntu-20.04
       filter:
         owner: vaticle
         branch: [master, development]
@@ -224,13 +224,6 @@ release:
         owner: vaticle
         branch: master
       command: |
-        export PYENV_ROOT="/opt/pyenv"
-        pyenv install 3.7.9
-        pyenv global 3.7.9
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
-        python3 -m pip install certifi
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
         bazel run --define version=$(cat VERSION) //:deploy-github -- $FACTORY_COMMIT
     deploy-brew:
@@ -251,12 +244,6 @@ release:
       command: |
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
-        export PYENV_ROOT="/opt/pyenv"
-        pyenv install 3.7.9
-        pyenv global 3.7.9
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
         bazel run --define version=$(cat VERSION) //server:deploy-apt -- release
         bazel run --define version=$(cat VERSION) //:deploy-apt -- release
     deploy-docker:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -176,16 +176,11 @@ build:
         branch: [master, development]
       dependencies: [test-assembly-linux-targz]
       command: |
-        export PYENV_ROOT="/opt/pyenv"
-        pyenv install 3.7.9
-        pyenv global 3.7.9
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run --define version=$(git rev-parse HEAD) //server:deploy-apt -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-apt-x86_64 -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-apt-arm64 -- snapshot
         bazel run --define version=$(git rev-parse HEAD) //:deploy-apt -- snapshot
     deploy-brew-snapshot:
       image: vaticle-ubuntu-22.04
@@ -225,6 +220,7 @@ release:
         branch: master
       command: |
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --define version=$(cat VERSION) //:deploy-github -- $FACTORY_COMMIT
     deploy-brew:
       image: vaticle-ubuntu-22.04
@@ -244,8 +240,10 @@ release:
       command: |
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
-        bazel run --define version=$(cat VERSION) //server:deploy-apt -- release
-        bazel run --define version=$(cat VERSION) //:deploy-apt -- release
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-apt-x86_64 -- release
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-apt-arm64 -- release
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-apt -- release
     deploy-docker:
       image: vaticle-ubuntu-22.04
       filter:
@@ -254,6 +252,7 @@ release:
       dependencies: [deploy-github]
       command: |
         docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run //:deploy-docker-release
         bazel run //:deploy-docker-release-overwrite-latest-tag
     deploy-artifact-release:
@@ -265,6 +264,7 @@ release:
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --define version=$(cat VERSION) //server:deploy-linux-targz -- release
         bazel run --define version=$(cat VERSION) //server:deploy-mac-zip -- release
         bazel run --define version=$(cat VERSION) //server:deploy-windows-zip -- release

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -190,7 +190,7 @@ build:
       command: |
         export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN DEPLOY_BREW_USERNAME=$REPO_GITHUB_USERNAME DEPLOY_BREW_EMAIL=$REPO_GITHUB_EMAIL
         bazel run --define version=$(cat VERSION) //:deploy-brew -- snapshot
-    test-deployment-apt:
+    test-deployment-apt-x86_64:
       image: vaticle-ubuntu-22.04 # use LTS for apt tests
       filter:
         owner: vaticle

--- a/BUILD
+++ b/BUILD
@@ -76,7 +76,7 @@ assemble_targz(
     name = "assemble-linux-arm64-targz",
     targets = [
         ":console-artifact-jars-linux-arm64",
-        "//server:server-deps-linux-x86_64",
+        "//server:server-deps-linux-arm64",
         "@vaticle_typedb_common//binary:assemble-bash-targz"
     ],
     additional_files = assemble_files,

--- a/BUILD
+++ b/BUILD
@@ -265,12 +265,15 @@ assemble_apt(
     package_name = "typedb-all",
     maintainer = "Vaticle <community@vaticle.com>",
     description = "TypeDB (all)",
+    # typedb-server and typedb-console have arm/intel releases. Apt will find one matching installer's platform
     depends = [
         "openjdk-11-jre",
         "typedb-server (=%{version})",
+        # Note: arbitrarily pick version from the x86_64 console artifact
         "typedb-console (=%{@vaticle_typedb_console_artifact_linux-x86_64})",
     ],
     workspace_refs = "@vaticle_typedb_workspace_refs//:refs.json",
+    architecture = "all",
 )
 
 deploy_apt(

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -25,5 +25,5 @@ def vaticle_typedb_console_artifact():
         artifact_name = "typedb-console-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        tag = "2.24.8",
+        tag = "2.24.9",
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,14 +28,14 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        tag = "2.24.8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        tag = "2.24.11",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/flyingsilverfin/typedb-common",
-        commit = "7774bbd62dba3c967cddc35ce9e2c7e52371f773",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        tag = "2.24.10",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -34,8 +34,8 @@ def vaticle_typeql():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.24.5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/flyingsilverfin/typedb-common",
+        commit = "7774bbd62dba3c967cddc35ce9e2c7e52371f773",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():

--- a/server/BUILD
+++ b/server/BUILD
@@ -305,12 +305,12 @@ assemble_apt(
     installation_dir = "/opt/typedb/core/",
     files = assemble_files,
     empty_dirs = [
-        "opt/typedb/core/server/lib/",
-        "var/lib/typedb/core/data/"
+        "/opt/typedb/core/server/lib/",
+        "/var/lib/typedb/core/data/"
     ],
     empty_dirs_permission = "0777",
     symlinks = {
-        "opt/typedb/core/server/data": "/var/lib/typedb/core/data/",
+        "/opt/typedb/core/server/data": "/var/lib/typedb/core/data/",
     },
 )
 

--- a/server/BUILD
+++ b/server/BUILD
@@ -292,7 +292,7 @@ deploy_artifact(
 )
 
 assemble_apt(
-    name = "assemble-linux-apt",
+    name = "assemble-linux-x86_64-apt",
     package_name = "typedb-server",
     maintainer = "Vaticle <community@vaticle.com>",
     description = "TypeDB (server)",
@@ -312,11 +312,43 @@ assemble_apt(
     symlinks = {
         "/opt/typedb/core/server/data": "/var/lib/typedb/core/data/",
     },
+    architecture = "amd64",
+)
+
+assemble_apt(
+    name = "assemble-linux-arm64-apt",
+    package_name = "typedb-server",
+    maintainer = "Vaticle <community@vaticle.com>",
+    description = "TypeDB (server)",
+    depends = [
+      "openjdk-11-jre",
+      "typedb-bin (=%{@vaticle_typedb_common})"
+    ],
+    workspace_refs = "@vaticle_typedb_workspace_refs//:refs.json",
+    archives = [":server-deps-linux-arm64"],
+    installation_dir = "/opt/typedb/core/",
+    files = assemble_files,
+    empty_dirs = [
+        "/opt/typedb/core/server/lib/",
+        "/var/lib/typedb/core/data/"
+    ],
+    empty_dirs_permission = "0777",
+    symlinks = {
+        "/opt/typedb/core/server/data": "/var/lib/typedb/core/data/",
+    },
+    architecture = "arm64",
 )
 
 deploy_apt(
-    name = "deploy-apt",
-    target = ":assemble-linux-apt",
+    name = "deploy-apt-x86_64",
+    target = ":assemble-linux-x86_64-apt",
+    snapshot = deployment['apt.snapshot'],
+    release = deployment['apt.release']
+)
+
+deploy_apt(
+    name = "deploy-apt-arm64",
+    target = ":assemble-linux-arm64-apt",
     snapshot = deployment['apt.snapshot'],
     release = deployment['apt.release']
 )


### PR DESCRIPTION
## What is the goal of this PR?

We deploy two apt distributions: `x86_64` (aka `amd64` in apt) and `arm64`. Apt automatically selects the correct architecture matching the current platform, so users just need to add the apt source and install the server.

## What are the changes implemented in this PR?

* We deploy a distribution to apt for both intel and arm architectures
* We use the bazel cache for release jobs as well as correctness jobs
