### PR TITLE
Add flag to config to easily enable or disable loggers

### DIFF
--- a/server/logging/CoreLogback.java
+++ b/server/logging/CoreLogback.java
@@ -65,11 +65,14 @@ public class CoreLogback {
                                                                                LoggerContext logContext,
                                                                                LayoutWrappingEncoder<EVENT> encoder,
                                                                                CoreConfig.Common.Output.Type outputType) {
+        Appender<EVENT> appender;
         if (outputType.isStdout()) {
-            return consoleAppender(name, logContext, encoder);
+            appender = consoleAppender(name, logContext, encoder);
         } else if (outputType.isFile()) {
-            return fileAppender(name, logContext, encoder, outputType.asFile());
+            appender = fileAppender(name, logContext, encoder, outputType.asFile());
         } else throw TypeDBException.of(ILLEGAL_STATE);
+        if (outputType.enabled()) appender.start();
+        return appender;
     }
 
     private static void configureLogger(CoreConfig.Log.Logger.Filtered logger, LoggerContext context,
@@ -101,7 +104,6 @@ public class CoreLogback {
         appender.setContext(context);
         appender.setName(name);
         appender.setEncoder(encoder);
-        appender.start();
         return appender;
     }
 
@@ -127,7 +129,6 @@ public class CoreLogback {
         policy.setParent(appender);
         policy.start();
         appender.setRollingPolicy(policy);
-        appender.start();
         return appender;
     }
 

--- a/server/parameters/CoreConfig.java
+++ b/server/parameters/CoreConfig.java
@@ -85,6 +85,16 @@ public class CoreConfig {
 
             public static abstract class Type {
 
+                private final boolean enable;
+
+                protected Type(boolean enable) {
+                    this.enable = enable;
+                }
+
+                public boolean enabled() {
+                    return enable;
+                }
+
                 public boolean isStdout() {
                     return false;
                 }
@@ -103,7 +113,8 @@ public class CoreConfig {
 
                 public static class Stdout extends Type {
 
-                    Stdout() {
+                    Stdout(boolean enable) {
+                        super(enable);
                     }
 
                     @Override
@@ -127,9 +138,10 @@ public class CoreConfig {
                     private final String filename;
                     private final String extension;
 
-                    File(Path baseDirectory, String filename, String extension,
+                    File(boolean enable, Path baseDirectory, String filename, String extension,
                          long fileSizeLimit, YAMLParser.Value.TimePeriodName archiveGrouping,
                          YAMLParser.Value.TimePeriod archiveAgeLimit, long archivesSizeLimit) {
+                        super(enable);
                         this.baseDirectory = baseDirectory;
                         this.filename = filename;
                         this.extension = extension;

--- a/server/parameters/CoreConfigParser.java
+++ b/server/parameters/CoreConfigParser.java
@@ -139,12 +139,12 @@ public class CoreConfigParser extends YAMLParser.Value.Compound<CoreConfig> {
                     public static final String type = "stdout";
                     public static final String description = "Options to configure a log output to stdout.";
 
-                    private static final Predefined<Boolean> enable =
-                            predefined("enable", "Enable logging to stdout.", BOOLEAN);
                     private static final Predefined<String> typeParser = predefined(
                             "type", "An output that writes to stdout.", restricted(STRING, list(type))
                     );
-                    private static final Set<Predefined<?>> parsers = set(enable, typeParser);
+                    private static final Predefined<Boolean> enable =
+                            predefined("enable", "Enable logging to stdout.", BOOLEAN);
+                    private static final Set<Predefined<?>> parsers = set(typeParser, enable);
 
                     @Override
                     public CoreConfig.Common.Output.Type.Stdout parse(YAML yaml, String path) {
@@ -159,7 +159,7 @@ public class CoreConfigParser extends YAMLParser.Value.Compound<CoreConfig> {
 
                     @Override
                     public List<com.vaticle.typedb.core.server.parameters.util.Help> helpList(String path) {
-                        return list(typeParser.help(path));
+                        return list(typeParser.help(path), enable.help(path));
                     }
                 }
 
@@ -168,10 +168,10 @@ public class CoreConfigParser extends YAMLParser.Value.Compound<CoreConfig> {
                     public static final String type = "file";
                     public static final String description = "Options to configure a log output to files in a directory.";
 
-                    private static final Predefined<Boolean> enable =
-                            predefined("enable", "Enable logging to the file.", BOOLEAN);
                     private static final Predefined<String> typeParser =
                             predefined("type", "An output that writes to a directory.", restricted(STRING, list(type)));
+                    private static final Predefined<Boolean> enable =
+                            predefined("enable", "Enable logging to the file.", BOOLEAN);
                     private static final Predefined<Path> baseDirectory =
                             predefined("base-dir", "Directory to write to. Relative paths are relative to distribution path.", PATH);
                     private static final Predefined<Long> fileSizeLimit =
@@ -187,7 +187,7 @@ public class CoreConfigParser extends YAMLParser.Value.Compound<CoreConfig> {
                                     BYTES_SIZE
                             ); // TODO reasoner needs to respect this
                     private static final Set<Predefined<?>> parsers = set(
-                            enable, typeParser, baseDirectory, fileSizeLimit, archiveGrouping, archiveAgeLimit, archivesSizeLimit
+                            typeParser, enable, baseDirectory, fileSizeLimit, archiveGrouping, archiveAgeLimit, archivesSizeLimit
                     );
 
                     private final String filename;
@@ -220,7 +220,7 @@ public class CoreConfigParser extends YAMLParser.Value.Compound<CoreConfig> {
 
                     @Override
                     public List<com.vaticle.typedb.core.server.parameters.util.Help> helpList(String path) {
-                        return list(typeParser.help(path), baseDirectory.help(path),
+                        return list(typeParser.help(path), enable.help(path), baseDirectory.help(path),
                                 fileSizeLimit.help(path), archiveGrouping.help(path), archiveAgeLimit.help(path),
                                 archivesSizeLimit.help(path));
                     }

--- a/server/parameters/CoreConfigParser.java
+++ b/server/parameters/CoreConfigParser.java
@@ -139,10 +139,12 @@ public class CoreConfigParser extends YAMLParser.Value.Compound<CoreConfig> {
                     public static final String type = "stdout";
                     public static final String description = "Options to configure a log output to stdout.";
 
+                    private static final Predefined<Boolean> enable =
+                            predefined("enable", "Enable logging to stdout.", BOOLEAN);
                     private static final Predefined<String> typeParser = predefined(
                             "type", "An output that writes to stdout.", restricted(STRING, list(type))
                     );
-                    private static final Set<Predefined<?>> parsers = set(typeParser);
+                    private static final Set<Predefined<?>> parsers = set(enable, typeParser);
 
                     @Override
                     public CoreConfig.Common.Output.Type.Stdout parse(YAML yaml, String path) {
@@ -150,7 +152,8 @@ public class CoreConfigParser extends YAMLParser.Value.Compound<CoreConfig> {
                             validatePredefinedKeys(parsers, yaml.asMap().keys(), path);
                             String type = typeParser.parse(yaml.asMap(), path);
                             assert Stdout.type.equals(type);
-                            return new CoreConfig.Common.Output.Type.Stdout();
+                            boolean enabled = enable.parse(yaml.asMap(), path);
+                            return new CoreConfig.Common.Output.Type.Stdout(enabled);
                         } else throw TypeDBException.of(CONFIG_SECTION_MUST_BE_MAP, path);
                     }
 
@@ -165,6 +168,8 @@ public class CoreConfigParser extends YAMLParser.Value.Compound<CoreConfig> {
                     public static final String type = "file";
                     public static final String description = "Options to configure a log output to files in a directory.";
 
+                    private static final Predefined<Boolean> enable =
+                            predefined("enable", "Enable logging to the file.", BOOLEAN);
                     private static final Predefined<String> typeParser =
                             predefined("type", "An output that writes to a directory.", restricted(STRING, list(type)));
                     private static final Predefined<Path> baseDirectory =
@@ -182,7 +187,7 @@ public class CoreConfigParser extends YAMLParser.Value.Compound<CoreConfig> {
                                     BYTES_SIZE
                             ); // TODO reasoner needs to respect this
                     private static final Set<Predefined<?>> parsers = set(
-                            typeParser, baseDirectory, fileSizeLimit, archiveGrouping, archiveAgeLimit, archivesSizeLimit
+                            enable, typeParser, baseDirectory, fileSizeLimit, archiveGrouping, archiveAgeLimit, archivesSizeLimit
                     );
 
                     private final String filename;
@@ -201,6 +206,7 @@ public class CoreConfigParser extends YAMLParser.Value.Compound<CoreConfig> {
                             String type = typeParser.parse(yaml.asMap(), path);
                             assert File.type.equals(type);
                             return new CoreConfig.Common.Output.Type.File(
+                                    enable.parse(yaml.asMap(), path),
                                     configPathAbsolute(baseDirectory.parse(yaml.asMap(), path)),
                                     filename,
                                     extension,

--- a/server/parameters/config.yml
+++ b/server/parameters/config.yml
@@ -30,8 +30,10 @@ storage:
 log:
   output:
     stdout:
+      enable: true
       type: stdout
     file:
+      enable: true
       type: file
       base-dir: server/logs
       file-size-limit: 50mb

--- a/server/parameters/config.yml
+++ b/server/parameters/config.yml
@@ -30,11 +30,11 @@ storage:
 log:
   output:
     stdout:
-      enable: true
       type: stdout
-    file:
       enable: true
+    file:
       type: file
+      enable: true
       base-dir: server/logs
       file-size-limit: 50mb
       archive-grouping: month

--- a/server/test/parameters/config/config-invalid-logger-output.yml
+++ b/server/test/parameters/config/config-invalid-logger-output.yml
@@ -28,8 +28,10 @@ log:
   output:
     stdout:
       type: stdout
+      enable: true
     file:
       type: file
+      enable: true
       base-dir: server/logs
       file-size-limit: 50mb
       archive-grouping: month

--- a/server/test/parameters/config/config-minimal-abs-path.yml
+++ b/server/test/parameters/config/config-minimal-abs-path.yml
@@ -28,8 +28,10 @@ log:
   output:
     stdout:
       type: stdout
+      enable: true
     file:
       type: file
+      enable: true
       base-dir: /absolute/path/to/logs/dir
       file-size-limit: 50mb
       archive-grouping: month

--- a/server/test/parameters/config/config-missing-debugger.yml
+++ b/server/test/parameters/config/config-missing-debugger.yml
@@ -29,8 +29,10 @@ log:
   output:
     stdout:
       type: stdout
+      enable: true
     file:
       type: file
+      enable: true
       base-dir: server/logs
       file-size-limit: 50mb
       archive-grouping: month


### PR DESCRIPTION
## Usage and product changes
Adds an 'enable' flag to the logger output config for easy enabling/disabling.

## Implementation
* Adds flag `log.output.(name).enable` and propagates changes to config objects & parser.
* An appender is still added to the list of appenders, but is only started if it is enabled.
