### PR TITLE
Generate persistent server ID

### DIFF
--- a/server/TypeDBServer.java
+++ b/server/TypeDBServer.java
@@ -204,27 +204,23 @@ public class TypeDBServer implements AutoCloseable {
 
     protected String serverID() {
         try {
-            return serverIDStored();
+            Path serverIDFile = config().storage().dataDir().resolve(SERVER_ID_FILE_NAME);
+            if (serverIDFile.toFile().exists()) {
+                return Files.readString(serverIDFile);
+            } else {
+                Random random = new Random();
+                String serverID = IntStream.range(0, SERVER_ID_LENGTH).boxed()
+                        .map(i -> SERVER_ID_ALPHABET.charAt(random.nextInt(SERVER_ID_ALPHABET.length())))
+                        .map(String::valueOf)
+                        .collect(Collectors.joining());
+                Files.writeString(serverIDFile, serverID);
+                return serverID;
+            }
         } catch (Exception e) {
             LOG.debug("Failed to create, persist, or read stored server ID: ", e);
         }
         // fallback
         return "_0";
-    }
-
-    private String serverIDStored() throws IOException {
-        Path serverIDFile = config().storage().dataDir().resolve(SERVER_ID_FILE_NAME);
-        if (serverIDFile.toFile().exists()) {
-            return Files.readString(serverIDFile);
-        } else {
-            Random random = new Random();
-            String serverID = IntStream.range(0, SERVER_ID_LENGTH).boxed()
-                    .map(i -> SERVER_ID_ALPHABET.charAt(random.nextInt(SERVER_ID_ALPHABET.length())))
-                    .map(String::valueOf)
-                    .collect(Collectors.joining());
-            Files.writeString(serverIDFile, serverID);
-            return serverID;
-        }
     }
 
     protected io.grpc.Server rpcServer() {

--- a/server/TypeDBServer.java
+++ b/server/TypeDBServer.java
@@ -49,18 +49,11 @@ import java.io.IOException;
 import java.net.BindException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.NetworkInterface;
 import java.net.ServerSocket;
-import java.net.SocketException;
-import java.net.UnknownHostException;
-import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -215,13 +208,6 @@ public class TypeDBServer implements AutoCloseable {
         } catch (Exception e) {
             LOG.debug("Failed to create, persist, or read stored server ID: ", e);
         }
-
-        try {
-            return serverIDNetwork();
-        } catch (Exception e) {
-            LOG.debug("Failed to derive server ID from mac address: ", e);
-        }
-
         // fallback
         return "_0";
     }
@@ -239,13 +225,6 @@ public class TypeDBServer implements AutoCloseable {
             Files.writeString(serverIDFile, serverID);
             return serverID;
         }
-    }
-
-    private String serverIDNetwork() throws UnknownHostException, SocketException, NoSuchAlgorithmException {
-        byte[] mac = NetworkInterface.getByInetAddress(InetAddress.getLocalHost()).getHardwareAddress();
-        byte[] macHash = MessageDigest.getInstance("SHA-256").digest(mac);
-        byte[] truncatedHash = Arrays.copyOfRange(macHash, 0, 8);
-        return String.format("%X", ByteBuffer.wrap(truncatedHash).getLong());
     }
 
     protected io.grpc.Server rpcServer() {

--- a/server/common/Constants.java
+++ b/server/common/Constants.java
@@ -32,4 +32,7 @@ public class Constants {
     public static final String TYPEDB_LOG_FILE_EXT = ".log";
     public static final String TYPEDB_LOG_ARCHIVE_EXT = ".log.gz";
     public static final String DIAGNOSTICS_REPORTING_URI = "https://3d710295c75c81492e57e1997d9e01e1@o4506315929812992.ingest.sentry.io/4506316048629760";
+    public static final String SERVER_ID_FILE_NAME = "_server_id";
+    public static final int SERVER_ID_LENGTH = 16;
+    public static final String SERVER_ID_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 }


### PR DESCRIPTION
## Usage and product changes

We update the server ID to be generated once, then persisted into the server's data directory. A fallback ID of of `_0` is also used if this fails for any reason.

## Implementation

Generate a length 16 string of  upperchase ASCII character and digits, persisted into the data directory. On bootup we read this value, if it exists.