### PR TITLE
Update assembly tests to use new console flags

### DIFF
--- a/test/assembly/AssemblyTest.java
+++ b/test/assembly/AssemblyTest.java
@@ -45,7 +45,7 @@ public class AssemblyTest {
             server.start();
             TypeDBConsoleRunner console = new TypeDBConsoleRunner();
             int exitCode = console.run(
-                    "--server", server.address(),
+                    "--core", server.address(),
                     "--script", Paths.get("test", "assembly", "console-script").toAbsolutePath().toString()
             );
             assert exitCode == 0;

--- a/test/assembly/DockerTest.java
+++ b/test/assembly/DockerTest.java
@@ -70,7 +70,7 @@ public class DockerTest {
     }
 
     private static boolean isTypeDBServerReady(TypeDBConsoleRunner consoleRunner) {
-        return consoleRunner.run("--server", "localhost:" + typeDBPort, "--command", "database create docker-test") == 0;
+        return consoleRunner.run("--core", "localhost:" + typeDBPort, "--command", "database create docker-test") == 0;
     }
 
     private ProcessResult execute(String... cmd) throws InterruptedException, TimeoutException, IOException {


### PR DESCRIPTION
## Usage and product changes

Update assembly tests to use new `--core=<address>` flag in place of the old `--server=<address>`.