### PR TITLE
Fix apt deployment: correct entry point script

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -171,6 +171,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-x86_64-zip -- snapshot
     deploy-apt-snapshot:
       image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_APT_USERNAME=$REPO_TYPEDB_USERNAME
@@ -188,6 +191,9 @@ build:
 #        bazel run --define version=$(cat VERSION) //:deploy-brew -- snapshot
     test-deployment-apt-x86_64:
       image: vaticle-ubuntu-22.04 # use LTS for apt tests
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies: [deploy-apt-snapshot]
       command: |
         export TEST_DEPLOYMENT_APT_COMMIT=$FACTORY_COMMIT

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -171,9 +171,6 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-x86_64-zip -- snapshot
     deploy-apt-snapshot:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
       dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_APT_USERNAME=$REPO_TYPEDB_USERNAME
@@ -191,9 +188,6 @@ build:
 #        bazel run --define version=$(cat VERSION) //:deploy-brew -- snapshot
     test-deployment-apt-x86_64:
       image: vaticle-ubuntu-22.04 # use LTS for apt tests
-      filter:
-        owner: vaticle
-        branch: [master, development]
       dependencies: [deploy-apt-snapshot]
       command: |
         export TEST_DEPLOYMENT_APT_COMMIT=$FACTORY_COMMIT

--- a/BUILD
+++ b/BUILD
@@ -315,6 +315,7 @@ targz_edit(
     name = "console-artifact-native-arm64.tar.gz",
     src = "@vaticle_typedb_console_artifact_linux-arm64//file",
     strip_components = 1,
+    exclude_globs = ["typedb"],
 )
 
 assemble_apt(

--- a/BUILD
+++ b/BUILD
@@ -280,6 +280,7 @@ targz_edit(
     name = "console-artifact-native-x86_64.tar.gz",
     src = "@vaticle_typedb_console_artifact_linux-x86_64//file",
     strip_components = 1,
+    exclude_globs = ["typedb"],
 )
 
 assemble_apt(

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -3,12 +3,11 @@
 @maven//:com_eclipsesource_minimal_json_minimal_json_0_9_5
 @maven//:com_electronwill_night_config_core_3_6_5
 @maven//:com_electronwill_night_config_toml_3_6_5
-@maven//:com_fasterxml_jackson_core_jackson_core_2_11_3
 @maven//:com_github_ben_manes_caffeine_caffeine_2_8_6
 @maven//:com_google_android_annotations_4_1_1_4
 @maven//:com_google_api_grpc_proto_google_common_protos_2_9_0
-@maven//:com_google_auth_google_auth_library_credentials_0_22_0
-@maven//:com_google_auth_google_auth_library_oauth2_http_0_22_0
+@maven//:com_google_auth_google_auth_library_credentials_1_6_0
+@maven//:com_google_auth_google_auth_library_oauth2_http_1_6_0
 @maven//:com_google_auto_value_auto_value_1_9
 @maven//:com_google_auto_value_auto_value_annotations_1_9
 @maven//:com_google_code_findbugs_jsr305_3_0_2
@@ -18,7 +17,7 @@
 @maven//:com_google_guava_guava_30_1_jre
 @maven//:com_google_guava_listenablefuture_9999_0_empty_to_avoid_conflict_with_guava
 @maven//:com_google_http_client_google_http_client_1_34_2
-@maven//:com_google_http_client_google_http_client_jackson2_1_37_0
+@maven//:com_google_http_client_google_http_client_gson_1_41_4
 @maven//:com_google_j2objc_j2objc_annotations_1_3
 @maven//:com_google_ortools_ortools_darwin_aarch64_9_6_2534
 @maven//:com_google_ortools_ortools_darwin_x86_64_9_6_2534

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,14 +21,14 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "4a01d09ef542a423ced909db9a61291dc0a6acc5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "c473d17530dff5a4398d2de9c9fe966df9aca4ce",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )
 
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "3bd3fbcda4567dcea41f941eb6073b8673ba2a17", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "a97a8cf4d764384d5ea09621f836856dfe0845c8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():


### PR DESCRIPTION
## Usage and product changes

When assembling a server + console bundle for apt deployment, the console entry point would sometimes override the bundle entry point, making the server inaccessible. We resolve that issue by explicitly filtering out the console entry point during assembly.