### PR TITLE
Bundle java deps ignoring transitive dependencies without maven coordinates

### DIFF
--- a/database/CoreDatabase.java
+++ b/database/CoreDatabase.java
@@ -442,21 +442,27 @@ public class CoreDatabase implements TypeDB.Database {
     @Override
     public String schema() {
         try (TypeDB.Session session = databaseMgr.session(name, DATA); TypeDB.Transaction tx = session.transaction(READ)) {
-            return TypeQL.parseQuery("define\n\n" + tx.concepts().typesSyntax() + tx.logic().rulesSyntax()).toString(true);
+            String syntax = tx.concepts().typesSyntax() + tx.logic().rulesSyntax();
+            if (syntax.trim().isEmpty()) return "";
+            else return TypeQL.parseQuery("define\n\n" + syntax).toString(true);
         }
     }
 
     @Override
     public String typeSchema() {
         try (TypeDB.Session session = databaseMgr.session(name, DATA); TypeDB.Transaction tx = session.transaction(READ)) {
-            return TypeQL.parseQuery("define\n\n" + tx.concepts().typesSyntax()).toString(true);
+            String syntax = tx.concepts().typesSyntax();
+            if (syntax.trim().isEmpty()) return "";
+            return TypeQL.parseQuery("define\n\n" + syntax).toString(true);
         }
     }
 
     @Override
     public String ruleSchema() {
         try (TypeDB.Session session = databaseMgr.session(name, DATA); TypeDB.Transaction tx = session.transaction(READ)) {
-            return TypeQL.parseQuery("define\n\n" + tx.logic().rulesSyntax()).toString(true);
+            String syntax = tx.logic().rulesSyntax();
+            if (syntax.trim().isEmpty()) return "";
+            else return TypeQL.parseQuery("define\n\n" + syntax).toString(true);
         }
     }
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "adda846178ed799aca001cc9dfd7934cd4f805a8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "daac0e87c3c378fb03fcc5370c94828383e3504e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():
@@ -42,7 +42,7 @@ def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/vaticle/typedb-protocol",
-        tag = "2.25.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        tag = "2.25.1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/migrator/BUILD
+++ b/migrator/BUILD
@@ -39,12 +39,14 @@ java_grpc_library(
     name = "migrator-protocol",
     protos = [":migrator-proto"],
     visibility = ["//visibility:public"],
+    tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-migrator-protocol:{pom_version}"],
 )
 
 java_grpc_library(
     name = "migrator-data",
     protos = [":database-proto"],
     visibility = ["//visibility:public"],
+    tags = ["maven_coordinates=com.vaticle.typedb:typedb-core-migrator-data:{pom_version}"],
 )
 
 native_java_libraries(

--- a/server/BUILD
+++ b/server/BUILD
@@ -146,7 +146,8 @@ java_deps(
     target = ":server-bin-linux-arm64",
     java_deps_root = "server/lib/",
     visibility = ["//:__pkg__"],
-    maven_name = False,
+    maven_name = True,
+    ignore_missing_maven_name = True,
 )
 
 java_deps(
@@ -154,7 +155,8 @@ java_deps(
     target = ":server-bin-linux-x86_64",
     java_deps_root = "server/lib/",
     visibility = ["//:__pkg__"],
-    maven_name = False,
+    maven_name = True,
+    ignore_missing_maven_name = True,
 )
 
 java_deps(
@@ -162,7 +164,8 @@ java_deps(
     target = ":server-bin-mac-arm64",
     java_deps_root = "server/lib/",
     visibility = ["//:__pkg__"],
-    maven_name = False,
+    maven_name = True,
+    ignore_missing_maven_name = True,
 )
 
 java_deps(
@@ -170,7 +173,8 @@ java_deps(
     target = ":server-bin-mac-x86_64",
     java_deps_root = "server/lib/",
     visibility = ["//:__pkg__"],
-    maven_name = False,
+    maven_name = True,
+    ignore_missing_maven_name = True,
 )
 
 java_deps(
@@ -178,7 +182,8 @@ java_deps(
     target = ":server-bin-windows-x86_64",
     java_deps_root = "server/lib/",
     visibility = ["//:__pkg__"],
-    maven_name = False,
+    maven_name = True,
+    ignore_missing_maven_name = True,
 )
 
 assemble_files = {


### PR DESCRIPTION
## What is the goal of this PR?

Recent upgrades to bazel build rules for java, protobuf, and grpc meant that their internal dependencies no longer use Maven coordinates, but are more bazel-native in their build process. However, this means that to 'correctly' bundle TypeDB Server, we also need to include the rules' dependencies into our distribution (such as `com_google_protobuf`). The issue arises that we also directly use these libraries occasionally, and pull them via Maven. As a result, we end up with duplicates: bazel-build JARs, and maven-sourced JARs inserted into our distribution.

Our workaround for now is to skip all bazel-build JARs that don't also have maven coordinates. This is **dangerous** since it means we don't find out we have missing JARs in our distributions until booting up the server and testing it. This works only because we have manually verified to include all the 'equivalent' JARs from maven in our distribution instead.

Our reasoning for this is that in TypeDB 3.0 (rust) this issue will no longer be present as most dependencies will be compiled into the final static library.


## What are the changes implemented in this PR?

* Build distributions while skipping JARs that don't have maven coordinates. We add maven coordinates for our libraries: typedb-protocol (provided in tagged release 2.25.1), and the migrator protocol libraries
* Drive-by: fix exception that arises when migrating schemas that are empty 
