### PR TITLE
Update Console artifact: Cloud connection rename

### DIFF
--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -25,5 +25,5 @@ def vaticle_typedb_console_artifact():
         artifact_name = "typedb-console-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "f91333de5a4e7a925f3441a883fbde50a30522fd",
+        commit = "1153bbecd1880a19395594315b857395cd51e167",
     )


### PR DESCRIPTION
## Usage and product changes

We update the console artifact to make it transitively available to the TypeDB Cloud distribution. The principal change in Console is the updated CLI flag to connect to a Cloud instance (`--cloud` rather than `--enterprise`).