### PR TITLE
Enable Unicode variable names

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -56,5 +56,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "e770b696b04138488894b636c61f08eaf030b45d" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "64430c4fb512a70d2f5cc02087e0b8561bff7417" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -34,8 +34,8 @@ def vaticle_dependencies():
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/vaticle/typeql",
-        commit = "3a523f4d7d40b0c5d3b9af68f31a3859215fa671",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/flyingsilverfin/typeql",
+        commit = "3f5b92f0376af20ea2fdc469d6c545fc7fa833f8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
@@ -56,5 +56,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "ba3220fe96f016a5d97cd047fccc4693a15bb71c" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "e770b696b04138488894b636c61f08eaf030b45d" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )


### PR DESCRIPTION
## Usage and product changes

We update to TypeQL with Unicode support in both value and concept variables. This makes the following valid TypeQL:

```
match $人 isa person, has name "Liu"; get  $人;
```

```
match $אדם isa person, has name "Solomon"; get $אדם;
```

This change is fully backwards compatible.

## Implementation
- Update to the latest TypeQL, which has support for Unicode/utf-8
- Update BDD to test a larger suite of utf-8 characters in attribute, labels, and values.
