### PR TITLE
Improve error message when using anonymous variable in delete query

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -293,8 +293,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Pattern(9, "The thing variable '%s' has multiple 'isa' constraints, '%s' and '%s'.");
         public static final Pattern MULTIPLE_THING_CONSTRAINT_RELATION =
                 new Pattern(10, "The relation variable '%s' has multiple 'relation' constraints");
-        public static final Pattern ILLEGAL_REDECLARED_THING_CONSTRAINT_ISA =
-                new Pattern(11, "The thing variable '%s'  has a redeclared 'isa' constraint, in a query that does not allow it.");
+        public static final Pattern ILLEGAL_IMPLICIT_THING_CONSTRAINT_ISA =
+                new Pattern(11, "The thing variable '%s' has an implicit 'isa' constraint, in a query that does not allow it.");
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_SUB =
                 new Pattern(12, "The type variable '%s' has multiple 'sub' constraints.");
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_LABEL =

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -293,8 +293,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new Pattern(9, "The thing variable '%s' has multiple 'isa' constraints, '%s' and '%s'.");
         public static final Pattern MULTIPLE_THING_CONSTRAINT_RELATION =
                 new Pattern(10, "The relation variable '%s' has multiple 'relation' constraints");
-        public static final Pattern ILLEGAL_DERIVED_THING_CONSTRAINT_ISA =
-                new Pattern(11, "The thing variable '%s' has a derived 'isa' constraint, in a query that does not allow it.");
+        public static final Pattern ILLEGAL_REDECLARED_THING_CONSTRAINT_ISA =
+                new Pattern(11, "The thing variable '%s'  has a redeclared 'isa' constraint, in a query that does not allow it.");
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_SUB =
                 new Pattern(12, "The type variable '%s' has multiple 'sub' constraints.");
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_LABEL =
@@ -446,10 +446,10 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new ThingWrite(14, "Attempted to re-insert pre-existing thing of matched variable '%s' as a new instance (isa) of type '%s'.");
         public static final ThingWrite THING_ISA_MISSING =
                 new ThingWrite(15, "The thing variable '%s' cannot be inserted as a new instance without providing its type (isa).");
-        public static final ThingWrite ILLEGAL_ANONYMOUS_RELATION_IN_DELETE =
-                new ThingWrite(16, "Illegal anonymous relation in delete query: '%s'.  You must match the relation variable by name, and then delete it.");
+        public static final ThingWrite ILLEGAL_VALUE_VARIABLE_IN_DELETE =
+                new ThingWrite(16, "Illegal value variable '%s' in delete query. You can only delete named variables that were matched.");
         public static final ThingWrite ILLEGAL_ANONYMOUS_VARIABLE_IN_DELETE =
-                new ThingWrite(17, "Illegal anonymous variable in delete query: '%s'.  You can only delete named variables that were matched.");
+                new ThingWrite(17, "Illegal anonymous delete variable in constraint '%s'.  You can only delete named variables that were matched.");
         public static final ThingWrite INVALID_DELETE_THING =
                 new ThingWrite(18, "The thing '%s' cannot be deleted, as the provided type '%s' is not its direct type nor supertype.");
         public static final ThingWrite INVALID_DELETE_THING_DIRECT =
@@ -482,12 +482,10 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
                 new ThingWrite(32, "Could not perform delete of role players due to multiple relation constraints being present for relation '%s'.");
         public static final ThingWrite DELETE_ROLEPLAYER_NOT_PRESENT =
                 new ThingWrite(33, "Could not delete roleplayer '%s' as relation '%s' does not relate it.");
-        public static final ThingWrite ILLEGAL_VALUE_VARIABLE_IN_DELETE =
-                new ThingWrite(34, "Illegal value variable '%s' found in delete query. Value variables may not be used in delete queries.");
         public static final ThingWrite ILLEGAL_VALUE_CONSTRAINT_IN_INSERT =
-                new ThingWrite(35, "Illegal value constraint found in the insert query on variable '%s'. Value variables are only permitted to specify attribute values.");
+                new ThingWrite(34, "Illegal value constraint found in the insert query on variable '%s'. Value variables are only permitted to specify attribute values.");
         public static final ThingWrite ILLEGAL_UNBOUND_TYPE_VAR_IN_INSERT =
