### PR TITLE
Rename TypeDB Enterprise to TypeDB Cloud

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -9,7 +9,7 @@ labels: bug
 
 ## Environment
 
-1. TypeDB distribution: Core/Enterprise/Cloud
+1. TypeDB distribution: Core/Cloud
 2. TypeDB version:
 3. Environment: Linux/Mac/Windows/TypeDB Cloud/Google Cloud/AWS/Azure
 4. Client and version:

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ TypeDB breaks down the patchwork of existing database paradigms into three funda
 ### TypeDB editions
 
 * [TypeDB Cloud](https://cloud.typedb.com) — multi-cloud DBaaS
-* [TypeDB Enterprise](mailto://sales@vaticle.com) — Enterprise edition of TypeDB
+* [TypeDB Cloud self-hosted](mailto://sales@vaticle.com) — allows you to deploy TypeDB Cloud in your own environment
 * **TypeDB Core** — Open-source edition of TypeDB ← _This repository_
 
 For a comparison of all three editions, see the [Deploy](https://typedb.com/deploy) page on our website.
@@ -240,7 +240,7 @@ This software is developed by [Vaticle](https://vaticle.com/).
 It's released under the GNU Affero GENERAL PUBLIC LICENSE version 3 (AGPL v.3.0).
 For license information, please see [LICENSE](https://github.com/vaticle/typedb/blob/master/LICENSE). 
 
-Vaticle also provides a commercial license for TypeDB Enterprise - get in touch with our team at 
+Vaticle also provides a commercial license for TypeDB Cloud self-hosted - get in touch with our team at 
 [commercial@vaticle.com](emailto://sales@vaticle.com).
 
 Copyright (C) 2023 Vaticle.

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -110,7 +110,7 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final Server ERROR_LOGGING_CONNECTIONS =
                 new Server(36, "An error occurred while logging server connection info.");
         public static final Server USER_MANAGEMENT_NOT_AVAILABLE =
-                new Server(37, "User management is only available in TypeDB Enterprise.");
+                new Server(37, "User management is only available in TypeDB Cloud.");
 
         private static final String codePrefix = "SRV";
         private static final String messagePrefix = "Invalid Server Operation";

--- a/encoding/Encoding.java
+++ b/encoding/Encoding.java
@@ -149,7 +149,7 @@ public class Encoding {
      * The values in this class will be used as 'prefixes' within an IID for every database object,
      * and must not overlap with each other.
      * <p>
-     * A prefix is 1 unsigned byte, up to the value of 179. Values 180-255 are reserved for TypeDB Enterprise.
+     * A prefix is 1 unsigned byte, up to the value of 179. Values 180-255 are reserved for TypeDB Cloud.
      */
     public enum Prefix {
         SYSTEM(0, PrefixType.SYSTEM),
@@ -191,7 +191,7 @@ public class Encoding {
         private final ByteArray bytes;
 
         Prefix(int key, PrefixType type) {
-            assert key < 180 : "The encoding range >= 180 is reserved for TypeDB Enterprise.";
+            assert key < 180 : "The encoding range >= 180 is reserved for TypeDB Cloud.";
             this.key = unsignedByte(key);
             this.type = type;
             this.bytes = ByteArray.of(new byte[]{this.key});

--- a/tool/runner/Util.java
+++ b/tool/runner/Util.java
@@ -78,7 +78,7 @@ public class Util {
         } else {
             throw new IllegalStateException(String.format("The distribution archive format must be either %s or %s", TAR_GZ, ZIP));
         }
-        // The TypeDB Enterprise archive extracts to a folder inside TYPEDB_TARGET_DIRECTORY named
+        // The TypeDB Cloud archive extracts to a folder inside TYPEDB_TARGET_DIRECTORY named
         // typedb-server-{platform}-{version}. We know it's the only folder, so we can retrieve it using Files.list.
         return Files.list(runnerDir).findFirst().get().toAbsolutePath();
     }


### PR DESCRIPTION
## Usage and product changes

Whenever an error message previously referred to TypeDB "Enterprise" edition, it now refers to "Cloud" instead.

## Implementation

- Update all remaining references to TypeDB Enterprise to refer to Cloud instead.