### PR TITLE
Assemble and deploy a single apt package

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -180,9 +180,8 @@ build:
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run --define version=$(git rev-parse HEAD) //server:deploy-apt-x86_64 -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //server:deploy-apt-arm64 -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-apt -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-apt-x86_64 -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-apt-arm64 -- snapshot
 #    deploy-brew-snapshot:
 #      image: vaticle-ubuntu-22.04
 #      filter:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -172,9 +172,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-x86_64-zip -- snapshot
     deploy-apt-snapshot:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
@@ -192,9 +192,9 @@ build:
 #        bazel run --define version=$(cat VERSION) //:deploy-brew -- snapshot
     test-deployment-apt-x86_64:
       image: vaticle-ubuntu-22.04 # use LTS for apt tests
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies: [deploy-apt-snapshot]
       command: |
         export TEST_DEPLOYMENT_APT_COMMIT=$FACTORY_COMMIT

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -172,9 +172,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-x86_64-zip -- snapshot
     deploy-apt-snapshot:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
       dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
@@ -192,9 +192,9 @@ build:
 #        bazel run --define version=$(cat VERSION) //:deploy-brew -- snapshot
     test-deployment-apt-x86_64:
       image: vaticle-ubuntu-22.04 # use LTS for apt tests
-      filter:
-        owner: vaticle
-        branch: [master, development]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
       dependencies: [deploy-apt-snapshot]
       command: |
         export TEST_DEPLOYMENT_APT_COMMIT=$FACTORY_COMMIT

