### PR TITLE
Disable monitoring in assembly tests

### DIFF
--- a/test/assembly/AssemblyTest.java
+++ b/test/assembly/AssemblyTest.java
@@ -33,7 +33,10 @@ public class AssemblyTest {
 
     @Test
     public void bootup() throws InterruptedException, TimeoutException, IOException {
-        TypeDBCoreRunner server = new TypeDBCoreRunner(map(pair("--diagnostics.reporting.errors", "false")));
+        TypeDBCoreRunner server = new TypeDBCoreRunner(map(
+            pair("--diagnostics.reporting.errors", "false"),
+            pair("--diagnostics.monitoring.enable", "false")
+        ));
         try {
             server.start();
         } finally {
@@ -43,7 +46,10 @@ public class AssemblyTest {
 
     @Test
     public void console() throws InterruptedException, TimeoutException, IOException {
-        TypeDBCoreRunner server = new TypeDBCoreRunner();
+        TypeDBCoreRunner server = new TypeDBCoreRunner(map(
+            pair("--diagnostics.reporting.errors", "false"),
+            pair("--diagnostics.monitoring.enable", "false")
+        ));
         try {
             server.start();
             TypeDBConsoleRunner console = new TypeDBConsoleRunner();


### PR DESCRIPTION
## Usage and product changes

Failure to bind a port for the monitoring server for some reason results in a failure of assembly tests on Windows. Disabling monitoring should resolve the issue.