### PR TITLE
WAL

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -84,6 +84,7 @@ rust_register_toolchains(
         "x86_64-unknown-linux-gnu",
     ],
     rust_analyzer_version = rust_common.default_version,
+    versions = ["1.76.0"],
 )
 
 rust_analyzer_toolchain_tools_repository(

--- a/common/primitive/primitives.rs
+++ b/common/primitive/primitives.rs
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::ops::{Add, Sub};
-
 pub mod maybe_owns;
 pub mod u80;
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "8545840466c5c04dda7339ebf0e1ecad81424413",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "b9ecf840ae3d3c8c7c1b7d6353e1089e1f2d6ad5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():

--- a/storage/durability/benches/BUILD
+++ b/storage/durability/benches/BUILD
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+load("@rules_rust//rust:defs.bzl", "rust_test", "rust_binary")
+package(default_visibility = ["//visibility:public",])
+
+# bazel test --compilation_mode=opt //storage/durability/benches:throughput --test_arg=--bench
+rust_test(
+    name = "throughput",
+    srcs = ["throughput.rs"],
+    deps = [
+        "//storage/durability:durability",
+
+        "@crates//:bincode",
+        "@crates//:criterion",
+        "@crates//:itertools",
+        "@crates//:tempdir",
+    ],
+    use_libtest_harness = False,
+)
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    license_type = "agpl-header",
+)
+

--- a/storage/durability/benches/throughput.rs
+++ b/storage/durability/benches/throughput.rs
@@ -62,7 +62,7 @@ fn throughput_small(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("throughput");
     group.throughput(Throughput::Bytes(serialized_len as u64));
-    group.bench_function("write", |b| b.iter(|| wal.sequenced_write(&message).unwrap()));
+    group.bench_function("write_small", |b| b.iter(|| wal.sequenced_write(&message).unwrap()));
     group.finish();
 }
 
@@ -79,7 +79,7 @@ fn throughput_large(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("throughput");
     group.throughput(Throughput::Bytes(serialized_len as u64));
-    group.bench_function("write", |b| b.iter(|| wal.sequenced_write(&message).unwrap()));
+    group.bench_function("write_large", |b| b.iter(|| wal.sequenced_write(&message).unwrap()));
     group.finish();
 }
 