--- a/BUILD
+++ b/BUILD
@@ -307,7 +307,7 @@ deploy_apt(
     name = "deploy-apt-x86_64",
     target = ":assemble-linux-x86_64-apt",
     snapshot = deployment['apt.snapshot'],
-    release = deployment['apt.release']
+    release = deployment['apt.release'],
 )
 
 targz_edit(
@@ -341,7 +341,7 @@ deploy_apt(
     name = "deploy-apt-arm64",
     target = ":assemble-linux-arm64-apt",
     snapshot = deployment['apt.snapshot'],
-    release = deployment['apt.release']
+    release = deployment['apt.release'],
 )
 
 release_validate_deps(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -92,7 +92,7 @@ unuseddeps_deps()
 # Load @vaticle_bazel_distribution #
 ######################################
 
-load("@vaticle_dependencies//distribution:deps.bzl", "vaticle_bazel_distribution")
+load("//dependencies/vaticle:repositories.bzl", "vaticle_bazel_distribution")
 vaticle_bazel_distribution()
 
 # Load //common

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,8 +20,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
-        remote = "https://github.com/dmitrii-ubskii/bazel-distribution",
-        commit = "f8b8390e220abf06e43f5cc62b1b85ac74dc31ae",
+        remote = "https://github.com/vaticle/bazel-distribution",
+        commit = "939a5424bd276b007620ee96829ff713b12b12d0",
     )
 
 def vaticle_dependencies():
@@ -41,8 +41,8 @@ def vaticle_typeql():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/dmitrii-ubskii/typedb-common",
-        commit = "b18063410125bc755d057048a420f0bf2422562d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        commit = "04ff8a59ab6f1a855f3a327f4d59e760417a0265",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -17,6 +17,13 @@
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
+def vaticle_bazel_distribution():
+    git_repository(
+        name = "vaticle_bazel_distribution",
+        remote = "https://github.com/dmitrii-ubskii/bazel-distribution",
+        commit = "f8b8390e220abf06e43f5cc62b1b85ac74dc31ae",
+    )
+
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
@@ -34,8 +41,8 @@ def vaticle_typeql():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.25.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/dmitrii-ubskii/typedb-common",
+        commit = "b18063410125bc755d057048a420f0bf2422562d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():

--- a/migrator/BUILD
+++ b/migrator/BUILD
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-load("@vaticle_bazel_distribution//apt:rules.bzl", "assemble_apt", "deploy_apt")
 load("@vaticle_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_zip", "java_deps")
 load("@vaticle_bazel_distribution//artifact:rules.bzl", "deploy_artifact")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")

--- a/server/BUILD
+++ b/server/BUILD
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-load("@vaticle_bazel_distribution//apt:rules.bzl", "assemble_apt", "deploy_apt")
 load("@vaticle_bazel_distribution//artifact:rules.bzl", "deploy_artifact")
 load("@vaticle_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_zip", "java_deps")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
@@ -294,68 +293,6 @@ deploy_artifact(
     artifact_name = "typedb-server-windows-x86_64-{version}.zip",
     release = deployment['artifact.release'],
     snapshot = deployment['artifact.snapshot'],
-)
-
-assemble_apt(
-    name = "assemble-linux-x86_64-apt",
-    package_name = "typedb-server",
-    maintainer = "Vaticle <community@vaticle.com>",
-    description = "TypeDB (server)",
-    depends = [
-      "openjdk-11-jre",
-      "typedb-bin (=%{@vaticle_typedb_common})"
-    ],
-    workspace_refs = "@vaticle_typedb_workspace_refs//:refs.json",
-    archives = [":server-deps-linux-x86_64"],
-    installation_dir = "/opt/typedb/core/",
-    files = assemble_files,
-    empty_dirs = [
-        "/opt/typedb/core/server/lib/",
-        "/var/lib/typedb/core/data/"
-    ],
-    empty_dirs_permission = "0777",
-    symlinks = {
-        "/opt/typedb/core/server/data": "/var/lib/typedb/core/data/",
-    },
-    architecture = "amd64",
-)
-
-assemble_apt(
-    name = "assemble-linux-arm64-apt",
-    package_name = "typedb-server",
-    maintainer = "Vaticle <community@vaticle.com>",
-    description = "TypeDB (server)",
-    depends = [
-      "openjdk-11-jre",
-      "typedb-bin (=%{@vaticle_typedb_common})"
-    ],
-    workspace_refs = "@vaticle_typedb_workspace_refs//:refs.json",
-    archives = [":server-deps-linux-arm64"],
-    installation_dir = "/opt/typedb/core/",
-    files = assemble_files,
-    empty_dirs = [
-        "/opt/typedb/core/server/lib/",
-        "/var/lib/typedb/core/data/"
-    ],
-    empty_dirs_permission = "0777",
-    symlinks = {
-        "/opt/typedb/core/server/data": "/var/lib/typedb/core/data/",
-    },
-    architecture = "arm64",
-)
-
-deploy_apt(
-    name = "deploy-apt-x86_64",
-    target = ":assemble-linux-x86_64-apt",
-    snapshot = deployment['apt.snapshot'],
-    release = deployment['apt.release']
-)
-
-deploy_apt(
-    name = "deploy-apt-arm64",
-    target = ":assemble-linux-arm64-apt",
-    snapshot = deployment['apt.snapshot'],
-    release = deployment['apt.release']
 )
 
 checkstyle_test(

--- a/server/test/BUILD
+++ b/server/test/BUILD
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-load("@vaticle_bazel_distribution//apt:rules.bzl", "assemble_apt", "deploy_apt")
 load("@vaticle_bazel_distribution//artifact:rules.bzl", "deploy_artifact")
 load("@vaticle_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_zip", "java_deps")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")

--- a/test/deployment/AptTest.java
+++ b/test/deployment/AptTest.java
@@ -80,7 +80,7 @@ public class AptTest {
     private void install() throws InterruptedException, TimeoutException, IOException {
         System.out.println("core = " + commit);
         Files.write(versionFile, commit.getBytes(StandardCharsets.US_ASCII));
-        execute("sudo", "apt", "install", "-y", "typedb-server=0.0.0-" + commit, "typedb-bin=" + getDependencyVersion("vaticle_typedb_common"));
+        execute("sudo", "apt", "install", "-y", "typedb=0.0.0-" + commit);
     }
 
     private void start() throws InterruptedException, IOException {


### PR DESCRIPTION
## What is the goal of this PR?

We no longer deploy `typedb-server` or `typedb-all` as a separate package, but rather a single package called `typedb` which contains server, console, and the binary. This approach now mirrors the 'brew' installation package.