### PR TITLE
Fix commit-time cleanup of chains of empty relations

### DIFF
--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -376,7 +376,7 @@ public final class ConceptManager {
             deleted = graphMgr.data().writeVertices()
                     .filter(v -> v.existence().equals(STORED) && v.isModified() && v.encoding().equals(RELATION))
                     .map(v -> ThingImpl.of(this, v).asRelation().deleteIfNoPlayer())
-                    .anyMatch(d -> d);
+                    .reduce(false, ((acc, val) -> acc || val));
         }
     }
 

--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -371,10 +371,13 @@ public final class ConceptManager {
     }
 
     public void cleanupRelations() {
-        graphMgr.data().writeVertices()
-                .filter(v -> v.existence().equals(STORED) && v.isModified() && v.encoding().equals(RELATION))
-                .forEachRemaining(v -> ThingImpl.of(this, v).asRelation().deleteIfNoPlayer());
-
+        boolean deleted = true;
+        while (deleted) {
+            deleted = graphMgr.data().writeVertices()
+                    .filter(v -> v.existence().equals(STORED) && v.isModified() && v.encoding().equals(RELATION))
+                    .map(v -> ThingImpl.of(this, v).asRelation().deleteIfNoPlayer())
+                    .anyMatch(d -> d);
+        }
     }
 
     public void validateThings() {

--- a/concept/thing/impl/RelationImpl.java
+++ b/concept/thing/impl/RelationImpl.java
@@ -107,8 +107,13 @@ public class RelationImpl extends ThingImpl implements Relation {
         super.delete();
     }
 
-    public void deleteIfNoPlayer() {
-        if (!writableVertex().outs().edge(RELATING).to().hasNext()) this.delete();
+    public boolean deleteIfNoPlayer() {
+        if (!writableVertex().outs().edge(RELATING).to().hasNext()) {
+            this.delete();
+            return true;
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,6 +48,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "483eac8b122cbafe5ea154580b98aa671e51ea35",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
+        commit = "b6985e8c50379ae12d763232a984f1865696d2b7",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,6 +48,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-        commit = "b6985e8c50379ae12d763232a984f1865696d2b7",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "031ab431f14f86b0ceed3b12bed8267f88868c72",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )


### PR DESCRIPTION
## Usage and product changes

In cases where chains of empty relations existed, for example `r1 -> r2 -> r3... -> rX`,  it was possible that TypeDB did not correctly execute the automatic relation cleanup due to the order the relations happened to be traversed.

TypeDB now retries the commit-time cleanup of empty relations until there are no new deletions. We accept the higher runtime cost of this operation since 1) we expect the number of modified relations in a transaction to be relatively small (no more than thousands) 2) relation chains are relatively rare 3) relation chains that must clean up in dependent fashion are extremely rare.

## Implementation

* Add a loop that retries relation cleanup until no more relations are deleted.
