### PR TITLE
Optional config values

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,7 +35,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.24.14",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        tag = "2.24.15",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():

--- a/server/parameters/CoreConfigFactory.java
+++ b/server/parameters/CoreConfigFactory.java
@@ -105,7 +105,8 @@ public class CoreConfigFactory {
     protected static void substituteEnvVars(YAML.Map yaml) {
         for (String key : yaml.keys()) {
             YAML value = yaml.get(key);
-            if (value.isString()) {
+            if (value == null) continue;
+            else if (value.isString()) {
                 String valueStr = value.asString().value();
                 if (valueStr.startsWith("$")) {
                     String envVarName = valueStr.substring(1);

--- a/server/parameters/util/YAMLParser.java
+++ b/server/parameters/util/YAMLParser.java
@@ -151,6 +151,14 @@ public class YAMLParser {
             throw TypeDBException.of(ILLEGAL_CAST, className(getClass()), className(Restricted.class));
         }
 
+        public boolean isOptional() {
+            return false;
+        }
+
+        public Optional<?> asOptional() {
+            throw TypeDBException.of(ILLEGAL_CAST, className(getClass()), className(Optional.class));
+        }
+
         boolean isCompound() {
             return false;
         }
@@ -253,6 +261,40 @@ public class YAMLParser {
 
             @Override
             Restricted<T> asRestricted() {
+                return this;
+            }
+        }
+
+        public static class Optional<T> extends Value<java.util.Optional<T>> {
+
+            private final Primitive<T> valueParser;
+
+            public Optional(Primitive<T> valueParser) {
+                this.valueParser = valueParser;
+            }
+
+            @Override
+            public java.util.Optional<T> parse(YAML yaml, String path) {
+                if (yaml == null) return java.util.Optional.empty();
+                else return java.util.Optional.of(valueParser.parse(yaml, path));
+            }
+
+            public String description() {
+                return  valueParser.description() + "|null";
+            }
+
+            @Override
+            Help help(String key, String keyValueDescription) {
+                return new Primitive.Help(key, keyValueDescription, description());
+            }
+
+            @Override
+            public boolean isOptional() {
+                return true;
+            }
+
+            @Override
+            public Optional<T> asOptional() {
                 return this;
             }
         }
@@ -497,14 +539,14 @@ public class YAMLParser {
                 return tryParse(string).isPresent();
             }
 
-            private static Optional<TimePeriodName> tryParse(String string) {
+            private static java.util.Optional<TimePeriodName> tryParse(String string) {
                 for (TimePeriodName timePeriodName : values()) {
                     String canonicalString = string.trim().toLowerCase();
                     if (canonicalString.equals(timePeriodName.singular) || canonicalString.equals(timePeriodName.plural)) {
-                        return Optional.of(timePeriodName);
+                        return java.util.Optional.of(timePeriodName);
                     }
                 }
-                return Optional.empty();
+                return java.util.Optional.empty();
             }
 
             public ChronoUnit chronoUnit() {
@@ -545,15 +587,15 @@ public class YAMLParser {
                 return tryParse(periodString).isPresent();
             }
 
-            private static Optional<TimePeriod> tryParse(String periodString) {
+            private static java.util.Optional<TimePeriod> tryParse(String periodString) {
                 Matcher matcher = PATTERN.matcher(periodString);
                 if (matcher.matches()) {
                     String lenStr = matcher.group(LENGTH_GROUP);
                     long lenValue = Long.parseLong(lenStr);
                     String unitStr = matcher.group(PERIOD_NAME_GROUP);
                     TimePeriodName periodName = TimePeriodName.parse(unitStr);
-                    return Optional.of(new TimePeriod(lenValue, periodName));
-                } else return Optional.empty();
+                    return java.util.Optional.of(new TimePeriod(lenValue, periodName));
+                } else return java.util.Optional.empty();
             }
 
             public long length() {

--- a/server/parameters/util/YAMLParser.java
+++ b/server/parameters/util/YAMLParser.java
@@ -167,7 +167,7 @@ public class YAMLParser {
             throw TypeDBException.of(ILLEGAL_CAST, className(getClass()), className(Compound.class));
         }
 
-        abstract Help help(String key, String description);
+        public abstract Help help(String key, String description);
 
         public static abstract class Compound<T> extends Value<T> {
 
@@ -184,7 +184,7 @@ public class YAMLParser {
             }
 
             @Override
-            Help help(String key, String description) {
+            public Help help(String key, String description) {
                 return new Help(key, description, helpList(key));
             }
 
@@ -284,7 +284,7 @@ public class YAMLParser {
             }
 
             @Override
-            Help help(String key, String keyValueDescription) {
+            public Help help(String key, String keyValueDescription) {
                 return new Primitive.Help(key, keyValueDescription, description());
             }
 
@@ -323,7 +323,7 @@ public class YAMLParser {
             public static final Primitive<Path> PATH = new Primitive<>(
                     (yaml) -> yaml.isString(),
                     (yaml) -> Paths.get(yaml.asString().value()),
-                    "<relative or absolute path>"
+                    "<path>"
             );
             public static final Primitive<Long> BYTES_SIZE = new Primitive<>(
                     (yaml) -> yaml.isString() && Bytes.isValidString(yaml.asString().value()),

--- a/server/test/parameters/CoreConfigTest.java
+++ b/server/test/parameters/CoreConfigTest.java
@@ -20,7 +20,6 @@ package com.vaticle.typedb.core.server.parameters;
 
 import com.vaticle.typedb.core.common.collection.Bytes;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
-import com.vaticle.typedb.core.server.common.Util;
 import com.vaticle.typedb.core.server.parameters.util.Option;
 import com.vaticle.typedb.core.server.parameters.util.YAMLParser;
 import org.junit.Test;
@@ -28,7 +27,6 @@ import org.junit.Test;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.text.DecimalFormat;
 import java.util.HashSet;
 
 import static com.vaticle.typedb.common.collection.Collections.list;
@@ -149,7 +147,7 @@ public class CoreConfigTest {
         } catch (TypeDBException e) {
             assert e.code().isPresent();
             assertEquals(CONFIG_VALUE_UNEXPECTED.code(), e.code().get());
-            assertEquals(CONFIG_VALUE_UNEXPECTED.message("storage.data", "123456[int]", YAMLParser.Value.Primitive.PATH.help()), e.getMessage());
+            assertEquals(CONFIG_VALUE_UNEXPECTED.message("storage.data", "123456[int]", YAMLParser.Value.Primitive.PATH.description()), e.getMessage());
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We implement a new paradigm for configurations in TypeDB: optional primitive values. The outcome of this is that we have the following three top-level paradigms in our configuration file:

1. All configuration file options are present in the configuration file
2. 'Compound' (eg. nested blocks) of options that are optional are by convention protected by an `enable: true|false` option on the same level.
3. For any optional primitive/leaf configurations, they may be left empty (or by YAML conventions set to `null` or `~`).

Points 2 and 3 derive from point 1 in that they allow us to keep all configurations present, but introduce optionality for either entire blocks or leaf configurations.

## What are the changes implemented in this PR?

* Introduce Optional primitive value parsers that can be used for future configurations and in TypeDB Enterprise
* Refactor Help menu generation and formatting for clarity
