### PR TITLE
Fix negated traversals so filters apply after the negation

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -57,5 +57,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "32e66b46fd124d52b81842f4719460b31bca2c48" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "859999d645eecf2351ce4ee159994c172dc3ab79" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -57,5 +57,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "859999d645eecf2351ce4ee159994c172dc3ab79" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "47a735fb9b4d4091f087157b3f4109d2943333c6" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -56,6 +56,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "47a735fb9b4d4091f087157b3f4109d2943333c6" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "9f72b32fdd13ae7041463e67767c026750d2bcd7" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -56,6 +56,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "46a16939c1dd94aac6aebc3dd7e50e8280d3dfe5" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "32e66b46fd124d52b81842f4719460b31bca2c48" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -279,9 +279,9 @@ public class Reasoner {
     private FunctionalIterator<ConceptMap> iterator(Conjunction conjunction, Filter filter) {
         assert conjunction.isCoherent();
         if (!conjunction.isAnswerable()) return empty();
-        FunctionalIterator<ConceptMap> answers = traversalEng.iterator(conjunction.traversal(filter)).map(conceptMgr::conceptMap);
-        if (conjunction.negations().isEmpty()) return answers;
-        else {
+        if (conjunction.negations().isEmpty()) {
+            return traversalEng.iterator(conjunction.traversal(filter)).map(conceptMgr::conceptMap);
+        } else {
             return traversalEng.iterator(conjunction.traversal()).map(conceptMgr::conceptMap)
                     .filter(ans -> !isNegated(ans, conjunction.negations()))
                     .map(conceptMap -> conceptMap.filter(filter)).distinct();
@@ -291,11 +291,13 @@ public class Reasoner {
     private SortedIterator<ConceptMap.Sortable, Order.Asc> iteratorSorted(Conjunction conjunction,
                                                                           Filter filter, Sorting sorting) {
         ConceptMap.Sortable.Comparator comparator = ConceptMap.Comparator.create(sorting);
-        SortedIterator<ConceptMap.Sortable, Order.Asc> answers = traversalEng.iterator(conjunction.traversal(filter, sorting))
-                .mapSorted(vertexMap -> conceptMgr.conceptMapOrdered(vertexMap, comparator), ASC);
-        if (conjunction.negations().isEmpty()) return answers;
-        else {
-            return answers.filter(ans -> !isNegated(ans, conjunction.negations()))
+        if (conjunction.negations().isEmpty()) {
+            return traversalEng.iterator(conjunction.traversal(filter, sorting))
+                    .mapSorted(vertexMap -> conceptMgr.conceptMapOrdered(vertexMap, comparator), ASC);
+        } else {
+            return traversalEng.iterator(conjunction.traversal(Filter.create(list()), sorting))
+                    .mapSorted(vertexMap -> conceptMgr.conceptMapOrdered(vertexMap, comparator), ASC)
+                    .filter(ans -> !isNegated(ans, conjunction.negations()))
                     .mapSorted(conceptMap -> conceptMap.filter(filter), ASC).distinct();
         }
     }


### PR DESCRIPTION
## Usage and product changes
Fixes a bug where the `get` clause filtered out concepts before the negation was applied. This lead to the negation being evaluated without that variable being bound.

## Implementation
* Refactor code so the `Modifier.Filter` is not passed to the traversal if a negation is present. Instead the answers coming out of the negation are filtered afterwards using `FunctionalIterator.filter`. This matches an existing case which was correctly implemented.