### PR TITLE
Fix traversing edges to role vertices

### DIFF
--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -986,7 +986,8 @@ public abstract class ProcedureEdge<
                 assert !to.props().hasIID() && to.props().predicates().isEmpty();
                 ThingVertex relationOrPlayer = fromVertex.asThing();
                 TypeVertex type = relationOrPlayer.type();
-                Set<TypeVertex> roleTypes = type.isRelationType() ?
+                assert encoding == PLAYING || encoding == RELATING;
+                Set<TypeVertex> roleTypes = encoding == RELATING ?
                         graphMgr.schema().relatedRoleTypes(type) : graphMgr.schema().playedRoleTypes(type);
                 return iterate(roleTypes)
                         .filter(rt -> to.props().types().contains(rt.properLabel()))


### PR DESCRIPTION
## What is the goal of this PR?
Fixes a bug in resolving edge types when traversing to a role vertex.
This could cause missing results in queries involving role variables and relations playing roles in relations.

## What are the changes implemented in this PR?
- Fixes the resolution of edge types to be based on the type of edge being traversed. Checking whether the starting vertex is a relation fails when both the role-player is also a relation.
