### PR TITLE
Fix bug when overriding committed role-types with newly defined role-types  

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,7 +35,7 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        tag = "2.26.6-rc0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        commit = "bf830772903e71f7aaec84dd9a4ea6114e111536",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_protocol():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,6 +48,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "031ab431f14f86b0ceed3b12bed8267f88868c72",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "324b5f46556d27083a7a724b222d4b623c54eee5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -48,6 +48,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "324b5f46556d27083a7a724b222d4b623c54eee5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/vaticle/typedb-behaviour",
+        commit = "5c8b8a15134a9b82f285f9405498e2409163de59",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -49,5 +49,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "5c8b8a15134a9b82f285f9405498e2409163de59",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "0d000e49669f9812c9de7322e82188084c88cfd7",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/graph/edge/impl/TypeEdgeImpl.java
+++ b/graph/edge/impl/TypeEdgeImpl.java
@@ -489,7 +489,7 @@ public abstract class TypeEdgeImpl implements TypeEdge {
             if (overridden.isFirst()) {
                 overridden = Either.second(overridden.first() != null ? graph.convert(overridden.first()) : null);
             }
-            return Optional.of(overridden.second());
+            return Optional.ofNullable(overridden.second());
         }
 
         /**

--- a/test/behaviour/query/TypeQLSteps.java
+++ b/test/behaviour/query/TypeQLSteps.java
@@ -88,8 +88,15 @@ public class TypeQLSteps {
 
     @Given("typeql define")
     public void typeql_define(String defineQueryStatements) {
-        TypeQLDefine typeQLQuery = TypeQL.parseQuery(String.join("\n", defineQueryStatements)).asDefine();
-        tx().query().define(typeQLQuery);
+        try {
+            TypeQLDefine typeQLQuery = TypeQL.parseQuery(String.join("\n", defineQueryStatements)).asDefine();
+            tx().query().define(typeQLQuery);
+        } catch (TypeQLException e) {
+            // NOTE: We manually close transaction here, because we want to align with all non-java drivers,
+            // where parsing happens at server-side which closes transaction if they fail
+            tx().close();
+            throw e;
+        }
     }
 
     @Given("typeql define; throws exception containing {string}")


### PR DESCRIPTION
## Usage and product changes
Fixes a bug which creates an invalid override when a committed role-type is overridden with a newly defined role-type.

## Implementation
Updates `TypeEdgeImpl.Persisted` to treat overrides as `TypeEdgeImpl.Buffered` does - Writing to the transaction is delayed to the `commit()`  method, by when the overridden vertex will have been translated.

fixes #6985 
