### PR TITLE
Sync dependencies in CI

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -211,6 +211,32 @@ build:
         export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //tool/runner:deploy-maven -- snapshot
 
+    sync-dependencies:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - build
+        - build-dependency
+        - test-unit
+        - test-integration
+        - test-behaviour-connection
+        - test-behaviour-concept
+        - test-behaviour-query-read
+        - test-behaviour-query-write
+        - test-behaviour-query-definable
+        - test-behaviour-reasoner
+        - test-benchmark-reasoner
+        - test-assembly-linux-targz
+        - test-assembly-docker
+        - deploy-artifact-snapshot
+        - deploy-apt-snapshot
+        - test-deployment-apt-x86_64
+      command: |
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
+
 release:
   filter:
     owner: vaticle
@@ -286,7 +312,6 @@ release:
         bazel run --define version=$(cat VERSION) //:deploy-mac-arm64-zip -- release
         bazel run --define version=$(cat VERSION) //:deploy-mac-x86_64-zip -- release
         bazel run --define version=$(cat VERSION) //:deploy-windows-x86_64-zip -- release
-
     deploy-runner-maven-release:
       filter:
         owner: vaticle
@@ -297,3 +322,17 @@ release:
         export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(cat VERSION) //tool/runner:deploy-maven -- release
+    sync-dependencies-release:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies:
+        - deploy-github
+        - deploy-brew
+        - deploy-apt-release
+        - deploy-docker
+        - deploy-artifact-release
+      command: |
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@$(cat VERSION)

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,20 +21,20 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "4a01d09ef542a423ced909db9a61291dc0a6acc5",
+        commit = "4a01d09ef542a423ced909db9a61291dc0a6acc5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )
 
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "a4a3bac9515fd51365e02f6aad762f67357e49a5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "a4a3bac9515fd51365e02f6aad762f67357e49a5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/flyingsilverfin/typeql",
+        remote = "https://github.com/vaticle/typeql",
         commit = "029a66fc9fd5cf7ac8ad08701fad2c8966268a10",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
@@ -49,12 +49,12 @@ def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/vaticle/typedb-protocol",
-        commit = "a1ebf01a761268dc28c6fd2ab8b6cd825431f3d4"
+        commit = "a1ebf01a761268dc28c6fd2ab8b6cd825431f3d4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "64430c4fb512a70d2f5cc02087e0b8561bff7417" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "64430c4fb512a70d2f5cc02087e0b8561bff7417",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )


### PR DESCRIPTION
## Usage and product changes

We add a sync-dependencies job to be run in CI after successful snapshot and release deployments. The job sends a request to vaticle-bot to update all downstream dependencies.

Note: this PR does _not_ update the `dependencies` repo dependency. It will be updated automatically by the bot during its first pass.