### PR TITLE
Update reasoner benchmark to avoid role aliases

### DIFF
--- a/test/benchmark/reasoner/iam/complex/ConjunctionStructureTest.java
+++ b/test/benchmark/reasoner/iam/complex/ConjunctionStructureTest.java
@@ -103,6 +103,6 @@ public class ConjunctionStructureTest {
 
         benchmark.assertAnswerCountCorrect();
         benchmark.assertRunningTime(1000);
-        benchmark.assertCounters(500, 15, 104, 128, 230);
+        benchmark.assertCounters(500, 22, 69, 102, 165);
     }
 }

--- a/test/benchmark/reasoner/iam/complex/LanguageFeaturesTest.java
+++ b/test/benchmark/reasoner/iam/complex/LanguageFeaturesTest.java
@@ -91,6 +91,6 @@ public class LanguageFeaturesTest {
 
         benchmark.assertAnswerCountCorrect();
         benchmark.assertRunningTime(100);
-        benchmark.assertCounters(200, 9, 29, 101, 105);
+        benchmark.assertCounters(200, 9, 21, 129, 141);
     }
 }

--- a/test/benchmark/reasoner/iam/complex/language-features-test.tql
+++ b/test/benchmark/reasoner/iam/complex/language-features-test.tql
@@ -17,10 +17,17 @@
 
 # Ensure none of the new rules are triggered by only creating rules which conclude test-specific types
 define
-variabilised-membership sub relation, relates parent, relates member; # abstract
-variabilised-collection-membership sub variabilised-membership, relates collection as parent;
-variabilised-set-membership sub variabilised-membership, relates set as parent;
-variabilised-group-membership sub variabilised-membership, relates group as parent;
+variabilised-membership sub relation,
+    relates base-parent, relates base-member; # abstract
+variabilised-collection-membership sub variabilised-membership,
+    relates collection as base-parent,
+    relates member as base-member;
+variabilised-set-membership sub variabilised-membership,
+    relates set as base-parent,
+    relates member as base-member;
+variabilised-group-membership sub variabilised-membership,
+    relates group as base-parent,
+    relates member as base-member;
 
 user-group plays variabilised-group-membership:group;
 subject plays variabilised-group-membership:member;
@@ -47,8 +54,8 @@ when {
         ($parent: $p, $member: $t) isa! $membership;
         ($parent: $t, $member: $m) isa! $membership;
         $membership relates $parent, relates $member;
-        $parent sub variabilised-membership:parent;
-        $member sub variabilised-membership:member;
+        $parent sub variabilised-membership:base-parent;
+        $member sub variabilised-membership:base-member;
 } then {
         ($parent: $p, $member: $m) isa $membership;
 };

--- a/test/benchmark/reasoner/iam/resources/types.tql
+++ b/test/benchmark/reasoner/iam/resources/types.tql
@@ -88,29 +88,34 @@ operation-set sub action,
 
 membership sub relation,
     # abstract,
-    relates parent,
-    relates member;
+    relates base-parent,
+    relates base-member;
 
 group-membership sub membership,
-    relates group as parent;
+    relates group as base-parent,
+    relates member as base-member;
 
 collection-membership sub membership,
-    relates collection as parent;
+    relates collection as base-parent,
+    relates member as base-member;
 
 set-membership sub membership,
-    relates set as parent;
+    relates set as base-parent,
+    relates member as base-member;
 
 ownership sub relation,
     # abstract,
-    relates owned,
-    relates owner;
+    relates base-owned,
+    relates base-owner;
 
 group-ownership sub ownership,
-    relates group as owned,
+    relates group as base-owned,
+    relates owner as base-owner,
     owns ownership-type;
 
 object-ownership sub ownership,
-    relates object as owned,
+    relates object as base-owned,
+    relates owner as base-owner,
     owns ownership-type;
 
 access sub relation,


### PR DESCRIPTION
## What is the goal of this PR?
Updates the IAM reasoner benchmark schema to account for role aliases being disallowed. Relaxes some of the counter upper bounds to accommodate the resulting changes in the plans.

## What are the changes implemented in this PR?
* Updates IAM benchmark schema to not use role aliases
* Updates counters for new plans.
