### PR TITLE
Migrate artifact hosting to cloudsmith 

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -207,8 +207,8 @@ build:
 #        branch: master
 #      dependencies: [build]
       command: |
-        export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
+        export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //tool/runner:deploy-maven -- snapshot
 
 release:
@@ -294,6 +294,6 @@ release:
       image: vaticle-ubuntu-22.04
       dependencies: [build]
       command: |
-        export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
+        export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(cat VERSION) //tool/runner:deploy-maven -- release

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -152,10 +152,10 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies: [test-assembly-linux-targz]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
@@ -201,11 +201,11 @@ build:
         bazel test //test/deployment:apt --action_env=TEST_DEPLOYMENT_APT_COMMIT --test_output=streamed
 
     deploy-runner-maven-snapshot:
-      filter:
-        owner: vaticle
-        branch: master
       image: vaticle-ubuntu-22.04
-      dependencies: [build]
+#      filter:
+#        owner: vaticle
+#        branch: master
+#      dependencies: [build]
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -152,10 +152,10 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies: [test-assembly-linux-targz]
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
@@ -202,10 +202,10 @@ build:
 
     deploy-runner-maven-snapshot:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: master
-#      dependencies: [build]
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies: [build]
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -157,8 +157,8 @@ build:
         branch: [master, development]
       dependencies: [test-assembly-linux-targz]
       command: |
-        export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-arm64-targz -- snapshot
         bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-x86_64-targz -- snapshot
@@ -177,8 +177,8 @@ build:
         branch: [master, development]
       dependencies: [test-assembly-linux-targz]
       command: |
-        export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export DEPLOY_APT_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_APT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --define version=$(git rev-parse HEAD) //:deploy-apt-x86_64 -- snapshot
         bazel run --define version=$(git rev-parse HEAD) //:deploy-apt-arm64 -- snapshot
@@ -250,8 +250,8 @@ release:
         branch: master
       dependencies: [deploy-github]
       command: |
-        export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export DEPLOY_APT_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_APT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --define version=$(cat VERSION) //:deploy-apt-x86_64 -- release
         bazel run --define version=$(cat VERSION) //:deploy-apt-arm64 -- release
@@ -273,8 +273,8 @@ release:
         branch: master
       dependencies: [deploy-github]
       command: |
-        export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --define version=$(cat VERSION) //server:deploy-linux-arm64-targz -- release
         bazel run --define version=$(cat VERSION) //server:deploy-linux-x86_64-targz -- release

