### PR TITLE
Fetch nulls

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -152,10 +152,10 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies: [test-assembly-linux-targz]
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -152,10 +152,10 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies: [test-assembly-linux-targz]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD

--- a/concept/answer/ReadableConceptTree.java
+++ b/concept/answer/ReadableConceptTree.java
@@ -267,7 +267,7 @@ public class ReadableConceptTree {
 
             @Override
             public String toJSON() {
-                if (readableConcept == null) return "";
+                if (readableConcept == null) return "null";
                 else if (readableConcept.isType()) return getType(readableConcept.asType());
                 else if (readableConcept.isAttribute()) return getAttribute(readableConcept.asAttribute());
                 else if (readableConcept.isValue()) return getValue(readableConcept.asValue());

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,8 +48,8 @@ def vaticle_typedb_common():
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/flyingsilverfin/typedb-protocol",
-        commit = "0e965c120c574af4524428efbbe554a3949fdf89",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/vaticle/typedb-protocol",
+        tag = "2.25.2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -55,6 +55,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-        commit = "348425193aac94e691fa0328e69f291e2b4fa4d1" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "46a16939c1dd94aac6aebc3dd7e50e8280d3dfe5" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,13 +48,13 @@ def vaticle_typedb_common():
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/vaticle/typedb-protocol",
-        tag = "2.25.2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/flyingsilverfin/typedb-protocol",
+        commit = "0e965c120c574af4524428efbbe554a3949fdf89",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "7bfccec5e600bf385dc64f493473897a639ec68c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
+        commit = "348425193aac94e691fa0328e69f291e2b4fa4d1" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/server/common/ResponseBuilder.java
+++ b/server/common/ResponseBuilder.java
@@ -1165,7 +1165,7 @@ public class ResponseBuilder {
         private static AnswerProto.ReadableConceptTree.Node.ReadableConcept readableConcept(
                 @Nullable com.vaticle.typedb.core.concept.Concept.Readable concept) {
             AnswerProto.ReadableConceptTree.Node.ReadableConcept.Builder builder = AnswerProto.ReadableConceptTree.Node.ReadableConcept.newBuilder();
-            if (concept == null) return builder.setEmpty(true).build();
+            if (concept == null) return builder.build();
             else if (concept.isType()) {
                 com.vaticle.typedb.core.concept.type.Type type = concept.asType();
                 if (type.isEntityType()) {

--- a/server/common/ResponseBuilder.java
+++ b/server/common/ResponseBuilder.java
@@ -1165,7 +1165,7 @@ public class ResponseBuilder {
         private static AnswerProto.ReadableConceptTree.Node.ReadableConcept readableConcept(
                 @Nullable com.vaticle.typedb.core.concept.Concept.Readable concept) {
             AnswerProto.ReadableConceptTree.Node.ReadableConcept.Builder builder = AnswerProto.ReadableConceptTree.Node.ReadableConcept.newBuilder();
-            if (concept == null) return null;
+            if (concept == null) return builder.setEmpty(true).build();
             else if (concept.isType()) {
                 com.vaticle.typedb.core.concept.type.Type type = concept.asType();
                 if (type.isEntityType()) {
@@ -1184,7 +1184,6 @@ public class ResponseBuilder {
             } else if (concept.isValue()) {
                 return builder.setValue(Value.protoValue(concept.asValue())).build();
             } else throw TypeDBException.of(ILLEGAL_STATE);
-
         }
     }
 }


### PR DESCRIPTION
## Usage and product changes

We fix a bug where a Fetch query with a Get-Aggregate subquery that returned an empty (ie. undefined) answer throw a null pointer exception.

For example this used to error if 'Alice' doesn't have any salaries in the database, since a 'sum' is undefined for 0 entries.
```
match
$x isa person, has name $n; $n == "Alice";
fetch
$n as "name";
total-salary: {
  match $x has salary $s;
  get $s; 
  sum $s;
};
```

We now return the following JSON structure
```
[
  {
    "name": {"value": "Alice",  "type":  {"label": "name", "root": "attribute", "value_type": "string"}},
    "total-salary": null
  }
]
```

## Implementation

* We allow 'null' in our internal Fetch answer response data structure
* We package 'null' as an empty 'ReadableConcept' in the protobuf answer message
* We update typedb-behaviour to a new version that includes the relevant test