-                new ThingWrite(36, "Type variable '%s' found in the insert query must retrieved by the match previously.");
+                new ThingWrite(35, "Type variable '%s' found in the insert query must retrieved by the match previously.");
 
         private static final String codePrefix = "THW";
         private static final String messagePrefix = "Invalid Thing Write";

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -55,6 +55,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "9f72b32fdd13ae7041463e67767c026750d2bcd7",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
+        commit = "530a63c440966c6ddd22efe93184af1a6b35c01f" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -55,6 +55,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-        commit = "530a63c440966c6ddd22efe93184af1a6b35c01f" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "ba3220fe96f016a5d97cd047fccc4693a15bb71c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/pattern/variable/ThingVariable.java
+++ b/pattern/variable/ThingVariable.java
@@ -42,7 +42,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.ILLEGAL_REDECLARED_THING_CONSTRAINT_ISA;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.ILLEGAL_IMPLICIT_THING_CONSTRAINT_ISA;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.MULTIPLE_THING_CONSTRAINT_IID;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.MULTIPLE_THING_CONSTRAINT_ISA;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.MULTIPLE_THING_CONSTRAINT_RELATION;
@@ -71,7 +71,7 @@ public class ThingVariable extends com.vaticle.typedb.core.pattern.variable.Vari
                                  com.vaticle.typedb.core.pattern.variable.VariableRegistry registry) {
         constraints.forEach(constraint -> {
             if (constraint.isIsa() && constraint.asIsa().isDerived() && !registry.allowsDerived()) {
-                throw TypeDBException.of(ILLEGAL_REDECLARED_THING_CONSTRAINT_ISA, id(), constraint.asIsa().type());
+                throw TypeDBException.of(ILLEGAL_IMPLICIT_THING_CONSTRAINT_ISA, id(), constraint.asIsa().type());
             }
             this.constrain(ThingConstraint.of(this, constraint, registry));
         });

--- a/pattern/variable/ThingVariable.java
+++ b/pattern/variable/ThingVariable.java
@@ -42,7 +42,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.ILLEGAL_DERIVED_THING_CONSTRAINT_ISA;
+import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.ILLEGAL_REDECLARED_THING_CONSTRAINT_ISA;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.MULTIPLE_THING_CONSTRAINT_IID;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.MULTIPLE_THING_CONSTRAINT_ISA;
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Pattern.MULTIPLE_THING_CONSTRAINT_RELATION;
@@ -71,7 +71,7 @@ public class ThingVariable extends com.vaticle.typedb.core.pattern.variable.Vari
                                  com.vaticle.typedb.core.pattern.variable.VariableRegistry registry) {
         constraints.forEach(constraint -> {
             if (constraint.isIsa() && constraint.asIsa().isDerived() && !registry.allowsDerived()) {
-                throw TypeDBException.of(ILLEGAL_DERIVED_THING_CONSTRAINT_ISA, id(), constraint.asIsa().type());
+                throw TypeDBException.of(ILLEGAL_REDECLARED_THING_CONSTRAINT_ISA, id(), constraint.asIsa().type());
             }
             this.constrain(ThingConstraint.of(this, constraint, registry));
         });

--- a/query/Deleter.java
+++ b/query/Deleter.java
@@ -76,7 +76,7 @@ public class Deleter {
     }
 
     public static Deleter create(Reasoner reasoner, ConceptManager conceptMgr, TypeQLDelete query, Context.Query context) {
-        validateNamedThingVariables(query);
+        validateTypeQLVariables(query);
         VariableRegistry registry = VariableRegistry.createFromThings(query.statements(), false);
         registry.variables().forEach(Deleter::validate);
         assert query.match().get().namedVariables().containsAll(query.namedVariables());
@@ -92,7 +92,7 @@ public class Deleter {
         return new Deleter(getter, registry.things(), context);
     }
 
-    private static void validateNamedThingVariables(TypeQLDelete query) {
+    private static void validateTypeQLVariables(TypeQLDelete query) {
         for (Statement statement : query.statements()) {
             for (Constraint constraint : statement.constraints()) {
                 Optional<? extends TypeQLVariable> var = constraint.variables().stream().filter(v ->  v.isValueVar() || v.isAnonymised()).findFirst();

--- a/test/behaviour/query/TypeQLSteps.java
+++ b/test/behaviour/query/TypeQLSteps.java
@@ -140,6 +140,11 @@ public class TypeQLSteps {
         assertThrows(() -> typeql_delete(deleteQueryStatements));
     }
 
+    @Given("typeql delete; throws exception containing {string}")
+    public void typeql_delete_throws_exception(String exception, String deleteQueryStatements) {
+        assertThrowsWithMessage(() -> typeql_delete(deleteQueryStatements), exception);
+    }
+
     @Given("typeql update")
     public void typeql_update(String updateQueryStatements) {
         TypeQLUpdate typeQLQuery = TypeQL.parseQuery(String.join("\n", updateQueryStatements)).asUpdate();


### PR DESCRIPTION
## Usage and product changes

We now throw an explicit error message when a user tries to delete a 'thing' variable that is not named.
For example:
```
match $x isa person;
delete $x has name 'John';
```

Will now explicitly throw an exception saying that the 'delete' variables must be matched first.

## Implementation

Update behaviour tests and throw an more readable error message.
