### PR TITLE
Ignore data directories that aren't TypeDB databases

### DIFF
--- a/database/CoreDatabase.java
+++ b/database/CoreDatabase.java
@@ -234,7 +234,7 @@ public class CoreDatabase implements TypeDB.Database {
     }
 
     protected void load() {
-        validateDirectories();
+        assert isExistingDatabaseDirectory(directory());
         loadSchema();
         validateEncodingVersion();
         loadData();
@@ -249,12 +249,10 @@ public class CoreDatabase implements TypeDB.Database {
         statisticsCorrector.doReactivate();
     }
 
-    protected void validateDirectories() {
-        boolean dataExists = directory().resolve(Encoding.ROCKS_DATA).toFile().exists();
-        boolean schemaExists = directory().resolve(Encoding.ROCKS_SCHEMA).toFile().exists();
-        if (!schemaExists || !dataExists) {
-            throw TypeDBException.of(INVALID_DATABASE_DIRECTORIES, name(), directory(), list(ROCKS_SCHEMA, ROCKS_DATA));
-        }
+    public static boolean isExistingDatabaseDirectory(Path directory) {
+        boolean dataExists = directory.resolve(Encoding.ROCKS_DATA).toFile().exists();
+        boolean schemaExists = directory.resolve(Encoding.ROCKS_SCHEMA).toFile().exists();
+        return dataExists && schemaExists;
     }
 
     protected void loadSchema() {

--- a/database/CoreDatabaseManager.java
+++ b/database/CoreDatabaseManager.java
@@ -45,6 +45,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.TYP
 public class CoreDatabaseManager implements TypeDB.DatabaseManager {
 
     static final int MAX_THREADS = Runtime.getRuntime().availableProcessors();
+
     static {
         RocksDB.loadLibrary();
         Loader.loadNativeLibraries();
@@ -87,11 +88,13 @@ public class CoreDatabaseManager implements TypeDB.DatabaseManager {
     protected void loadAll() {
         File[] databaseDirectories = directory().toFile().listFiles(File::isDirectory);
         if (databaseDirectories != null && databaseDirectories.length > 0) {
-            Arrays.stream(databaseDirectories).parallel().forEach(directory -> {
-                String name = directory.getName();
-                CoreDatabase database = databaseFactory.databaseLoadAndOpen(this, name);
-                databases.put(name, database);
-            });
+            Arrays.stream(databaseDirectories).parallel()
+                    .filter(file -> CoreDatabase.isExistingDatabaseDirectory(file.toPath()))
+                    .forEach(directory -> {
+                        String name = directory.getName();
+                        CoreDatabase database = databaseFactory.databaseLoadAndOpen(this, name);
+                        databases.put(name, database);
+                    });
         }
     }
 


### PR DESCRIPTION
## Release notes: usage and product changes

TypeDB ignores directories in its configured 'data' directory that do not contain the subdirectories 'data' and 'schema'. In the past, the any directory was loaded as a TypeDB database, which could cause the server to crash on bootup.

This should help with OS-created directories in some system (such as Lost+Found), or users' debugging directories.

## Implementation

* Instead of validating and crashing when the data directory does not conform to the expected shape, we now ignore the directory and proceed.
