### PR TITLE
Allow disconnected relations

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -449,30 +449,28 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new ThingWrite(24, "Unable to insert attribute '%s' of type '%s' without a value assigned to the variable.");
         public static final ThingWrite INSERT_RELATION_CONSTRAINT_TOO_MANY =
                 new ThingWrite(25, "Unable to insert relation '%s' as it has more than one relation tuple describing the role players.");
-        public static final ThingWrite RELATION_CONSTRAINT_MISSING =
-                new ThingWrite(26, "Unable to insert relation '%s' as it is missing the relation tuple describing the role players.");
         public static final ThingWrite ROLE_TYPE_AMBIGUOUS =
-                new ThingWrite(27, "Unable to add role player '%s' to the relation, as there are more than one possible role type it could play.");
+                new ThingWrite(26, "Unable to add role player '%s' to the relation, as there are more than one possible role type it could play.");
         public static final ThingWrite ROLE_TYPE_MISSING =
-                new ThingWrite(28, "Unable to add role player '%s' to the relation, as there is no provided or inferrable role type.");
+                new ThingWrite(27, "Unable to add role player '%s' to the relation, as there is no provided or inferrable role type.");
         public static final ThingWrite ROLE_TYPE_MISMATCH =
-                new ThingWrite(29, "The type '%s' cannot be used as a role type.");
+                new ThingWrite(28, "The type '%s' cannot be used as a role type.");
         public static final ThingWrite PLAYING_TYPE_MISMATCH =
-                new ThingWrite(30, "The instance of type '%s' cannot play the role type '%s'.");
+                new ThingWrite(29, "The instance of type '%s' cannot play the role type '%s'.");
         public static final ThingWrite RELATING_TYPE_MISMATCH =
-                new ThingWrite(31, "The relation instance of type '%s' cannot relate the role type '%s'.");
+                new ThingWrite(30, "The relation instance of type '%s' cannot relate the role type '%s'.");
         public static final ThingWrite MAX_INSTANCE_REACHED =
-                new ThingWrite(32, "The maximum number of instances for type '%s' has been reached: '%s'");
+                new ThingWrite(31, "The maximum number of instances for type '%s' has been reached: '%s'");
         public static final ThingWrite DELETE_RELATION_CONSTRAINT_TOO_MANY =
-                new ThingWrite(33, "Could not perform delete of role players due to multiple relation constraints being present for relation '%s'.");
+                new ThingWrite(32, "Could not perform delete of role players due to multiple relation constraints being present for relation '%s'.");
         public static final ThingWrite DELETE_ROLEPLAYER_NOT_PRESENT =
-                new ThingWrite(34, "Could not delete roleplayer '%s' as relation '%s' does not relate it.");
+                new ThingWrite(33, "Could not delete roleplayer '%s' as relation '%s' does not relate it.");
         public static final ThingWrite ILLEGAL_VALUE_VARIABLE_IN_DELETE =
-                new ThingWrite(35, "Illegal value variable '%s' found in delete query. Value variables may not be used in delete queries.");
+                new ThingWrite(34, "Illegal value variable '%s' found in delete query. Value variables may not be used in delete queries.");
         public static final ThingWrite ILLEGAL_VALUE_CONSTRAINT_IN_INSERT =
-                new ThingWrite(36, "Illegal value constraint found in the insert query on variable '%s'. Value variables are only permitted to specify attribute values.");
+                new ThingWrite(35, "Illegal value constraint found in the insert query on variable '%s'. Value variables are only permitted to specify attribute values.");
         public static final ThingWrite ILLEGAL_UNBOUND_TYPE_VAR_IN_INSERT =
-                new ThingWrite(37, "Type variable '%s' found in the insert query must retrieved by the match previously.");
+                new ThingWrite(36, "Type variable '%s' found in the insert query must retrieved by the match previously.");
 
         private static final String codePrefix = "THW";
         private static final String messagePrefix = "Invalid Thing Write";

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -96,7 +96,6 @@ public class RelationImpl extends ThingImpl implements Relation {
         ).to().filter(v -> v.ins().edge(PLAYING, ((ThingImpl) player).writableVertex()) != null).first();
         if (role.isPresent()) {
             RoleImpl.of(role.get()).delete();
-            deleteIfNoPlayer();
         } else {
             throw exception(TypeDBException.of(DELETE_ROLEPLAYER_NOT_PRESENT, player.getType().getLabel(), roleType.getLabel().toString()));
         }
@@ -108,7 +107,7 @@ public class RelationImpl extends ThingImpl implements Relation {
         super.delete();
     }
 
