### PR TITLE
Enable criterion flamegraphs

### DIFF
--- a/storage/benches/BUILD
+++ b/storage/benches/BUILD
@@ -36,6 +36,7 @@ rust_test(
         "@crates//:rand",
         "@crates//:tracing",
         "@crates//:criterion",
+        "@crates//:pprof",
     ],
     use_libtest_harness = False,
 )

--- a/storage/benches/bench_mvcc_storage.rs
+++ b/storage/benches/bench_mvcc_storage.rs
@@ -15,10 +15,22 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::{path::PathBuf, rc::Rc};
-
+use std::{
+    path::Path,
+    path::PathBuf,
+    rc::Rc,
+    fs::File,
+    os::raw::c_int,
+};
 use bytes::{byte_array::ByteArray, byte_reference::ByteReference};
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{
+    criterion_group,
+    criterion_main,
+    Criterion,
+    profiler::Profiler,
+};
+use pprof::ProfilerGuard;
+
 use resource::constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE};
 use storage::{
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
@@ -124,55 +136,53 @@ fn criterion_benchmark(c: &mut Criterion) {
         delete_dir(storage_path);
     }
 }
+// --- Code to generate flamegraphs copied from https://www.jibbow.com/posts/criterion-flamegraphs/ ---
+// This causes a SIGBUS on (mac) arm64 if the frequency is set too high.
 
-criterion_group!(benches, criterion_benchmark);
+pub struct FlamegraphProfiler<'a> {
+    frequency: c_int,
+    active_profiler: Option<ProfilerGuard<'a>>,
+}
+
+impl<'a> FlamegraphProfiler<'a> {
+    #[allow(dead_code)]
+    pub fn new(frequency: c_int) -> Self {
+        FlamegraphProfiler {
+            frequency,
+            active_profiler: None,
+        }
+    }
+}
+
+impl<'a> Profiler for FlamegraphProfiler<'a> {
+    fn start_profiling(&mut self, _benchmark_id: &str, _benchmark_dir: &Path) {
+        self.active_profiler = Some(ProfilerGuard::new(self.frequency).unwrap());
+    }
+
+    fn stop_profiling(&mut self, _benchmark_id: &str, benchmark_dir: &Path) {
+        std::fs::create_dir_all(benchmark_dir).unwrap();
+        let flamegraph_path = benchmark_dir.join("flamegraph.svg");
+        let flamegraph_file = File::create(&flamegraph_path)
+            .expect("File system error while creating flamegraph.svg");
+        if let Some(profiler) = self.active_profiler.take() {
+            profiler
+                .report()
+                .build()
+                .unwrap()
+                .flamegraph(flamegraph_file)
+                .expect("Error writing flamegraph");
+        }
+    }
+}
+
+fn profiled() -> Criterion {
+    Criterion::default().with_profiler(FlamegraphProfiler::new(100))
+}
+
+criterion_group!(
+    name = benches;
+    config= profiled();
+    targets = criterion_benchmark
+);
+
 criterion_main!(benches);
-
-// --- TODO: this flame graph output isn't working. Copied from https://www.jibbow.com/posts/criterion-flamegraphs/ ---
-
-// pub struct FlamegraphProfiler<'a> {
-//     frequency: c_int,
-//     active_profiler: Option<ProfilerGuard<'a>>,
-// }
-//
-// impl<'a> FlamegraphProfiler<'a> {
-//     #[allow(dead_code)]
-//     pub fn new(frequency: c_int) -> Self {
-//         FlamegraphProfiler {
-//             frequency,
-//             active_profiler: None,
-//         }
-//     }
-// }
-//
-// impl<'a> Profiler for FlamegraphProfiler<'a> {
-//     fn start_profiling(&mut self, _benchmark_id: &str, _benchmark_dir: &Path) {
-//         self.active_profiler = Some(ProfilerGuard::new(self.frequency).unwrap());
-//     }
-//
-//     fn stop_profiling(&mut self, _benchmark_id: &str, benchmark_dir: &Path) {
-//         std::fs::create_dir_all(benchmark_dir).unwrap();
-//         let flamegraph_path = benchmark_dir.join("flamegraph.svg");
-//         let flamegraph_file = File::create(&flamegraph_path)
-//             .expect("File system error while creating flamegraph.svg");
-//         if let Some(profiler) = self.active_profiler.take() {
-//             profiler
-//                 .report()
-//                 .build()
-//                 .unwrap()
-//                 .flamegraph(flamegraph_file)
-//                 .expect("Error writing flamegraph");
-//         }
-//     }
-// }
-//
-// fn profiled() -> Criterion {
-//     Criterion::default().with_profiler(FlamegraphProfiler::new(100))
-// }
-// criterion_group!(
-//     name = benches;
-//     config = profiled();
-//     targets = criterion_benchmark
-// );
-//
-// criterion_main!(benches);


### PR DESCRIPTION
## Usage and product changes

Re-enables flame graphs on the criterion storage benchmarks. 

To execute a benchmark, we can either run it via Cargo:
```
cargo bench --package storage --bench bench_mvcc_storage
```

or via Bazel:
```
bazel test --compilation_mode=opt //storage/benches:bench_mvcc_storage --test_arg=--bench
```

Note that this currently does not finish successfull on ARM64 Macs because of a `SIGBUS` in `libunwind`. 

## Implementation

Re-enables flame graphs on the criterion storage benchmarks and updates dependencies to include require `pprof` library.