### PR TITLE
Fix schema export of overridden plays edge

### DIFF
--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -204,7 +204,7 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
             RoleType overridden = getPlaysOverridden(roleType);
             if (overridden != null) {
                 builder.append(SPACE).append(TypeQLToken.Constraint.AS).append(SPACE)
-                        .append(overridden.getLabel().scopedName());
+                        .append(overridden.getLabel().name());
             }
         });
     }


### PR DESCRIPTION
## Usage and product changes
Make schema exports consistent with the TypeQL spec of overridden roles in 'plays' declarations being unscoped labels. 

## Implementation
* `ThingTypeImpl.getSyntax()` exports overridden role-types in 'plays' edges as unstopped labels. 

- fixes vaticle/typeql#312