### PR TITLE
Fetch query can infer fetched attributes

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -23,10 +23,7 @@ labels: bug
 2. Execute
 
 
-3. Test/Query
-
-
-4. Unexpected result
+3. Unexpected result
 
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-## Release notes: usage and product changes
+## Usage and product changes
 
 
 ## Implementation

--- a/common/parameters/Context.java
+++ b/common/parameters/Context.java
@@ -30,9 +30,11 @@ public class Context<PARENT extends Context<?, ?>, OPTIONS extends Options<?, ?>
     Arguments.Session.Type sessionType;
     Arguments.Transaction.Type transactionType;
     long transactionId;
+    private final PARENT parent;
     private final OPTIONS options;
 
     private Context(@Nullable PARENT parent, OPTIONS options) {
+        this.parent = parent;
         this.options = options;
         if (parent != null) {
             this.sessionType = parent.sessionType();
@@ -46,6 +48,10 @@ public class Context<PARENT extends Context<?, ?>, OPTIONS extends Options<?, ?>
 
     public OPTIONS options() {
         return options;
+    }
+
+    public PARENT parent() {
+        return parent;
     }
 
     public Arguments.Session.Type sessionType() {

--- a/concept/answer/ConceptMap.java
+++ b/concept/answer/ConceptMap.java
@@ -32,6 +32,7 @@ import com.vaticle.typedb.core.traversal.common.Modifiers;
 import com.vaticle.typeql.lang.common.Reference;
 import com.vaticle.typeql.lang.common.TypeQLVariable;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -48,13 +49,11 @@ import static java.util.Collections.unmodifiableMap;
 
 public class ConceptMap {
 
+    public static ConceptMap EMPTY = new ConceptMap(Collections.emptyMap());
+
     private final Map<Retrievable, ? extends Concept> concepts;
     private final Explainables explainables;
     private final int hash;
-
-    public ConceptMap() {
-        this(new HashMap<>());
-    }
 
     public ConceptMap(Map<Retrievable, ? extends Concept> concepts) {
         this(concepts, new Explainables());

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -56,5 +56,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "1bf6d5dd0f5f95a1617fbecb3d076d3d9bc159d4" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "3c43834e044933d3bc55e8af22e8f02f5b8c3e28" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -56,5 +56,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "3c43834e044933d3bc55e8af22e8f02f5b8c3e28" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "7bfccec5e600bf385dc64f493473897a639ec68c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/query/Getter.java
+++ b/query/Getter.java
@@ -129,7 +129,7 @@ public class Getter {
     }
 
     public FunctionalIterator<? extends ConceptMap> execute(Context.Query context) {
-        return execute(new ConceptMap(), context);
+        return execute(ConceptMap.EMPTY, context);
     }
 
     FunctionalIterator<? extends ConceptMap> execute(ConceptMap bindings, Context.Query context) {
@@ -156,7 +156,7 @@ public class Getter {
         }
 
         public Optional<Value<?>> execute() {
-            return execute(new ConceptMap());
+            return execute(ConceptMap.EMPTY);
         }
 
         public Optional<Value<?>> execute(ConceptMap bindings) {

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -153,7 +153,7 @@ public class Inserter {
 
     public FunctionalIterator<ConceptMap> execute() {
         if (getter != null) return context.options().parallel() ? executeParallel() : executeSerial();
-        else return single(new Operation(conceptMgr, new ConceptMap(), variables).execute());
+        else return single(new Operation(conceptMgr, ConceptMap.EMPTY, variables).execute());
     }
 
     private FunctionalIterator<ConceptMap> executeParallel() {

--- a/reasoner/controller/RootConjunctionController.java
+++ b/reasoner/controller/RootConjunctionController.java
@@ -48,7 +48,7 @@ public class RootConjunctionController
     public void initialise() {
         planner().planRoot(conjunction);
         setUpUpstreamControllers();
-        getOrCreateProcessor(new ConceptMap());
+        getOrCreateProcessor(ConceptMap.EMPTY);
     }
 
     @Override

--- a/reasoner/controller/RootDisjunctionController.java
+++ b/reasoner/controller/RootDisjunctionController.java
@@ -49,7 +49,7 @@ public class RootDisjunctionController
     public void initialise() {
         planner().planRoot(disjunction);
         setUpUpstreamControllers();
-        getOrCreateProcessor(new ConceptMap());
+        getOrCreateProcessor(ConceptMap.EMPTY);
     }
 
     @Override


### PR DESCRIPTION
## Usage and product changes

We fix #6952 , by allowing attribute fetching to trigger reasoning. For example;

Given:
```
define
rule has-name: when { $x isa person; } then { $x has name "John"; };
```

Then the query:
```
match $x isa person;
fetch $x: name;
```

Can now retrieve `name "John"` as part of the fetch response.


## Implementation
