### PR TITLE
Disable diagnostics in Docker and Assembly tests

### DIFF
--- a/test/assembly/AssemblyTest.java
+++ b/test/assembly/AssemblyTest.java
@@ -26,12 +26,14 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeoutException;
 
+import static com.vaticle.typedb.common.collection.Collections.map;
+import static com.vaticle.typedb.common.collection.Collections.pair;
+
 public class AssemblyTest {
 
     @Test
     public void bootup() throws InterruptedException, TimeoutException, IOException {
-        TypeDBCoreRunner server = new TypeDBCoreRunner();
-        // TODO: disable reporting via configuration
+        TypeDBCoreRunner server = new TypeDBCoreRunner(map(pair("--diagnostics.reporting.enable", "false")));
         try {
             server.start();
         } finally {

--- a/test/assembly/BUILD
+++ b/test/assembly/BUILD
@@ -25,6 +25,7 @@ typedb_java_test(
     srcs = ["AssemblyTest.java"],
     deps = [
         "//tool/runner:typedb-runner",
+        "@vaticle_typedb_common//:common",
         "@maven//:com_vaticle_typedb_typedb_console_runner",
     ],
     server_artifacts = {

--- a/test/assembly/DockerTest.java
+++ b/test/assembly/DockerTest.java
@@ -48,11 +48,11 @@ public class DockerTest {
         String imagePath = Paths.get("assemble-docker.tar").toAbsolutePath().toString();
         ProcessResult result = execute("docker", "load", "-i", imagePath);
         LOG.info(result.outputString());
-        // TODO: disable diagnostics reporting
         StartedProcess typeDBProcess = executor.command(
                 "docker", "run", "--name", "typedb",
                 "--rm", "-t", "-p", String.format("%d:%d", typeDBPort, typeDBPort),
-                "bazel:assemble-docker"
+                "bazel:assemble-docker",
+                "/opt/typedb-all-linux-x86_64/typedb", "server", "--diagnostics.reporting.enable=false"
         ).start();
         TypeDBConsoleRunner consoleRunner = new TypeDBConsoleRunner();
         testIsReady(consoleRunner);

--- a/tool/runner/TypeDBCoreRunner.java
+++ b/tool/runner/TypeDBCoreRunner.java
@@ -24,8 +24,11 @@ import org.zeroturnaround.exec.StartedProcess;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
@@ -43,8 +46,14 @@ public class TypeDBCoreRunner implements TypeDBRunner {
     private final int port;
     private StartedProcess process;
     private final ProcessExecutor executor;
+    private Map<String, String> options;
 
     public TypeDBCoreRunner() throws InterruptedException, TimeoutException, IOException {
+        this(new HashMap<>());
+    }
+
+    public TypeDBCoreRunner(Map<String, String> options) throws InterruptedException, TimeoutException, IOException {
+        this.options = options;
         port = findUnusedPorts(1).get(0);
         System.out.println(address() + ": Constructing " + name() + " runner");
         System.out.println(address() + ": Extracting distribution archive...");
@@ -88,13 +97,12 @@ public class TypeDBCoreRunner implements TypeDBRunner {
     }
 
     private List<String> command() {
-        return typeDBCommand(
-                "server",
-                "--server.address",
-                address(),
-                "--storage.data",
-                dataDir.toAbsolutePath().toString()
-        );
+        List<String> cmd = new ArrayList<>();
+        cmd.add("server");
+        cmd.add("--server.address=" + address());
+        cmd.add("--storage.data=" + dataDir.toAbsolutePath().toString());
+        options.forEach((key, value) -> cmd.add(key + "=" + value));
+        return typeDBCommand(cmd);
     }
 
     @Override


### PR DESCRIPTION
## Usage and product changes

We disable diagnostics in Docker and Assembly tests. This also required allow the TypeDB Runner library to accept and transmit arguments to the binary it boots.

## Implementation

* Implement option pass-through for the TypeDB Runner
* Docker and Assembly tests pass `--diagnostics.reporting.enable = false` to the server on bootup