--- a/storage/durability/benches/throughput.rs
+++ b/storage/durability/benches/throughput.rs
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use std::path::Path;
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use durability::{wal::WAL, DurabilityRecord, DurabilityRecordType, DurabilityService};
+use tempdir::TempDir;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct TestRecord {
+    pub bytes: Vec<u8>,
+}
+
+impl DurabilityRecord for TestRecord {
+    const RECORD_TYPE: DurabilityRecordType = 0;
+    const RECORD_NAME: &'static str = "TEST";
+
+    fn serialise_into(&self, writer: &mut impl std::io::Write) -> bincode::Result<()> {
+        writer.write_all(&self.bytes)?;
+        Ok(())
+    }
+
+    fn deserialize_from(reader: &mut impl std::io::Read) -> bincode::Result<Self> {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes)?;
+        Ok(Self { bytes })
+    }
+}
+
+pub fn open_wal(directory: impl AsRef<Path>) -> WAL {
+    let mut wal = WAL::open(directory).unwrap();
+    wal.register_record_type::<TestRecord>();
+    wal
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let directory = TempDir::new("wal-test").unwrap();
+    let wal = open_wal(&directory);
+
+    let message = TestRecord { bytes: b"hello world".to_vec() };
+    let serialized_len = {
+        let mut buf = Vec::new();
+        message.serialise_into(&mut buf).unwrap();
+        buf.len()
+    };
+
+    let mut group = c.benchmark_group("throughput");
+    group.throughput(Throughput::Bytes(serialized_len as u64));
+    group.bench_function("write", |b| b.iter(|| wal.sequenced_write(&message).unwrap()));
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/storage/durability/durability.rs
+++ b/storage/durability/durability.rs
@@ -85,6 +85,7 @@ pub trait DurabilityService: Sequencer {
 
     fn iter_from(&self, sequence_number: SequenceNumber) -> impl Iterator<Item = io::Result<RawRecord>>;
 
+    fn checkpoint(&self) -> Result<()>;
     fn recover(&self) -> impl Iterator<Item = io::Result<RawRecord>>;
 }
 

--- a/storage/durability/durability.rs
+++ b/storage/durability/durability.rs
@@ -33,36 +33,36 @@ pub mod wal;
 
 pub type Result<T> = std::result::Result<T, DurabilityError>;
 
-///
-/// Notes:
-///     We can provide to a DurabilityService for Records
-///     Records have a serialised Byte representations and type (ID)
-///
-///     We have two choices:
-///         1. Long files (~ 100s MB) with many records embedded into fixed-sized blocks (fixed size = seekable)
-///         2. Shorter files (~ 10s MB) without fixed sized blocks internally.
-///
-///     We should aim to minimise the amount of data ending on the Disk, which means compression is critical.
-///     For this, having rolling shorter files that are compressed in larger, irregular chunks as they are written,
-///     is more optimal. Having rolling shorter files named by the first sequence number they contain,
-///     still allows skipping through the logical WAL by binary searching file names,
-///     then doing a scan through 10s of MB of data. This is acceptable if:
-///         1. we rarely need to do point look ups in data (iterating is amortises the cost)
-///         2. the costs of reading 10s of extra MB during a lookup is acceptable to overall performance.
-///
-///     Either solution will allow writing SerialisedRecord (data + type tag), and retrieving SerialisedRecords.
-///
-///     The final piece of the puzzle will be: how do we ensure with very high likelihood that we don't have two
-///     different implementations of SerialisedRecord using the same type tag?
-///
-///     First idea:
-///         On creation, we register a "name" and "type ID" against the DurabilityService.
-///         The service only serialises Records of a TypeID + Name that have been recognised - this can fail with a debug_assert
-///         The service should check that all TypeIDs registered have a different Name.
-///
-/// Other questions:
-///     1. Recovery/Checksum requirements - what are the failure modes
-///     2. How to benchmark
+//
+// Notes:
+//     We can provide to a DurabilityService for Records
+//     Records have a serialised Byte representations and type (ID)
+//
+//     We have two choices:
+//         1. Long files (~ 100s MB) with many records embedded into fixed-sized blocks (fixed size = seekable)
+//         2. Shorter files (~ 10s MB) without fixed sized blocks internally.
+//
+//     We should aim to minimise the amount of data ending on the Disk, which means compression is critical.
+//     For this, having rolling shorter files that are compressed in larger, irregular chunks as they are written,
+//     is more optimal. Having rolling shorter files named by the first sequence number they contain,
+//     still allows skipping through the logical WAL by binary searching file names,
+//     then doing a scan through 10s of MB of data. This is acceptable if:
+//         1. we rarely need to do point look ups in data (iterating is amortises the cost)
+//         2. the costs of reading 10s of extra MB during a lookup is acceptable to overall performance.
+//
+//     Either solution will allow writing SerialisedRecord (data + type tag), and retrieving SerialisedRecords.
+//
+//     The final piece of the puzzle will be: how do we ensure with very high likelihood that we don't have two
+//     different implementations of SerialisedRecord using the same type tag?
+//
+//     First idea:
+//         On creation, we register a "name" and "type ID" against the DurabilityService.
+//         The service only serialises Records of a TypeID + Name that have been recognised - this can fail with a debug_assert
+//         The service should check that all TypeIDs registered have a different Name.
+//
+// Other questions:
+//     1. Recovery/Checksum requirements - what are the failure modes
+//     2. How to benchmark
 
 #[derive(Debug)]
 struct RecordHeader {

--- a/storage/durability/durability.rs
+++ b/storage/durability/durability.rs
@@ -31,37 +31,6 @@ pub mod wal;
 
 pub type Result<T> = std::result::Result<T, DurabilityError>;
 
-//
-// Notes:
-//     We can provide to a DurabilityService for Records
-//     Records have a serialised Byte representations and type (ID)
-//
-//     We have two choices:
-//         1. Long files (~ 100s MB) with many records embedded into fixed-sized blocks (fixed size = seekable)
-//         2. Shorter files (~ 10s MB) without fixed sized blocks internally.
-//
-//     We should aim to minimise the amount of data ending on the Disk, which means compression is critical.
-//     For this, having rolling shorter files that are compressed in larger, irregular chunks as they are written,
-//     is more optimal. Having rolling shorter files named by the first sequence number they contain,
-//     still allows skipping through the logical WAL by binary searching file names,
-//     then doing a scan through 10s of MB of data. This is acceptable if:
-//         1. we rarely need to do point look ups in data (iterating is amortises the cost)
-//         2. the costs of reading 10s of extra MB during a lookup is acceptable to overall performance.
-//
-//     Either solution will allow writing SerialisedRecord (data + type tag), and retrieving SerialisedRecords.
-//
-//     The final piece of the puzzle will be: how do we ensure with very high likelihood that we don't have two
-//     different implementations of SerialisedRecord using the same type tag?
-//
-//     First idea:
-//         On creation, we register a "name" and "type ID" against the DurabilityService.
-//         The service only serialises Records of a TypeID + Name that have been recognised - this can fail with a debug_assert
-//         The service should check that all TypeIDs registered have a different Name.
-//
-// Other questions:
-//     1. Recovery/Checksum requirements - what are the failure modes
-//     2. How to benchmark
-
 #[derive(Debug)]
 struct RecordHeader {
     sequence_number: SequenceNumber,

--- a/storage/durability/durability.rs
+++ b/storage/durability/durability.rs
@@ -54,6 +54,16 @@ pub trait DurabilityService: Sequencer {
 
     fn iter_from(&self, sequence_number: SequenceNumber) -> io::Result<impl Iterator<Item = io::Result<RawRecord>>>;
 
+    fn iter_type_from<Record: DurabilityRecord>(
+        &self,
+        sequence_number: SequenceNumber,
+    ) -> io::Result<impl Iterator<Item = Result<(SequenceNumber, Record)>>> {
+        Ok(self.iter_from(sequence_number)?.map(|res| {
+            let raw = res?;
+            Ok((raw.sequence_number, Record::deserialize_from(&mut &*raw.bytes)?))
+        }))
+    }
+
     fn checkpoint(&self) -> Result<()>;
     fn recover(&self) -> io::Result<impl Iterator<Item = io::Result<RawRecord>>>;
 }

--- a/storage/durability/durability.rs
+++ b/storage/durability/durability.rs
@@ -24,10 +24,8 @@ use std::{
     io::{self, Read, Write},
 };
 
-use primitive::U80;
-use serde::{Deserialize, Serialize};
-
 use primitive::u80::U80;
+use serde::{Deserialize, Serialize};
 
 pub mod wal;
 

--- a/storage/durability/durability.rs
+++ b/storage/durability/durability.rs
@@ -85,10 +85,10 @@ pub trait DurabilityService: Sequencer {
     where
         Record: DurabilityRecord;
 
-    fn iter_from(&self, sequence_number: SequenceNumber) -> impl Iterator<Item = io::Result<RawRecord>>;
+    fn iter_from(&self, sequence_number: SequenceNumber) -> io::Result<impl Iterator<Item = io::Result<RawRecord>>>;
 
     fn checkpoint(&self) -> Result<()>;
-    fn recover(&self) -> impl Iterator<Item = io::Result<RawRecord>>;
+    fn recover(&self) -> io::Result<impl Iterator<Item = io::Result<RawRecord>>>;
 }
 
 pub type DurabilityRecordType = u8;
@@ -146,6 +146,12 @@ impl SequenceNumber {
 
     pub const fn serialised_len() -> usize {
         U80::BYTES
+    }
+}
+
+impl From<u128> for SequenceNumber {
+    fn from(value: u128) -> Self {
+        Self::new(U80::new(value))
     }
 }
 

--- a/storage/durability/durability.rs
+++ b/storage/durability/durability.rs
@@ -64,12 +64,14 @@ pub type Result<T> = std::result::Result<T, DurabilityError>;
 ///     1. Recovery/Checksum requirements - what are the failure modes
 ///     2. How to benchmark
 
+#[derive(Debug)]
 struct RecordHeader {
     sequence_number: SequenceNumber,
     len: u32,
     record_type: DurabilityRecordType,
 }
 
+#[derive(Debug)]
 pub struct RawRecord {
     pub sequence_number: SequenceNumber,
     pub record_type: DurabilityRecordType,

--- a/storage/durability/tests/BUILD
+++ b/storage/durability/tests/BUILD
@@ -16,30 +16,50 @@
 #
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 package(default_visibility = ["//visibility:public",])
 
-rust_library(
-    name = "durability",
-    crate_root = "durability.rs",
-    srcs = glob([
-        "*.rs",
-    ]),
+rust_test(
+    name = "basic",
+    crate_root = "basic.rs",
+    srcs = glob(["common/*.rs"]) + ["basic.rs"],
     deps = [
-        "//common/logger",
-        "//common/primitive",
-
+        "//storage/durability:durability",
         "@crates//:bincode",
-        "@crates//:lz4",
+        "@crates//:tempdir",
+    ],
+)
+
+rust_binary(
+    name = "streamer",
+    crate_root = "streamer.rs",
+    srcs = glob(["common/*.rs"]) + ["streamer.rs"],
+    deps = [
+        "//storage/durability:durability",
+        "@crates//:bincode",
         "@crates//:itertools",
-        "@crates//:serde",
-        "@crates//:tracing",
-    ]
+    ],
+)
+
+rust_binary(
+    name = "recoverer",
+    crate_root = "recoverer.rs",
+    srcs = glob(["common/*.rs"]) + ["recoverer.rs"],
+    deps = [
+        "//storage/durability:durability",
+        "@crates//:bincode",
+    ],
 )
 
 rust_test(
-    name = "durability_unit_tests",
-    crate = ":durability",
+    name = "crash",
+    crate_root = "crash.rs",
+    srcs = ["crash.rs"],
+    env = {
+        "TEST_WAL_STREAMER": "$(rootpath :streamer)",
+        "TEST_WAL_RECOVERER": "$(rootpath :recoverer)",
+    },
+    data = [":streamer", ":recoverer"],
     deps = ["@crates//:tempdir"],
 )
 

--- a/storage/durability/tests/basic.rs
+++ b/storage/durability/tests/basic.rs
@@ -69,6 +69,7 @@ fn basic() {
     drop(wal);
 
     let wal = open_wal(&directory);
+
     let mut recovery_iterator = wal.recover();
     let RawRecord { sequence_number, record_type, bytes } = recovery_iterator.next().unwrap().unwrap();
     assert_eq!(sequence_number, written_entry_id);

--- a/storage/durability/tests/basic.rs
+++ b/storage/durability/tests/basic.rs
@@ -37,7 +37,7 @@ fn basic() {
     drop(wal);
 
     let wal = open_wal(&directory);
-    let raw_record = wal.iter_from(written_entry_id).next().unwrap().unwrap();
+    let raw_record = wal.iter_from(written_entry_id).unwrap().next().unwrap().unwrap();
     let read_record = TestRecord::deserialize_from(&mut &*raw_record.bytes).unwrap();
     assert_eq!(read_record, message);
     wal.checkpoint().unwrap();
@@ -47,7 +47,7 @@ fn basic() {
 
     let wal = open_wal(&directory);
 
-    let mut recovery_iterator = wal.recover();
+    let mut recovery_iterator = wal.recover().unwrap();
     let RawRecord { sequence_number, record_type, bytes } = recovery_iterator.next().unwrap().unwrap();
     assert_eq!(sequence_number, written_entry_id);
     assert_eq!(record_type, TestRecord::RECORD_TYPE);
@@ -59,6 +59,6 @@ fn basic() {
     drop(wal);
 
     let wal = open_wal(&directory);
-    let mut recovery_iterator = wal.recover();
+    let mut recovery_iterator = wal.recover().unwrap();
     assert!(recovery_iterator.next().is_none());
 }

--- a/storage/durability/tests/basic.rs
+++ b/storage/durability/tests/basic.rs
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2023 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#![deny(unused_must_use)]
+#![deny(rust_2018_idioms)]
+
+use durability::{wal::WAL, DurabilityRecord, DurabilityRecordType, DurabilityService, RawRecord};
+use tempdir::TempDir;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+struct TestRecord {
+    bytes: Vec<u8>,
+}
+
+impl DurabilityRecord for TestRecord {
+    const RECORD_TYPE: DurabilityRecordType = 0;
+    const RECORD_NAME: &'static str = "TEST";
+
+    fn serialise_into(&self, writer: &mut impl std::io::Write) -> bincode::Result<()> {
+        writer.write_all(&self.bytes)?;
+        Ok(())
+    }
+
+    fn deserialize_from(reader: &mut impl std::io::Read) -> bincode::Result<Self> {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes)?;
+        Ok(Self { bytes })
+    }
+}
+
+#[test]
+fn basic() {
+    let directory = TempDir::new("wal-test").unwrap();
+
+    let message = TestRecord { bytes: b"hello world".to_vec() };
+
+    let mut wal = WAL::open(&directory).unwrap();
+    wal.register_record_type::<TestRecord>();
+    let wal = wal;
+
+    let written_entry_id = wal.sequenced_write(&message).unwrap();
+    println!("hello world written to WAL in {written_entry_id}");
+    drop(wal);
+
+    let mut wal = WAL::open(&directory).unwrap();
+    wal.register_record_type::<TestRecord>();
+    let wal = wal;
+
+    let raw_record = wal.iter_from(written_entry_id).next().unwrap().unwrap();
+    let read_record = TestRecord::deserialize_from(&mut &*raw_record.bytes).unwrap();
+    assert_eq!(read_record, message);
+
+    wal.checkpoint().unwrap();
+    let written_entry_id = wal.sequenced_write(&message).unwrap();
+    println!("hello world written to WAL in {written_entry_id}");
+    drop(wal);
+
+    let mut wal = WAL::open(&directory).unwrap();
+    wal.register_record_type::<TestRecord>();
+    let wal = wal;
+
+    let mut recovery_iterator = wal.recover();
+
+    let RawRecord { sequence_number, record_type, bytes } = recovery_iterator.next().unwrap().unwrap();
+    assert_eq!(sequence_number, written_entry_id);
+    assert_eq!(record_type, TestRecord::RECORD_TYPE);
+    assert_eq!(message, TestRecord::deserialize_from(&mut &*bytes).unwrap());
+    assert!(recovery_iterator.next().is_none());
+    drop(recovery_iterator);
+
+    wal.checkpoint().unwrap();
+    drop(wal);
+
+    let mut wal = WAL::open(&directory).unwrap();
+    wal.register_record_type::<TestRecord>();
+    let wal = wal;
+
+    let mut recovery_iterator = wal.recover();
+    assert!(recovery_iterator.next().is_none());
+}

--- a/storage/durability/tests/basic.rs
+++ b/storage/durability/tests/basic.rs
@@ -18,35 +18,12 @@
 #![deny(unused_must_use)]
 #![deny(rust_2018_idioms)]
 
-use durability::{wal::WAL, DurabilityRecord, DurabilityRecordType, DurabilityService, RawRecord};
+use durability::{DurabilityRecord, DurabilityService, RawRecord};
 use tempdir::TempDir;
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-struct TestRecord {
-    bytes: Vec<u8>,
-}
+mod common;
 
-impl DurabilityRecord for TestRecord {
-    const RECORD_TYPE: DurabilityRecordType = 0;
-    const RECORD_NAME: &'static str = "TEST";
-
-    fn serialise_into(&self, writer: &mut impl std::io::Write) -> bincode::Result<()> {
-        writer.write_all(&self.bytes)?;
-        Ok(())
-    }
-
-    fn deserialize_from(reader: &mut impl std::io::Read) -> bincode::Result<Self> {
-        let mut bytes = Vec::new();
-        reader.read_to_end(&mut bytes)?;
-        Ok(Self { bytes })
-    }
-}
-
-fn open_wal(directory: &TempDir) -> WAL {
-    let mut wal = WAL::open(directory).unwrap();
-    wal.register_record_type::<TestRecord>();
-    wal
-}
+use self::common::{open_wal, TestRecord};
 
 #[test]
 fn basic() {

--- a/storage/durability/tests/common/mod.rs
+++ b/storage/durability/tests/common/mod.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use std::path::Path;
+
+use durability::{wal::WAL, DurabilityRecord, DurabilityRecordType, DurabilityService};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct TestRecord {
+    pub bytes: Vec<u8>,
+}
+
+impl DurabilityRecord for TestRecord {
+    const RECORD_TYPE: DurabilityRecordType = 0;
+    const RECORD_NAME: &'static str = "TEST";
+
+    fn serialise_into(&self, writer: &mut impl std::io::Write) -> bincode::Result<()> {
+        writer.write_all(&self.bytes)?;
+        Ok(())
+    }
+
+    fn deserialize_from(reader: &mut impl std::io::Read) -> bincode::Result<Self> {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes)?;
+        Ok(Self { bytes })
+    }
+}
+
+pub fn open_wal(directory: impl AsRef<Path>) -> WAL {
+    let mut wal = WAL::open(directory).unwrap();
+    wal.register_record_type::<TestRecord>();
+    wal
+}

--- a/storage/durability/tests/crash.rs
+++ b/storage/durability/tests/crash.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#![deny(unused_must_use)]
+#![deny(rust_2018_idioms)]
+
+use std::process::Command;
+
+use tempdir::TempDir;
+
+#[test]
+fn crash() {
+    let message = "hello there";
+
+    let streamer = std::env::var("TEST_WAL_STREAMER").unwrap();
+    let recoverer = std::env::var("TEST_WAL_RECOVERER").unwrap();
+
+    for _ in 0..10 {
+        let directory = TempDir::new("wal-test").unwrap();
+
+        let mut streamer_process = Command::new(&streamer).arg(directory.as_ref()).arg(message).spawn().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        streamer_process.kill().unwrap();
+
+        let output = Command::new(&recoverer).arg(directory.as_ref()).output().unwrap();
+        assert!(output.status.success(), "{}\n{}", output.status, String::from_utf8_lossy(&output.stderr));
+
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        for (i, line) in stdout.lines().enumerate() {
+            assert_eq!(line, format!(r#"{i} "{message} {i}""#));
+        }
+    }
+}

--- a/storage/durability/tests/recoverer.rs
+++ b/storage/durability/tests/recoverer.rs
@@ -28,7 +28,7 @@ use self::common::{open_wal, TestRecord};
 
 fn main() {
     let wal = open_wal(std::env::args().nth(1).unwrap());
-    for RawRecord { sequence_number, record_type, bytes } in wal.recover().map(|r| r.unwrap()) {
+    for RawRecord { sequence_number, record_type, bytes } in wal.recover().unwrap().map(|r| r.unwrap()) {
         assert_eq!(record_type, TestRecord::RECORD_TYPE);
         let number = sequence_number.number().number();
         println!(r#"{} "{}""#, number, str::from_utf8(&bytes).unwrap());

--- a/storage/durability/tests/recoverer.rs
+++ b/storage/durability/tests/recoverer.rs
@@ -18,36 +18,13 @@
 #![deny(unused_must_use)]
 #![deny(rust_2018_idioms)]
 
-use std::{path::Path, str};
+use std::str;
 
-use durability::{wal::WAL, DurabilityRecord, DurabilityRecordType, DurabilityService, RawRecord};
+use durability::{DurabilityRecord, DurabilityService, RawRecord};
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-struct TestRecord {
-    bytes: Vec<u8>,
-}
+mod common;
 
-impl DurabilityRecord for TestRecord {
-    const RECORD_TYPE: DurabilityRecordType = 0;
-    const RECORD_NAME: &'static str = "TEST";
-
-    fn serialise_into(&self, writer: &mut impl std::io::Write) -> bincode::Result<()> {
-        writer.write_all(&self.bytes)?;
-        Ok(())
-    }
-
-    fn deserialize_from(reader: &mut impl std::io::Read) -> bincode::Result<Self> {
-        let mut bytes = Vec::new();
-        reader.read_to_end(&mut bytes)?;
-        Ok(Self { bytes })
-    }
-}
-
-fn open_wal(directory: impl AsRef<Path>) -> WAL {
-    let mut wal = WAL::open(directory).unwrap();
-    wal.register_record_type::<TestRecord>();
-    wal
-}
+use self::common::{open_wal, TestRecord};
 
 fn main() {
     let wal = open_wal(std::env::args().nth(1).unwrap());

--- a/storage/durability/tests/recoverer.rs
+++ b/storage/durability/tests/recoverer.rs
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#![deny(unused_must_use)]
+#![deny(rust_2018_idioms)]
+
+use std::{path::Path, str};
+
+use durability::{wal::WAL, DurabilityRecord, DurabilityRecordType, DurabilityService, RawRecord};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+struct TestRecord {
+    bytes: Vec<u8>,
+}
+
+impl DurabilityRecord for TestRecord {
+    const RECORD_TYPE: DurabilityRecordType = 0;
+    const RECORD_NAME: &'static str = "TEST";
+
+    fn serialise_into(&self, writer: &mut impl std::io::Write) -> bincode::Result<()> {
+        writer.write_all(&self.bytes)?;
+        Ok(())
+    }
+
+    fn deserialize_from(reader: &mut impl std::io::Read) -> bincode::Result<Self> {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes)?;
+        Ok(Self { bytes })
+    }
+}
+
+fn open_wal(directory: impl AsRef<Path>) -> WAL {
+    let mut wal = WAL::open(directory).unwrap();
+    wal.register_record_type::<TestRecord>();
+    wal
+}
+
+fn main() {
+    let wal = open_wal(std::env::args().nth(1).unwrap());
+    for RawRecord { sequence_number, record_type, bytes } in wal.recover().map(|r| r.unwrap()) {
+        assert_eq!(record_type, TestRecord::RECORD_TYPE);
+        let number = sequence_number.number().number();
+        println!(r#"{} "{}""#, number, str::from_utf8(&bytes).unwrap());
+    }
+}

--- a/storage/durability/tests/streamer.rs
+++ b/storage/durability/tests/streamer.rs
@@ -18,37 +18,12 @@
 #![deny(unused_must_use)]
 #![deny(rust_2018_idioms)]
 
-use std::path::Path;
-
-use durability::{wal::WAL, DurabilityRecord, DurabilityRecordType, DurabilityService};
+use durability::DurabilityService;
 use itertools::Itertools;
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-struct TestRecord {
-    bytes: Vec<u8>,
-}
+mod common;
 
-impl DurabilityRecord for TestRecord {
-    const RECORD_TYPE: DurabilityRecordType = 0;
-    const RECORD_NAME: &'static str = "TEST";
-
-    fn serialise_into(&self, writer: &mut impl std::io::Write) -> bincode::Result<()> {
-        writer.write_all(&self.bytes)?;
-        Ok(())
-    }
-
-    fn deserialize_from(reader: &mut impl std::io::Read) -> bincode::Result<Self> {
-        let mut bytes = Vec::new();
-        reader.read_to_end(&mut bytes)?;
-        Ok(Self { bytes })
-    }
-}
-
-fn open_wal(directory: impl AsRef<Path>) -> WAL {
-    let mut wal = WAL::open(directory).unwrap();
-    wal.register_record_type::<TestRecord>();
-    wal
-}
+use self::common::{open_wal, TestRecord};
 
 fn main() {
     let wal = open_wal(std::env::args().nth(1).unwrap());

--- a/storage/durability/tests/streamer.rs
+++ b/storage/durability/tests/streamer.rs
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#![deny(unused_must_use)]
+#![deny(rust_2018_idioms)]
+
+use std::path::Path;
+
+use durability::{wal::WAL, DurabilityRecord, DurabilityRecordType, DurabilityService};
+use itertools::Itertools;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+struct TestRecord {
+    bytes: Vec<u8>,
+}
+
+impl DurabilityRecord for TestRecord {
+    const RECORD_TYPE: DurabilityRecordType = 0;
+    const RECORD_NAME: &'static str = "TEST";
+
+    fn serialise_into(&self, writer: &mut impl std::io::Write) -> bincode::Result<()> {
+        writer.write_all(&self.bytes)?;
+        Ok(())
+    }
+
+    fn deserialize_from(reader: &mut impl std::io::Read) -> bincode::Result<Self> {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes)?;
+        Ok(Self { bytes })
+    }
+}
+
+fn open_wal(directory: impl AsRef<Path>) -> WAL {
+    let mut wal = WAL::open(directory).unwrap();
+    wal.register_record_type::<TestRecord>();
+    wal
+}
+
+fn main() {
+    let wal = open_wal(std::env::args().nth(1).unwrap());
+    let message = std::env::args().nth(2).unwrap().bytes().collect_vec();
+    for i in 0.. {
+        let record = TestRecord { bytes: message.iter().copied().chain(format!(" {i}").bytes()).collect_vec() };
+        wal.sequenced_write(&record).unwrap();
+    }
+}

--- a/storage/durability/wal.rs
+++ b/storage/durability/wal.rs
@@ -299,6 +299,7 @@ fn read_header(file: &mut StdFile) -> io::Result<RecordHeader> {
 #[cfg(test)]
 mod test {
     use itertools::Itertools;
+    use tempdir::TempDir;
 
     use super::WAL;
     use crate::{DurabilityRecord, DurabilityRecordType, DurabilityService, RawRecord};
@@ -328,7 +329,7 @@ mod test {
 
     #[test]
     fn test_wal_write_read() -> Result<(), BoxError> {
-        let directory = tempdir::TempDir::new("wal-test")?;
+        let directory = TempDir::new("wal-test")?;
 
         let record = TestRecord { bytes: *b"test" };
 
@@ -347,7 +348,7 @@ mod test {
 
     #[test]
     fn test_wal_write_read_lots() -> Result<(), BoxError> {
-        let directory = tempdir::TempDir::new("wal-test")?;
+        let directory = TempDir::new("wal-test")?;
 
         let records = [TestRecord { bytes: *b"test" }; 1024];
 
@@ -372,7 +373,7 @@ mod test {
 
     #[test]
     fn test_wal_recover() -> Result<(), BoxError> {
-        let directory = tempdir::TempDir::new("wal-test")?;
+        let directory = TempDir::new("wal-test")?;
 
         let record = TestRecord { bytes: *b"test" };
 
@@ -395,7 +396,7 @@ mod test {
 
     #[test]
     fn test_wal_recover_multiple() -> Result<(), BoxError> {
-        let directory = tempdir::TempDir::new("wal-test")?;
+        let directory = TempDir::new("wal-test")?;
 
         let records = [TestRecord { bytes: *b"test" }, TestRecord { bytes: *b"abcd" }];
 
@@ -423,7 +424,7 @@ mod test {
 
     #[test]
     fn test_wal_checkpoint_recover() -> Result<(), BoxError> {
-        let directory = tempdir::TempDir::new("wal-test")?;
+        let directory = TempDir::new("wal-test")?;
 
         let committed_record = TestRecord { bytes: *b"1234" };
         let records = [TestRecord { bytes: *b"test" }, TestRecord { bytes: *b"abcd" }];
@@ -466,7 +467,7 @@ mod test {
 
     #[test]
     fn test_wal_iterate_from() -> Result<(), BoxError> {
-        let directory = tempdir::TempDir::new("wal-test")?;
+        let directory = TempDir::new("wal-test")?;
 
         let records = [TestRecord { bytes: *b"test" }, TestRecord { bytes: *b"abcd" }];
 

--- a/storage/durability/wal.rs
+++ b/storage/durability/wal.rs
@@ -28,7 +28,7 @@ use std::{
 };
 
 use itertools::Itertools;
-use primitive::U80;
+use primitive::u80::U80;
 
 use crate::{
     DurabilityRecord, DurabilityRecordType, DurabilityService, RawRecord, RecordHeader, Result, SequenceNumber,

--- a/storage/durability/wal.rs
+++ b/storage/durability/wal.rs
@@ -15,48 +15,110 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::collections::HashMap;
-use std::fs::{File, OpenOptions};
-use std::ops::DerefMut;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
+use std::{
+    collections::HashMap,
+    ffi::OsStr,
+    fs::{self, File as StdFile, OpenOptions},
+    io::{self, Read, Write},
+    iter,
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Mutex,
+    },
+};
 
-use primitive::u80::U80;
+use itertools::Itertools;
+use primitive::U80;
 
-use crate::{DurabilityError, DurabilityErrorKind, DurabilityRecord, DurabilityRecordType, DurabilityService, SequenceNumber, Sequencer};
+use crate::{DurabilityRecord, DurabilityRecordType, DurabilityService, RawRecord, Result, SequenceNumber, Sequencer};
 
-///
-/// I think we could use an MMAP append-only file to allow records to serialise themselves directly into the right place
-/// We could also use a Writer/Stream compressor to reduce the write bandwidth requirements
-///
+//
+// I think we could use an MMAP append-only file to allow records to serialise themselves directly into the right place
+// We could also use a Writer/Stream compressor to reduce the write bandwidth requirements
+//
 #[derive(Debug)]
 pub struct WAL {
     registered_types: HashMap<DurabilityRecordType, &'static str>,
     sequence_number: AtomicU64,
-    file: Mutex<File>,
+    directory: PathBuf,
+    files: Mutex<Files>,
+}
+
+struct File {
+    file: StdFile,
+    path: PathBuf,
+}
+
+impl File {
+    fn open(path: PathBuf) -> io::Result<Self> {
+        let file = OpenOptions::new().read(true).append(true).create(true).open(&path)?;
+        Ok(Self { file, path })
+    }
+}
+
+struct Files {
+    current: File,
+    previous: Vec<File>,
+}
+
+const FILE_PREFIX: &str = "wal-";
+
+impl Files {
+    fn format_file_name(seq: SequenceNumber) -> String {
+        format!("{}{:020}", FILE_PREFIX, seq.number().number())
+    }
+
+    fn open(directory: PathBuf) -> io::Result<Self> {
+        let mut files: Vec<File> = directory
+            .read_dir()?
+            .map_ok(|entry| entry.path())
+            .filter_ok(|path| {
+                path.file_name().and_then(OsStr::to_str).is_some_and(|name| name.starts_with(FILE_PREFIX))
+            })
+            .map(|path| File::open(path?))
+            .try_collect()?;
+        files.sort_unstable_by(|lhs, rhs| lhs.path.cmp(&rhs.path));
+
+        let seq = SequenceNumber::new(U80::new(0));
+        let last = files.pop().map(Ok).unwrap_or_else(|| File::open(directory.join(Self::format_file_name(seq))))?;
+
+        Ok(Self { current: last, previous: files })
+    }
 }
 
 impl WAL {
-    pub fn new() -> WAL {
-        let f = OpenOptions::new()
-            .append(true)
-                .create(true) // Optionally create the file if it doesn't already exist
-                .open("/tmp/test_wal")
-                .unwrap();
-        WAL {
+    pub fn open(directory: impl AsRef<Path>) -> io::Result<Self> {
+        Self::open_impl(directory.as_ref().to_owned())
+    }
+
+    fn open_impl(directory: PathBuf) -> io::Result<Self> {
+        if !directory.exists() {
+            fs::create_dir_all(&directory)?;
+        }
+
+        Ok(Self {
             registered_types: HashMap::new(),
             sequence_number: AtomicU64::new(1),
-            file: Mutex::new(f),
-        }
+            files: Mutex::new(Files::open(directory.clone())?),
+            directory,
+        })
+    }
+
+    fn write_header<Record: DurabilityRecord>(file: &mut StdFile, seq: SequenceNumber, len: u32) -> io::Result<()> {
+        file.write_all(&seq.number().to_be_bytes())?;
+        file.write_all(&len.to_be_bytes())?;
+        file.write_all(&[Record::RECORD_TYPE])?;
+        Ok(())
     }
 }
 
 impl Sequencer for WAL {
-    fn take_next(&self) -> SequenceNumber {
+    fn increment(&self) -> SequenceNumber {
         SequenceNumber::new(U80::new(self.sequence_number.fetch_add(1, Ordering::Relaxed) as u128))
     }
 
-    fn poll_next(&self) -> SequenceNumber {
+    fn current(&self) -> SequenceNumber {
         SequenceNumber::new(U80::new(self.sequence_number.load(Ordering::Relaxed) as u128))
     }
 
@@ -66,21 +128,146 @@ impl Sequencer for WAL {
 }
 
 impl DurabilityService for WAL {
-    fn register_record_type(&mut self, record_type: DurabilityRecordType, record_name: &'static str) {
-        if self.registered_types.get(&record_type).map(|name| *name != record_name).unwrap_or(false) {
+    fn register_record_type<Record: DurabilityRecord>(&mut self) {
+        if self.registered_types.get(&Record::RECORD_TYPE).is_some_and(|name| name != &Record::RECORD_NAME) {
             panic!("Illegal state: two types of WAL records registered with same ID and different names.")
         }
-        self.registered_types.insert(record_type, record_name);
+        self.registered_types.insert(Record::RECORD_TYPE, Record::RECORD_NAME);
     }
 
-    fn sequenced_write(&self, record: &impl DurabilityRecord, record_name: &'static str) -> Result<SequenceNumber, DurabilityError> {
-        debug_assert!(*self.registered_types.get(&record.record_type()).unwrap() == record_name);
-        let mut file = self.file.lock().unwrap();
+    fn sequenced_write<Record>(&self, record: &Record) -> Result<SequenceNumber>
+    where
+        Record: DurabilityRecord,
+    {
+        debug_assert!(self.registered_types.get(&Record::RECORD_TYPE) == Some(&Record::RECORD_NAME));
+        let mut files = self.files.lock().unwrap();
 
-        record.serialise_into(file.deref_mut()).map(|_| self.take_next())
-            .map_err(|err| DurabilityError {
-                kind: DurabilityErrorKind::BincodeSerializeError {source: err }
-            })
+        let file = &mut files.current.file;
+        let seq = self.increment();
+
+        let mut buf = Vec::new();
+        record.serialise_into(&mut buf)?;
+
+        Self::write_header::<Record>(file, seq, buf.len() as u32).unwrap(); // TODO
+        file.write_all(&buf).unwrap(); // TODO
+
+        Ok(seq)
+    }
+
+    // fn iterate_records_from(&self, sequence_number: SequenceNumber) -> Box<dyn Iterator<Item=(SequenceNumber, DurabilityRecordType, Box<[u8]>)>> { todo!() }
+
+    fn recover(&self) -> impl Iterator<Item = io::Result<RawRecord>> {
+        let mut files = self.files.lock().unwrap();
+        iter::from_fn(move || read_one_record(&mut files.current.file).transpose())
     }
 }
 
+fn read_one_record(file: &mut StdFile) -> io::Result<Option<RawRecord>> {
+    let (sequence_number, len, record_type) = match read_header(file) {
+        Ok(Some(header)) => header,
+        Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Ok(None) => return Ok(None),
+        Err(err) => return Err(err),
+    };
+
+    let mut bytes = vec![0; len as usize].into_boxed_slice();
+    file.read_exact(&mut bytes)?;
+    Ok(Some(RawRecord { sequence_number, record_type, bytes }))
+}
+
+fn read_header(file: &mut StdFile) -> io::Result<Option<(SequenceNumber, u32, u8)>> {
+    let mut buf = [0; U80::BYTES];
+    match file.read_exact(&mut buf) {
+        Ok(()) => (),
+        Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(err) => return Err(err),
+    }
+    let seq = SequenceNumber::new(U80::from_be_bytes(&buf));
+    let mut buf = [0; std::mem::size_of::<u32>()];
+    file.read_exact(&mut buf)?;
+    let len = u32::from_be_bytes(buf);
+    let mut buf = [0; 1];
+    file.read_exact(&mut buf)?;
+    let [record_type] = buf;
+    Ok(Some((seq, len, record_type)))
+}
+
+#[cfg(test)]
+mod test {
+    use itertools::Itertools;
+
+    use super::WAL;
+    use crate::{DurabilityRecord, DurabilityRecordType, DurabilityService, RawRecord};
+
+    type BoxError = Box<dyn std::error::Error>;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct TestRecord {
+        bytes: [u8; 4],
+    }
+
+    impl DurabilityRecord for TestRecord {
+        const RECORD_TYPE: DurabilityRecordType = 0;
+        const RECORD_NAME: &'static str = "TEST";
+
+        fn serialise_into(&self, writer: &mut impl std::io::Write) -> bincode::Result<()> {
+            writer.write_all(&self.bytes)?;
+            Ok(())
+        }
+
+        fn deserialize_from(reader: &mut impl std::io::Read) -> bincode::Result<Self> {
+            let mut bytes = [0; 4];
+            reader.read_exact(&mut bytes)?;
+            Ok(Self { bytes })
+        }
+    }
+
+    #[test]
+    fn test_wal_recover() -> Result<(), BoxError> {
+        let directory = tempdir::TempDir::new("wal-test")?;
+
+        let record = TestRecord { bytes: *b"test" };
+
+        let mut wal = WAL::open(&directory)?;
+        wal.register_record_type::<TestRecord>();
+        wal.sequenced_write(&record)?;
+        drop(wal);
+
+        let mut wal = WAL::open(&directory)?;
+        wal.register_record_type::<TestRecord>();
+        let RawRecord { record_type, bytes, .. } = wal.recover().next().unwrap()?;
+        assert_eq!(record_type, TestRecord::RECORD_TYPE);
+        let read_record = TestRecord::deserialize_from(&mut &*bytes)?;
+        assert_eq!(record, read_record);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_wal_recover_multiple() -> Result<(), BoxError> {
+        let directory = tempdir::TempDir::new("wal-test")?;
+
+        let records = [TestRecord { bytes: *b"test" }, TestRecord { bytes: *b"abcd" }];
+
+        let mut wal = WAL::open(&directory)?;
+        wal.register_record_type::<TestRecord>();
+        records.iter().try_for_each(|record| wal.sequenced_write(record).map(|_| ()))?;
+        drop(wal);
+
+        let mut wal = WAL::open(&directory)?;
+        wal.register_record_type::<TestRecord>();
+
+        let read_records = wal
+            .recover()
+            .map(|res| {
+                let RawRecord { record_type, bytes, .. } = res?;
+                assert_eq!(record_type, TestRecord::RECORD_TYPE);
+                Ok::<_, BoxError>(TestRecord::deserialize_from(&mut &*bytes)?)
+            })
+            .try_collect::<_, Vec<TestRecord>, _>()?;
+
+        assert_eq!(records, &*read_records);
+
+        Ok(())
+    }
+}

--- a/storage/durability/wal.rs
+++ b/storage/durability/wal.rs
@@ -304,6 +304,7 @@ impl<'a> Iterator for RecordIterator<'a> {
                     self.next()
                 }
             }
+            Some(Err(err)) if err.kind() == io::ErrorKind::UnexpectedEof => None,
             some => some,
         }
     }

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -62,14 +62,14 @@ impl MVCCStorage {
 
     pub fn new(owner_name: Rc<str>, path: &PathBuf) -> Result<Self, MVCCStorageError> {
         let storage_dir = path.with_extension(MVCCStorage::STORAGE_DIR_NAME);
-        let mut durability_service = WAL::new();
+        let mut durability_service = WAL::open("/tmp/wal").expect("Could not create WAL directory");
         durability_service.register_record_type(CommitRecord::DURABILITY_RECORD_TYPE, CommitRecord::DURABILITY_RECORD_NAME);
         Ok(MVCCStorage {
             owner_name: owner_name.clone(),
             path: storage_dir,
             keyspaces: Vec::new(),
             keyspaces_index: core::array::from_fn(|_| None),
-            isolation_manager: IsolationManager::new(durability_service.poll_next()),
+            isolation_manager: IsolationManager::new(durability_service.current()),
             durability_service: durability_service,
         })
     }


### PR DESCRIPTION
## Usage and product changes

We implement the local sharded (16 MB shards) write-ahead log to be used as a durability service. The WAL is using lz4 compression within each written record, which also provides the integrity checking mechanism.

Expected process flow during commit:

1. write data into WAL;
2. write data into speedb;
3. flush speedb to disk;
4. checkpoint WAL so that subsequent recoveries begin from the records after this successful commit.

## Implementation

- crash test: start a process that continuously writes records into the WAL, kill that process, then verify that the records can be read back without being corrupted.
- write benchmark: measures pre-serialization throughput of writing data into the WAL.


### Architecture decisions

The WAL has several goals:
1. It needs to act as a sequencer, which assigns a sequence number to each record that it receives
2. Performantly serialises data to the file on disk, guaranteeing durability of each record by flushing after each write
3. Allows retrieving old entries in the WAL with reasonable speed
4. Allow iterating through old entries of the WAL from a specific sequence number
5. Is able to handle heterogeneous record types
6. Includes compression to minimise disk bandwidth usage.

We decided to use a sharded WAL with relatively small files to allow period cleanup of old WAL files without causing rewrites or extensive locking. These files can also be used to effectively search for the location of an older sequence number, or even search by time.