-    void deleteIfNoPlayer() {
+    public void deleteIfNoPlayer() {
         if (!writableVertex().outs().edge(RELATING).to().hasNext()) this.delete();
     }
 

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -271,10 +271,8 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
 
     @Override
     public void delete() {
-        Set<RelationImpl> relations = writableVertex().ins().edge(ROLEPLAYER).from().map(v -> RelationImpl.of(conceptMgr, v)).toSet();
         writableVertex().outs().edge(PLAYING).to().map(RoleImpl::of).forEachRemaining(RoleImpl::delete);
         writableVertex().delete();
-        relations.forEach(RelationImpl::deleteIfNoPlayer);
     }
 
     @Override

--- a/database/CoreTransaction.java
+++ b/database/CoreTransaction.java
@@ -319,12 +319,12 @@ public abstract class CoreTransaction implements TypeDB.Transaction {
          */
         @Override
         public void commit() {
+            if (type().isWrite()) conceptMgr.cleanupRelations(); // writes requires transaction to be open
             if (isOpen.compareAndSet(true, false)) {
                 try {
                     if (type().isRead()) throw TypeDBException.of(ILLEGAL_COMMIT);
                     else if (graphMgr.schema().isModified()) throw TypeDBException.of(SESSION_DATA_VIOLATION);
 
-                    conceptMgr.cleanupRelations();
                     conceptMgr.validateThings();
                     graphMgr.data().commit();
 

--- a/database/CoreTransaction.java
+++ b/database/CoreTransaction.java
@@ -324,6 +324,7 @@ public abstract class CoreTransaction implements TypeDB.Transaction {
                     if (type().isRead()) throw TypeDBException.of(ILLEGAL_COMMIT);
                     else if (graphMgr.schema().isModified()) throw TypeDBException.of(SESSION_DATA_VIOLATION);
 
+                    conceptMgr.cleanupRelations();
                     conceptMgr.validateThings();
                     graphMgr.data().commit();
 

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -25,5 +25,5 @@ def vaticle_typedb_console_artifact():
         artifact_name = "typedb-console-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "b05edbcffd78c432d6df35b827f184ff31ada109",
+        tag = "2.25.0",
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -51,4 +51,3 @@ def vaticle_typedb_behaviour():
         remote = "https://github.com/flyingsilverfin/typedb-behaviour",
         commit = "53aa381fda1cd1aecf73f3e09ca1323f0104b2d8" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
-

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,5 +49,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-        commit = "53aa381fda1cd1aecf73f3e09ca1323f0104b2d8" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "9ef8139bb55d23ff7361d798367319aaa5e49511" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,6 +48,7 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "c96725f416eabd6ba9e8bf5a6218ad867e17d302",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
+        commit = "53aa381fda1cd1aecf73f3e09ca1323f0104b2d8" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
+

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,6 +48,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-        commit = "4bbd3d5932e3f02c134bff41fa20e1a0274a4710" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "52e169077a218112bcf7b0962fa3d229eb01968c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,5 +49,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-        commit = "9ef8139bb55d23ff7361d798367319aaa5e49511" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "4bbd3d5932e3f02c134bff41fa20e1a0274a4710" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/graph/ThingGraph.java
+++ b/graph/ThingGraph.java
@@ -120,7 +120,7 @@ public class ThingGraph {
         return statistics;
     }
 
-    public FunctionalIterator<ThingVertex.Write> vertices() {
+    public FunctionalIterator<ThingVertex.Write> writeVertices() {
         return link(thingsByIID.values().iterator(), attributesByIID.valuesIterator());
     }
 

--- a/graph/vertex/impl/AttributeVertexImpl.java
+++ b/graph/vertex/impl/AttributeVertexImpl.java
@@ -589,6 +589,16 @@ public abstract class AttributeVertexImpl {
         }
 
         @Override
+        public ThingAdjacency.In ins() {
+            return attributeVertex.ins();
+        }
+
+        @Override
+        public ThingAdjacency.Out outs() {
+            return attributeVertex.outs();
+        }
+
+        @Override
         public int compareTo(Vertex<?, ?> other) {
             if (other.isThing() && other.asThing().isAttribute() && other.asThing().asAttribute().isValueSortable()) {
                 ValueSortable<?> asValueSortable = other.asThing().asAttribute().asValueSortable();

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -64,7 +64,6 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.I
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_UNBOUND_TYPE_VAR_IN_INSERT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_VALUE_CONSTRAINT_IN_INSERT;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.INSERT_RELATION_CONSTRAINT_TOO_MANY;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.RELATION_CONSTRAINT_MISSING;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.ROLE_TYPE_MISMATCH;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.THING_IID_NOT_INSERTABLE;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.ThingWrite.THING_INSERT_ISA_NOT_THING_TYPE;
@@ -257,8 +256,7 @@ public class Inserter {
             if (type.isEntityType()) {
                 return type.asEntityType().create();
             } else if (type.isRelationType()) {
-                if (var.relation().isPresent()) return type.asRelationType().create();
-                else throw TypeDBException.of(RELATION_CONSTRAINT_MISSING, var.reference());
+                return type.asRelationType().create();
             } else if (type.isAttributeType()) {
                 return insertAttribute(type.asAttributeType(), var);
             } else if (type.isThingType() && type.isRoot()) {

--- a/test/assembly/console-script
+++ b/test/assembly/console-script
@@ -6,6 +6,6 @@ transaction test data write
     insert $x isa person;
     commit
 transaction test data read
-    match $x isa person;
+    match $x isa person; get;
     close
 database delete test

--- a/test/behaviour/query/TypeQLSteps.java
+++ b/test/behaviour/query/TypeQLSteps.java
@@ -167,7 +167,7 @@ public class TypeQLSteps {
     }
 
     @When("get answers of typeql get")
-    public void typeql_match(String typeQLQueryStatements) {
+    public void typeql_get(String typeQLQueryStatements) {
         try {
             TypeQLGet typeQLQuery = TypeQL.parseQuery(String.join("\n", typeQLQueryStatements)).asGet();
             clearAnswers();
@@ -205,17 +205,17 @@ public class TypeQLSteps {
     }
 
     @When("typeql get; throws exception")
-    public void typeql_match_throws_exception(String typeQLQueryStatements) {
-        assertThrows(() -> typeql_match(typeQLQueryStatements));
+    public void typeql_get_throws_exception(String typeQLQueryStatements) {
+        assertThrows(() -> typeql_get(typeQLQueryStatements));
     }
 
     @When("typeql get; throws exception containing {string}")
-    public void typeql_match_throws_exception(String exception, String typeQLQueryStatements) {
-        assertThrowsWithMessage(() -> typeql_match(typeQLQueryStatements), exception);
+    public void typeql_get_throws_exception(String exception, String typeQLQueryStatements) {
+        assertThrowsWithMessage(() -> typeql_get(typeQLQueryStatements), exception);
     }
 
     @When("get answer of typeql get aggregate")
-    public void typeql_match_aggregate(String typeQLQueryStatements) {
+    public void typeql_get_aggregate(String typeQLQueryStatements) {
         TypeQLGet.Aggregate typeQLQuery = TypeQL.parseQuery(String.join("\n", typeQLQueryStatements)).asGetAggregate();
         clearAnswers();
         aggregateAnswer = tx().query().get(typeQLQuery);
@@ -223,12 +223,12 @@ public class TypeQLSteps {
     }
 
     @When("typeql get aggregate; throws exception")
-    public void typeql_match_aggregate_throws_exception(String typeQLQueryStatements) {
-        assertThrows(() -> typeql_match_aggregate(typeQLQueryStatements));
+    public void typeql_get_aggregate_throws_exception(String typeQLQueryStatements) {
+        assertThrows(() -> typeql_get_aggregate(typeQLQueryStatements));
     }
 
     @When("get answers of typeql get group")
-    public void typeql_match_group(String typeQLQueryStatements) {
+    public void typeql_get_group(String typeQLQueryStatements) {
         TypeQLGet.Group typeQLQuery = TypeQL.parseQuery(String.join("\n", typeQLQueryStatements)).asGetGroup();
         clearAnswers();
         groupAnswers = tx().query().get(typeQLQuery).toList();
@@ -236,12 +236,12 @@ public class TypeQLSteps {
     }
 
     @When("typeql get group; throws exception")
-    public void typeql_match_group_throws_exception(String typeQLQueryStatements) {
-        assertThrows(() -> typeql_match_group(typeQLQueryStatements));
+    public void typeql_get_group_throws_exception(String typeQLQueryStatements) {
+        assertThrows(() -> typeql_get_group(typeQLQueryStatements));
     }
 
     @When("get answers of typeql get group aggregate")
-    public void typeql_match_group_aggregate(String typeQLQueryStatements) {
+    public void typeql_get_group_aggregate(String typeQLQueryStatements) {
         TypeQLGet.Group.Aggregate typeQLQuery = TypeQL.parseQuery(String.join("\n", typeQLQueryStatements)).asGetGroupAggregate();
         clearAnswers();
         groupAggregateAnswers = tx().query().get(typeQLQuery).toList();
@@ -605,7 +605,7 @@ public class TypeQLSteps {
     }
 
     @Then("templated typeql get; throws exception")
-    public void templated_typeql_match_throws_exception(String templatedTypeQLQuery) {
+    public void templated_typeql_get_throws_exception(String templatedTypeQLQuery) {
         String templatedQuery = String.join("\n", templatedTypeQLQuery);
         for (ConceptMap answer : getAnswers) {
             String queryString = applyQueryTemplate(templatedQuery, answer);


### PR DESCRIPTION
## What is the goal of this PR?

We implement the suggestion from https://github.com/vaticle/typedb/issues/6920, which will allow relations to exist without role players for the duration of a write transaction. At the end of the transaction, any relations without role players are deleted (preserving the existing behaviour of automatically deleting relations without role players, but we delay the operation until commit time).

This change addresses https://github.com/vaticle/typedb/issues/6902, https://github.com/vaticle/typedb/issues/6920, 

## What are the changes implemented in this PR?

We delay the deletion of relations until the end of the transaction. During commit, we delete any relations without role players.

Adding a test for this case led us to discover and fix a bug in the traversal engine