### PR TITLE
Transition from standalone typedb-common to typeql/common

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -20,7 +20,6 @@ config:
   dependencies:
     dependencies: [build]
     typeql: [build, release]
-    typedb-common: [build, release]
     typedb-protocol: [build, release]
     typedb-behaviour: [build]
 

--- a/BUILD
+++ b/BUILD
@@ -46,7 +46,7 @@ native_java_libraries(
     ],
     deps = [
         # Vaticle Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
     ],
     tags = ["maven_coordinates=com.vaticle.typedb:typedb:{pom_version}"],
     visibility = ["//visibility:public"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -148,10 +148,7 @@ container_pull(
 # Load @vaticle/typedb dependencies #
 #####################################
 
-# We don't load Maven artifacts for @vaticle_typedb_common as they are only needed
-# if you depend on @vaticle_typedb_common//test/server
-load("//dependencies/vaticle:repositories.bzl", "vaticle_typedb_common","vaticle_typeql", "vaticle_typedb_protocol", "vaticle_typedb_behaviour")
-vaticle_typedb_common()
+load("//dependencies/vaticle:repositories.bzl", "vaticle_typeql", "vaticle_typedb_protocol", "vaticle_typedb_behaviour")
 vaticle_typeql()
 vaticle_typedb_protocol()
 vaticle_typedb_behaviour()
@@ -160,7 +157,6 @@ load("//dependencies/vaticle:artifacts.bzl", "vaticle_typedb_console_artifact")
 vaticle_typedb_console_artifact()
 
 # Load maven artifacts
-load("@vaticle_typedb_common//dependencies/maven:artifacts.bzl", vaticle_typedb_common_artifacts = "artifacts")
 load("@vaticle_typeql//dependencies/maven:artifacts.bzl", vaticle_typeql_artifacts = "artifacts")
 load("@vaticle_typedb_protocol//dependencies/maven:artifacts.bzl", vaticle_typedb_protocol_artifacts = "artifacts")
 load("//dependencies/maven:artifacts.bzl", vaticle_typedb_artifacts = "artifacts")
@@ -171,7 +167,6 @@ load("//dependencies/vaticle:artifacts.bzl", vaticle_typedb_vaticle_maven_artifa
 ############################
 load("@vaticle_dependencies//library/maven:rules.bzl", "maven")
 maven(
-    vaticle_typedb_common_artifacts  +
     vaticle_dependencies_tool_maven_artifacts +
     vaticle_typeql_artifacts +
     vaticle_typedb_artifacts +

--- a/common/BUILD
+++ b/common/BUILD
@@ -25,7 +25,7 @@ native_java_libraries(
     srcs = glob(["*/*.java", "*/*/*.java"], exclude=["test/*", "*Test.java", "*/*Test.java"]),
     deps = [
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/query:query",
 
         # External Maven Dependencies
@@ -52,7 +52,7 @@ host_compatible_java_test(
     test_class = "com.vaticle.typedb.core.common.iterator.PermutationIteratorTest",
     deps = [
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
     ],
     native_libraries_deps = [
         "//common:common",

--- a/concept/BUILD
+++ b/concept/BUILD
@@ -45,7 +45,7 @@ native_java_libraries(
     ],
     deps = [
         # Internal Repository Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/common:common",
         "@vaticle_typeql//java/pattern:pattern",
         "@vaticle_typeql//java:typeql-lang",

--- a/concurrent/BUILD
+++ b/concurrent/BUILD
@@ -25,7 +25,7 @@ native_java_libraries(
     srcs = glob(["*/*.java", "*/*/*.java"], exclude=["test/*", "*Test.java", "*/*Test.java"]),
     deps = [
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:com_google_code_findbugs_jsr305",

--- a/database/BUILD
+++ b/database/BUILD
@@ -44,7 +44,7 @@ native_java_libraries(
     ],
     deps = [
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
 
         # External dependencies from Maven

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -38,13 +38,6 @@ def vaticle_typeql():
         commit = "230842fe545c6ebab59b976df834552d198c6dee",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
-def vaticle_typedb_common():
-    git_repository(
-        name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "3b704bc629b4bc994dd07f079e572af9da06202a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
-    )
-
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",

--- a/encoding/BUILD
+++ b/encoding/BUILD
@@ -32,7 +32,7 @@ native_java_libraries(
     srcs = glob(["*.java", "*/*.java"]),
     deps = [
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/common:common",
 
         # External Maven Dependencies

--- a/graph/BUILD
+++ b/graph/BUILD
@@ -31,7 +31,7 @@ native_java_libraries(
     srcs = glob(["*.java", "*/*.java", "*/*/*.java"]),
     deps = [
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External dependencies from Vaticle
         "@vaticle_typeql//java:typeql-lang",

--- a/logic/BUILD
+++ b/logic/BUILD
@@ -57,7 +57,7 @@ native_java_libraries(
     ],
     deps = [
         # Internal Repository Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/common",
         "@vaticle_typeql//java/pattern",
 
@@ -82,7 +82,7 @@ host_compatible_java_test(
         # Internal dependencies
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
     ],
 )
@@ -102,7 +102,7 @@ host_compatible_java_test(
     deps = [
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
     ],
 )
@@ -123,7 +123,7 @@ host_compatible_java_test(
         # Internal dependencies
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/common",
         "@vaticle_typeql//java:typeql-lang",
     ],

--- a/migrator/BUILD
+++ b/migrator/BUILD
@@ -65,7 +65,7 @@ native_java_libraries(
         ":migrator-data",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/pattern:pattern",
         "@vaticle_typeql//java/common:common",

--- a/pattern/BUILD
+++ b/pattern/BUILD
@@ -45,7 +45,7 @@ native_java_libraries(
     ], exclude = ["*Test.java", "*/*Test.java"],),
     deps = [
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/builder:builder",
         "@vaticle_typeql//java/common:common",
         "@vaticle_typeql//java/pattern:pattern",
@@ -73,7 +73,7 @@ host_compatible_java_test(
     ],
     deps = [
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
     ],
 )

--- a/query/BUILD
+++ b/query/BUILD
@@ -42,7 +42,7 @@ native_java_libraries(
     ],
     deps = [
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/common:common",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/pattern:pattern",

--- a/reasoner/BUILD
+++ b/reasoner/BUILD
@@ -55,7 +55,7 @@ native_java_libraries(
     ],
     deps = [
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/common",
         "@vaticle_typeql//java/pattern",
         "@vaticle_typeql//java/query",

--- a/server/BUILD
+++ b/server/BUILD
@@ -66,7 +66,7 @@ native_java_libraries(
         ":version",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/pattern:pattern",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/query",

--- a/server/test/BUILD
+++ b/server/test/BUILD
@@ -38,7 +38,7 @@ host_compatible_java_test(
         # Internal dependencies
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
     ],
     data = [
         "//server:config",

--- a/test/assembly/BUILD
+++ b/test/assembly/BUILD
@@ -25,7 +25,7 @@ typedb_java_test(
     srcs = ["AssemblyTest.java"],
     deps = [
         "//tool/runner:typedb-runner",
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@maven//:com_vaticle_typedb_typedb_console_runner",
     ],
     server_artifacts = {

--- a/test/behaviour/concept/thing/BUILD
+++ b/test/behaviour/concept/thing/BUILD
@@ -30,7 +30,7 @@ host_compatible_java_library(
         "//test/behaviour/connection:steps",
 
         # Vaticle Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/common",
 
         # External Maven Dependencies

--- a/test/behaviour/concept/thing/attribute/BUILD
+++ b/test/behaviour/concept/thing/attribute/BUILD
@@ -29,7 +29,7 @@ host_compatible_java_library(
         "//test/behaviour/connection:steps",
 
         # Internal Repository Dependencies
-        # "@vaticle_typedb_common//:common",
+        # "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:junit_junit",

--- a/test/behaviour/concept/thing/entity/BUILD
+++ b/test/behaviour/concept/thing/entity/BUILD
@@ -29,7 +29,7 @@ host_compatible_java_library(
         "//test/behaviour/connection:steps",
 
         # Internal Repository Dependencies
-        # "@vaticle_typedb_common//:common",
+        # "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:junit_junit",

--- a/test/behaviour/concept/thing/relation/BUILD
+++ b/test/behaviour/concept/thing/relation/BUILD
@@ -30,7 +30,7 @@ host_compatible_java_library(
         "//test/behaviour/connection:steps",
 
         # Internal Repository Dependencies
-        # "@vaticle_typedb_common//:common",
+        # "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:junit_junit",

--- a/test/behaviour/concept/type/attributetype/BUILD
+++ b/test/behaviour/concept/type/attributetype/BUILD
@@ -28,7 +28,7 @@ host_compatible_java_library(
         "//test/behaviour/connection:steps",
 
         # Vaticle Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/common",
 
         # External Maven Dependencies

--- a/test/behaviour/concept/type/thingtype/BUILD
+++ b/test/behaviour/concept/type/thingtype/BUILD
@@ -29,7 +29,7 @@ host_compatible_java_library(
         "//test/behaviour/connection:steps",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/common:common",
 
         # External Maven Dependencies

--- a/test/behaviour/connection/database/BUILD
+++ b/test/behaviour/connection/database/BUILD
@@ -28,7 +28,7 @@ java_library(
         "//test/behaviour/connection:steps",
 
         # Internal Repository Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:junit_junit",

--- a/test/behaviour/connection/session/BUILD
+++ b/test/behaviour/connection/session/BUILD
@@ -28,7 +28,7 @@ host_compatible_java_library(
         "//test/behaviour/connection:steps",
 
         # Internal Repository Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:junit_junit",

--- a/test/behaviour/connection/transaction/BUILD
+++ b/test/behaviour/connection/transaction/BUILD
@@ -28,7 +28,7 @@ host_compatible_java_library(
         "//test/behaviour/connection:steps",
 
         # Internal Repository Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External Maven Dependencies
         "@maven//:junit_junit",

--- a/test/behaviour/query/BUILD
+++ b/test/behaviour/query/BUILD
@@ -43,7 +43,7 @@ host_compatible_java_library(
         "//test/behaviour/exception",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/common",
         "@vaticle_typeql//java/query",

--- a/test/behaviour/reasoner/BUILD
+++ b/test/behaviour/reasoner/BUILD
@@ -34,7 +34,7 @@ host_compatible_java_library(
     deps = [
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/common",
         "@vaticle_typeql//java/query",

--- a/test/behaviour/reasoner/verification/BUILD
+++ b/test/behaviour/reasoner/verification/BUILD
@@ -33,7 +33,7 @@ native_java_libraries(
         "//reasoner:reasoner",
     ],
     deps = [
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/common",
         "@vaticle_typeql//java/query",

--- a/test/behaviour/reasoner/verification/test/BUILD
+++ b/test/behaviour/reasoner/verification/test/BUILD
@@ -37,7 +37,7 @@ host_compatible_java_test(
     deps = [
         "//test/integration/util:util",
         # External dependencies from @vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/query",
         "@vaticle_typeql//java/common",
@@ -61,7 +61,7 @@ host_compatible_java_test(
     deps = [
         "//test/integration/util",
         # External dependencies from @vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/query",
         "@vaticle_typeql//java/common",

--- a/test/benchmark/reasoner/iam/common/BUILD
+++ b/test/benchmark/reasoner/iam/common/BUILD
@@ -40,7 +40,7 @@ native_java_libraries(
         "//server:version",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/query",
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -76,7 +76,7 @@ host_compatible_java_test(
         "//test/integration/util:util",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
     ],
     size = "large",

--- a/test/integration/logic/BUILD
+++ b/test/integration/logic/BUILD
@@ -38,7 +38,7 @@ host_compatible_java_test(
         "//test/integration/util",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/pattern:pattern",
     ],
@@ -64,7 +64,7 @@ host_compatible_java_test(
         # External dependencies from Vaticle
         "@vaticle_typeql//java/query",
         "@vaticle_typeql//java:typeql-lang",
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
     ],
     data = [":basic-schema.tql", ":test-type-inference.tql"],
 )
@@ -87,7 +87,7 @@ host_compatible_java_test(
         "//test/integration/util",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
     ],
 )
@@ -110,7 +110,7 @@ host_compatible_java_test(
         "//test/integration/util",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
     ],
 )
@@ -133,7 +133,7 @@ host_compatible_java_test(
         "//test/integration/util",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
     ],
 )
@@ -156,7 +156,7 @@ host_compatible_java_test(
         "//test/integration/util",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
     ],
 )
@@ -177,7 +177,7 @@ host_compatible_java_test(
     deps = [
         "//test/integration/util",
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/pattern",
         "@vaticle_typeql//java:typeql-lang",
     ],

--- a/test/integration/reasoner/BUILD
+++ b/test/integration/reasoner/BUILD
@@ -35,7 +35,7 @@ host_compatible_java_test(
         "//test/integration/util",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
     ],
 )
@@ -59,7 +59,7 @@ host_compatible_java_test(
         "//test/integration/util",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
     ],
 )
@@ -85,7 +85,7 @@ host_compatible_java_test(
 
         # External dependencies from Vaticle
         "@vaticle_typeql//java:typeql-lang",
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
     ],
 )
 
@@ -108,7 +108,7 @@ host_compatible_java_test(
         "//test/integration/util",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/common",
         "@vaticle_typeql//java:typeql-lang",
     ],
@@ -133,7 +133,7 @@ host_compatible_java_test(
         "//test/integration/util",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
     ],
 )
@@ -157,7 +157,7 @@ host_compatible_java_test(
         "//test/integration/util",
 
         # External dependencies from Vaticle
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java:typeql-lang",
     ],
 )

--- a/test/integration/server/BUILD
+++ b/test/integration/server/BUILD
@@ -35,7 +35,7 @@ host_compatible_java_test(
     test_class = "com.vaticle.typedb.core.server.ParametersTest",
     deps = [
         "//test/integration/util:util",
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
     ],
 )
 

--- a/test/integration/traversal/BUILD
+++ b/test/integration/traversal/BUILD
@@ -42,7 +42,7 @@ host_compatible_java_test(
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/common",
         "@vaticle_typeql//java/pattern",
-        "@vaticle_typedb_common//:common"
+        "@vaticle_typeql//common/java:common"
     ],
 )
 

--- a/traversal/BUILD
+++ b/traversal/BUILD
@@ -40,7 +40,7 @@ native_java_libraries(
     ],
     deps = [
         # Vaticle Dependencies
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
         "@vaticle_typeql//java/common:common",
         "@vaticle_typeql//java/pattern:pattern",
         "@vaticle_typeql//java/query:query",


### PR DESCRIPTION
## Usage and product changes

We update Bazel dependencies and target paths following the merging of typedb-common into [vaticle/typeql](https://github.com/vaticle/typeql/) (see https://github.com/vaticle/typeql/pull/313).