### PR TITLE
Update entry point runner for better UX

### DIFF
--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -25,5 +25,5 @@ def vaticle_typedb_console_artifact():
         artifact_name = "typedb-console-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        tag = "2.25.7",
+        commit = "f91333de5a4e7a925f3441a883fbde50a30522fd",
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -41,8 +41,8 @@ def vaticle_typeql():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/dmitrii-ubskii/typedb-common",
-        commit = "cfe800260f1a3e79b586314b5ab169e9219c84ec",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        commit = "a338f2aec875f9e1a2578e803d0e7f2a92c6623d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -41,8 +41,8 @@ def vaticle_typeql():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.25.3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/dmitrii-ubskii/typedb-common",
+        commit = "cfe800260f1a3e79b586314b5ab169e9219c84ec",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():


### PR DESCRIPTION
## Usage and product changes

We update to the updated entry point for the assembled TypeDB Core, which omits `console` from the usage help if it is not present to avoid confusion. See https://github.com/vaticle/typedb/issues/6942 for more details.

The command to boot up the server (unchanged):
```
typedb server --server.address=<address>
``` 
The command to boot up the console:
```
typedb console --core=<address>
```

We also improve the UX of the windows version of the entry point. Console no longer opens in a new window, `--help` is printed inline as expected, and in the event of the server failure, the logs are displayed to the user. See https://github.com/vaticle/typedb-common/pull/158 for more details.