--- a/BUILD
+++ b/BUILD
@@ -165,46 +165,46 @@ assemble_zip(
 deploy_artifact(
     name = "deploy-linux-arm64-targz",
     target = ":assemble-linux-arm64-targz",
-    artifact_group = "vaticle_typedb",
+    artifact_group = "typedb-all-linux-arm64",
     artifact_name = "typedb-all-linux-arm64-{version}.tar.gz",
-    release = deployment['cloudsmith.release'],
-    snapshot = deployment['cloudsmith.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-linux-x86_64-targz",
     target = ":assemble-linux-x86_64-targz",
-    artifact_group = "vaticle_typedb",
+    artifact_group = "typedb-all-linux-x86_64",
     artifact_name = "typedb-all-linux-x86_64-{version}.tar.gz",
-    release = deployment['cloudsmith.release'],
-    snapshot = deployment['cloudsmith.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-mac-arm64-zip",
     target = ":assemble-mac-arm64-zip",
-    artifact_group = "vaticle_typedb",
+    artifact_group = "typedb-all-mac-arm64",
     artifact_name = "typedb-all-mac-arm64-{version}.zip",
-    release = deployment['cloudsmith.release'],
-    snapshot = deployment['cloudsmith.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-mac-x86_64-zip",
     target = ":assemble-mac-x86_64-zip",
-    artifact_group = "vaticle_typedb",
+    artifact_group = "typedb-all-mac-x86_64",
     artifact_name = "typedb-all-mac-x86_64-{version}.zip",
-    release = deployment['cloudsmith.release'],
-    snapshot = deployment['cloudsmith.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-windows-x86_64-zip",
     target = ":assemble-windows-x86_64-zip",
-    artifact_group = "vaticle_typedb",
+    artifact_group = "typedb-all-windows-x86_64",
     artifact_name = "typedb-all-windows-x86_64-{version}.zip",
-    release = deployment['cloudsmith.release'],
-    snapshot = deployment['cloudsmith.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 assemble_versioned(
@@ -251,8 +251,8 @@ deploy_github(
 
 deploy_brew(
     name = "deploy-brew",
-    snapshot = deployment['brew.snapshot'],
-    release = deployment['brew.release'],
+    snapshot = deployment['brew']['snapshot'],
+    release = deployment['brew']['release'],
     formula = "//config/brew:typedb.rb",
     file_substitutions = {
         "//:checksum-mac-arm64": "{sha256-arm64}",
@@ -306,8 +306,8 @@ assemble_apt(
 deploy_apt(
     name = "deploy-apt-x86_64",
     target = ":assemble-linux-x86_64-apt",
-    snapshot = deployment['cloudsmith.snapshot'],
-    release = deployment['cloudsmith.release'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
 )
 
 targz_edit(
@@ -340,8 +340,8 @@ assemble_apt(
 deploy_apt(
     name = "deploy-apt-arm64",
     target = ":assemble-linux-arm64-apt",
-    snapshot = deployment['cloudsmith.snapshot'],
-    release = deployment['cloudsmith.release'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
 )
 
 release_validate_deps(

--- a/BUILD
+++ b/BUILD
@@ -167,8 +167,8 @@ deploy_artifact(
     target = ":assemble-linux-arm64-targz",
     artifact_group = "vaticle_typedb",
     artifact_name = "typedb-all-linux-arm64-{version}.tar.gz",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['cloudsmith.release'],
+    snapshot = deployment['cloudsmith.snapshot'],
 )
 
 deploy_artifact(
@@ -176,8 +176,8 @@ deploy_artifact(
     target = ":assemble-linux-x86_64-targz",
     artifact_group = "vaticle_typedb",
     artifact_name = "typedb-all-linux-x86_64-{version}.tar.gz",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['cloudsmith.release'],
+    snapshot = deployment['cloudsmith.snapshot'],
 )
 
 deploy_artifact(
@@ -185,8 +185,8 @@ deploy_artifact(
     target = ":assemble-mac-arm64-zip",
     artifact_group = "vaticle_typedb",
     artifact_name = "typedb-all-mac-arm64-{version}.zip",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['cloudsmith.release'],
+    snapshot = deployment['cloudsmith.snapshot'],
 )
 
 deploy_artifact(
@@ -194,8 +194,8 @@ deploy_artifact(
     target = ":assemble-mac-x86_64-zip",
     artifact_group = "vaticle_typedb",
     artifact_name = "typedb-all-mac-x86_64-{version}.zip",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['cloudsmith.release'],
+    snapshot = deployment['cloudsmith.snapshot'],
 )
 
 deploy_artifact(
@@ -203,8 +203,8 @@ deploy_artifact(
     target = ":assemble-windows-x86_64-zip",
     artifact_group = "vaticle_typedb",
     artifact_name = "typedb-all-windows-x86_64-{version}.zip",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['cloudsmith.release'],
+    snapshot = deployment['cloudsmith.snapshot'],
 )
 
 assemble_versioned(
@@ -306,8 +306,8 @@ assemble_apt(
 deploy_apt(
     name = "deploy-apt-x86_64",
     target = ":assemble-linux-x86_64-apt",
-    snapshot = deployment['apt.snapshot'],
-    release = deployment['apt.release'],
+    snapshot = deployment['cloudsmith.snapshot'],
+    release = deployment['cloudsmith.release'],
 )
 
 targz_edit(
@@ -340,8 +340,8 @@ assemble_apt(
 deploy_apt(
     name = "deploy-apt-arm64",
     target = ":assemble-linux-arm64-apt",
-    snapshot = deployment['apt.snapshot'],
-    release = deployment['apt.release'],
+    snapshot = deployment['cloudsmith.snapshot'],
+    release = deployment['cloudsmith.release'],
 )
 
 release_validate_deps(

--- a/BUILD
+++ b/BUILD
@@ -306,8 +306,8 @@ assemble_apt(
 deploy_apt(
     name = "deploy-apt-x86_64",
     target = ":assemble-linux-x86_64-apt",
-    snapshot = deployment['artifact']['snapshot']['upload'],
-    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['apt']['snapshot']['upload'],
+    release = deployment['apt']['release']['upload'],
 )
 
 targz_edit(
@@ -340,8 +340,8 @@ assemble_apt(
 deploy_apt(
     name = "deploy-apt-arm64",
     target = ":assemble-linux-arm64-apt",
-    snapshot = deployment['artifact']['snapshot']['upload'],
-    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['apt']['snapshot']['upload'],
+    release = deployment['apt']['release']['upload'],
 )
 
 release_validate_deps(

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Discussion Forum](https://img.shields.io/badge/discourse-forum-blue.svg)](https://forum.typedb.com)
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typedb-796de3.svg)](https://stackoverflow.com/questions/tagged/typedb)
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-typeql-3dce8c.svg)](https://stackoverflow.com/questions/tagged/typeql)
+[![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=flat)](https://cloudsmith.com)
 
 # Introducing TypeDB
 
@@ -227,6 +228,11 @@ In the past, TypeDB was enabled by various open-source products and communities 
 [Apache TinkerPop](http://tinkerpop.apache.org), 
 and [JanusGraph](http://janusgraph.org). 
 
+### Package hosting
+Package repository hosting is graciously provided by  [Cloudsmith](https://cloudsmith.com).
+Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that
+enables your organization to create, store and share packages in any format, to any place, with total
+confidence.
 
 ## Licensing
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -105,6 +105,12 @@ github_deps()
 load("@vaticle_bazel_distribution//pip:deps.bzl", pip_deps = "deps")
 pip_deps()
 
+# Load @vaticle_bazel_distribution_cloudsmith
+load("@vaticle_bazel_distribution//common/cloudsmith:deps.bzl", cloudsmith_deps = "deps")
+cloudsmith_deps()
+load("@vaticle_bazel_distribution_cloudsmith//:requirements.bzl", install_cloudsmith_deps = "install_deps")
+install_cloudsmith_deps()
+
 ######################################
 # Load @vaticle_dependencies//distribution/docker #
 ######################################

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -105,11 +105,11 @@ github_deps()
 load("@vaticle_bazel_distribution//pip:deps.bzl", pip_deps = "deps")
 pip_deps()
 
-# Load @vaticle_bazel_distribution_cloudsmith
-load("@vaticle_bazel_distribution//common/cloudsmith:deps.bzl", cloudsmith_deps = "deps")
-cloudsmith_deps()
-load("@vaticle_bazel_distribution_cloudsmith//:requirements.bzl", install_cloudsmith_deps = "install_deps")
-install_cloudsmith_deps()
+# Load @vaticle_bazel_distribution_uploader
+load("@vaticle_bazel_distribution//common/uploader:deps.bzl", uploader_deps = "deps")
+uploader_deps()
+load("@vaticle_bazel_distribution_uploader//:requirements.bzl", install_uploader_deps = "install_deps")
+install_uploader_deps()
 
 ######################################
 # Load @vaticle_dependencies//distribution/docker #

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -32,6 +32,7 @@
 @maven//:com_googlecode_java_diff_utils_diffutils_1_3_0
 @maven//:com_squareup_okhttp_okhttp_2_7_5
 @maven//:com_squareup_okio_okio_1_17_5
+@maven//:com_vaticle_typedb_typedb_console_runner_45e1bae89d4495a5a44c9ca0dfb385fe4c9033a6
 @maven//:commons_codec_commons_codec_1_11
 @maven//:commons_io_commons_io_2_3
 @maven//:commons_logging_commons_logging_1_2

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -32,7 +32,6 @@
 @maven//:com_googlecode_java_diff_utils_diffutils_1_3_0
 @maven//:com_squareup_okhttp_okhttp_2_7_5
 @maven//:com_squareup_okio_okio_1_17_5
-@maven//:com_vaticle_typedb_typedb_console_runner_3a90fa5d47167508a1f221e0086f265864b91a1b
 @maven//:commons_codec_commons_codec_1_11
 @maven//:commons_io_commons_io_2_3
 @maven//:commons_logging_commons_logging_1_2

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,5 +29,5 @@ def vaticle_typedb_console_artifact():
     )
 
 maven_artifacts = {
-    "com.vaticle.typedb:typedb-console-runner": "3a90fa5d47167508a1f221e0086f265864b91a1b",
+#    "com.vaticle.typedb:typedb-console-runner": "3a90fa5d47167508a1f221e0086f265864b91a1b",
 }

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -21,11 +21,11 @@ load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
 def vaticle_typedb_console_artifact():
     native_artifact_files(
         name = "vaticle_typedb_console_artifact",
-        group_name = "vaticle_typedb_console",
+        group_name = "typedb-console-{platform}",
         artifact_name = "typedb-console-{platform}-{version}.{ext}",
-        tag_source = deployment["artifact.release"],
-        commit_source = deployment["artifact.snapshot"],
-        tag = "2.26.3",
+        tag_source = deployment["artifact"]["release"]["download"],
+        commit_source = deployment["artifact"]["snapshot"]["download"],
+        tag = "2.26.1",
     )
 
 maven_artifacts = {

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,5 +29,5 @@ def vaticle_typedb_console_artifact():
     )
 
 maven_artifacts = {
-#    "com.vaticle.typedb:typedb-console-runner": "3a90fa5d47167508a1f221e0086f265864b91a1b",
+    "com.vaticle.typedb:typedb-console-runner": "45e1bae89d4495a5a44c9ca0dfb385fe4c9033a6",
 }

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -25,7 +25,7 @@ def vaticle_typedb_console_artifact():
         artifact_name = "typedb-console-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        tag = "2.26.1",
+        tag = "2.26.0",
     )
 
 maven_artifacts = {

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,14 +21,14 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/krishnangovindraj/bazel-distribution",
-        commit = "e918931727da5de85b720e89a3c10e1eefe1ceb0",
+        commit = "4744ec59a944138033abf0eb67d2f6c7cefa41bc",
     )
 
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "c88f84f480496a5c85bb9c9d90e31e50378809f1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "3855727ed3f6d93ccc5f176f4414e0142ca718a2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():
@@ -42,14 +42,14 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/krishnangovindraj/typedb-common",
-        commit = "9574419264352ce3eae620aaae87ed99d1706fe2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "731c7d149c40e9ae1430a29cea4c3819a68d3b2d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/krishnangovindraj/typedb-protocol",
-        commit = "43c961b250096ffd95167a6e1a551694c329698f"
+        commit = "7b223fe459f9f0d1358ca3a71e531308aa328b7e"
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -42,7 +42,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/krishnangovindraj/typedb-common",
-        commit = "731c7d149c40e9ae1430a29cea4c3819a68d3b2d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "fb539f760b16412118d68c782c9cdf7d93e6f395",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,36 +20,36 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
-        remote = "https://github.com/krishnangovindraj/bazel-distribution",
-        commit = "4744ec59a944138033abf0eb67d2f6c7cefa41bc",
+        remote = "https://github.com/vaticle/bazel-distribution",
+        commit = "b3618bb5f6761f46a4ed3a3913c75bd795d1797a",
     )
 
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "3855727ed3f6d93ccc5f176f4414e0142ca718a2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "a4a3bac9515fd51365e02f6aad762f67357e49a5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/krishnangovindraj/typeql",
-        commit = "2212a98f5eb7ec3f9e5389831cf2ceebd63d5044",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/vaticle/typeql",
+        commit = "3a523f4d7d40b0c5d3b9af68f31a3859215fa671",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/krishnangovindraj/typedb-common",
-        commit = "fb539f760b16412118d68c782c9cdf7d93e6f395",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        commit = "dbc333528ecdafa5b571344237e831619c3fa5f0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/krishnangovindraj/typedb-protocol",
-        commit = "7b223fe459f9f0d1358ca3a71e531308aa328b7e"
+        remote = "https://github.com/vaticle/typedb-protocol",
+        commit = "a1ebf01a761268dc28c6fd2ab8b6cd825431f3d4"
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "7ec10d713d8feca159a4af8b5ef65e4a8d2f9b75", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "686bb3d964a1fd2a250ee118ddc8fb8c5507a21b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "b3618bb5f6761f46a4ed3a3913c75bd795d1797a",
+        commit = "4a01d09ef542a423ced909db9a61291dc0a6acc5",
     )
 
 def vaticle_dependencies():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,14 +28,14 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "b2d38ffe707d2caf84f4e27cb283b6a491ae15f5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "7ec10d713d8feca159a4af8b5ef65e4a8d2f9b75", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/krishnangovindraj/typeql",
-        commit = "d2316604b44710a9d965f6273aa80182ba7c9de8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        commit = "2212a98f5eb7ec3f9e5389831cf2ceebd63d5044",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
@@ -49,7 +49,7 @@ def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/krishnangovindraj/typedb-protocol",
-        commit = "472e871deff2baaa0e1fe0d7657e82c10687354a"
+        commit = "43c961b250096ffd95167a6e1a551694c329698f"
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,36 +20,36 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
-        remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "bc2fcd5d0caf521d54acf2b7dfe214352e0292d6",
+        remote = "https://github.com/krishnangovindraj/bazel-distribution",
+        commit = "4f6130fae3595bda08eb73121ce1d5b411b6289d",
     )
 
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "41bb5bfb1b5f2adab4a88886d2e74f10d456e7e1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/krishnangovindraj/dependencies",
+        commit = "b2d38ffe707d2caf84f4e27cb283b6a491ae15f5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/vaticle/typeql",
-        tag = "2.25.8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/krishnangovindraj/typeql",
+        commit = "8f5e5e154d180841512055488824c7bf48dee8c5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "1f0f1ec07c9869423b5698271fcca76fde4b4f9e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/krishnangovindraj/typedb-common",
+        commit = "fd9ec61f9cc8bd0ae7a70097257d3191731316e9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/vaticle/typedb-protocol",
-        commit = "9575d084bf4a8618175b70c316b476a8d3984cab",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/krishnangovindraj/typedb-protocol",
+        commit = "3e3a3861b8d90d196cfcfa570550e179a14c2a8c"
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,14 +21,14 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/krishnangovindraj/bazel-distribution",
-        commit = "c96f3bea0e6a9a480ed77b5e710c3057e0cf658d",
+        commit = "e918931727da5de85b720e89a3c10e1eefe1ceb0",
     )
 
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "686bb3d964a1fd2a250ee118ddc8fb8c5507a21b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "c88f84f480496a5c85bb9c9d90e31e50378809f1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,21 +35,21 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/krishnangovindraj/typeql",
-        commit = "8f5e5e154d180841512055488824c7bf48dee8c5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        commit = "d2316604b44710a9d965f6273aa80182ba7c9de8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/krishnangovindraj/typedb-common",
-        commit = "fd9ec61f9cc8bd0ae7a70097257d3191731316e9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "9574419264352ce3eae620aaae87ed99d1706fe2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/krishnangovindraj/typedb-protocol",
-        commit = "3e3a3861b8d90d196cfcfa570550e179a14c2a8c"
+        commit = "472e871deff2baaa0e1fe0d7657e82c10687354a"
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/krishnangovindraj/bazel-distribution",
-        commit = "4f6130fae3595bda08eb73121ce1d5b411b6289d",
+        commit = "c96f3bea0e6a9a480ed77b5e710c3057e0cf658d",
     )
 
 def vaticle_dependencies():

--- a/server/BUILD
+++ b/server/BUILD
@@ -254,46 +254,46 @@ assemble_zip(
 deploy_artifact(
     name = "deploy-linux-arm64-targz",
     target = ":assemble-linux-arm64-targz",
-    artifact_group = "vaticle_typedb",
+    artifact_group = "typedb-server-linux-arm64",
     artifact_name = "typedb-server-linux-arm64-{version}.tar.gz",
-    release = deployment['cloudsmith.release'],
-    snapshot = deployment['cloudsmith.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-linux-x86_64-targz",
     target = ":assemble-linux-x86_64-targz",
-    artifact_group = "vaticle_typedb",
+    artifact_group = "typedb-server-linux-x86_64",
     artifact_name = "typedb-server-linux-x86_64-{version}.tar.gz",
-    release = deployment['cloudsmith.release'],
-    snapshot = deployment['cloudsmith.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-mac-arm64-zip",
     target = ":assemble-mac-arm64-zip",
-    artifact_group = "vaticle_typedb",
+    artifact_group = "typedb-server-mac-arm64",
     artifact_name = "typedb-server-mac-arm64-{version}.zip",
-    release = deployment['cloudsmith.release'],
-    snapshot = deployment['cloudsmith.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-mac-x86_64-zip",
     target = ":assemble-mac-x86_64-zip",
-    artifact_group = "vaticle_typedb",
+    artifact_group = "typedb-server-mac-x86_64",
     artifact_name = "typedb-server-mac-x86_64-{version}.zip",
-    release = deployment['cloudsmith.release'],
-    snapshot = deployment['cloudsmith.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 deploy_artifact(
     name = "deploy-windows-x86_64-zip",
     target = ":assemble-windows-x86_64-zip",
-    artifact_group = "vaticle_typedb",
+    artifact_group = "typedb-server-windows-x86_64",
     artifact_name = "typedb-server-windows-x86_64-{version}.zip",
-    release = deployment['cloudsmith.release'],
-    snapshot = deployment['cloudsmith.snapshot'],
+    release = deployment['artifact']['release']['upload'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
 )
 
 checkstyle_test(

--- a/server/BUILD
+++ b/server/BUILD
@@ -256,8 +256,8 @@ deploy_artifact(
     target = ":assemble-linux-arm64-targz",
     artifact_group = "vaticle_typedb",
     artifact_name = "typedb-server-linux-arm64-{version}.tar.gz",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['cloudsmith.release'],
+    snapshot = deployment['cloudsmith.snapshot'],
 )
 
 deploy_artifact(
@@ -265,8 +265,8 @@ deploy_artifact(
     target = ":assemble-linux-x86_64-targz",
     artifact_group = "vaticle_typedb",
     artifact_name = "typedb-server-linux-x86_64-{version}.tar.gz",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['cloudsmith.release'],
+    snapshot = deployment['cloudsmith.snapshot'],
 )
 
 deploy_artifact(
@@ -274,8 +274,8 @@ deploy_artifact(
     target = ":assemble-mac-arm64-zip",
     artifact_group = "vaticle_typedb",
     artifact_name = "typedb-server-mac-arm64-{version}.zip",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['cloudsmith.release'],
+    snapshot = deployment['cloudsmith.snapshot'],
 )
 
 deploy_artifact(
@@ -283,8 +283,8 @@ deploy_artifact(
     target = ":assemble-mac-x86_64-zip",
     artifact_group = "vaticle_typedb",
     artifact_name = "typedb-server-mac-x86_64-{version}.zip",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['cloudsmith.release'],
+    snapshot = deployment['cloudsmith.snapshot'],
 )
 
 deploy_artifact(
@@ -292,8 +292,8 @@ deploy_artifact(
     target = ":assemble-windows-x86_64-zip",
     artifact_group = "vaticle_typedb",
     artifact_name = "typedb-server-windows-x86_64-{version}.zip",
-    release = deployment['artifact.release'],
-    snapshot = deployment['artifact.snapshot'],
+    release = deployment['cloudsmith.release'],
+    snapshot = deployment['cloudsmith.snapshot'],
 )
 
 checkstyle_test(

--- a/test/deployment/AptTest.java
+++ b/test/deployment/AptTest.java
@@ -38,9 +38,9 @@ import static org.junit.Assert.assertTrue;
 
 public class AptTest {
     private static final Logger LOG = LoggerFactory.getLogger(AptTest.class);
-    private static final String aptSnapshot = "https://repo.vaticle.com/repository/apt-snapshot/";
-    private static final String aptRelease = "https://repo.vaticle.com/repository/apt/";
-    private static final String pubkey1 = "8F3DA4B5E9AEF44C";
+    private static final String aptSnapshot = "https://repo.typedb.com/public/public-snapshot/deb/ubuntu";
+    private static final String aptRelease = "https://repo.typedb.com/public/public-release/deb/ubuntu";
+    private static final String pubkey1 = "17507562824cfdcc";
     private static final String pubkey2 = "https://cli-assets.heroku.com/apt/release.key";
     private static final String pubkey3 = "https://dl.google.com/linux/linux_signing_key.pub";
     private static final Path versionFile = Paths.get("VERSION");

--- a/tool/runner/BUILD
+++ b/tool/runner/BUILD
@@ -47,8 +47,8 @@ assemble_maven(
 deploy_maven(
     name = "deploy-maven",
     target = ":assemble-maven",
-    snapshot = deployment['maven.snapshot'],
-    release = deployment['maven.release']
+    snapshot = deployment['maven']['snapshot']['upload'],
+    release = deployment['maven']['release']['upload'],
 )
 
 checkstyle_test(


### PR DESCRIPTION
## Usage and product changes
Updates artifact credentials, and deployment & consumption rules to use cloudsmith (repo.typedb.com) instead of the self-hosted sonatype repository (repo.vaticle.com).

## Implementation
* Updates deployment & artifact consumption rules to point to Cloudsmith and update deployment rules and repositories
* Updates artifact_groups to reflect the revised repository layout
* Update package import paths for TypeDBRunner
