### PR TITLE
Implement storage error handling and propagation up to concept layer

### DIFF
--- a/concept/error.rs
+++ b/concept/error.rs
@@ -17,8 +17,8 @@
 
 use std::{error::Error, fmt};
 
-use encoding::{error::EncodingWriteError, value::value_type::ValueType};
-use storage::snapshot::{SnapshotError, SnapshotGetError, SnapshotPutError};
+use encoding::value::value_type::ValueType;
+use storage::snapshot::{SnapshotError, SnapshotGetError};
 
 #[derive(Debug)]
 pub struct ConceptError {
@@ -48,10 +48,8 @@ impl Error for ConceptError {
 
 #[derive(Debug)]
 pub enum ConceptWriteError {
-    SnapshotPut { source: SnapshotPutError },
     SnapshotGet { source: SnapshotGetError },
 
-    EncodingWrite { source: EncodingWriteError },
     ValueTypeMismatch { expected: Option<ValueType>, provided: ValueType },
 }
 
@@ -64,10 +62,8 @@ impl fmt::Display for ConceptWriteError {
 impl Error for ConceptWriteError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            Self::SnapshotPut { source, .. } => Some(source),
             Self::SnapshotGet { source, .. } => Some(source),
-            Self::EncodingWrite { source, .. } => Some(source),
-            Self::ValueTypeMismatch {..} => todo!(),
+            Self::ValueTypeMismatch { .. } => todo!(),
         }
     }
 }

--- a/concept/error.rs
+++ b/concept/error.rs
@@ -15,10 +15,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::{error::Error, fmt};
+use std::{error::Error, fmt, sync::Arc};
 
 use encoding::value::value_type::ValueType;
-use storage::snapshot::{SnapshotError, SnapshotGetError};
+use storage::snapshot::{iterator::SnapshotIteratorError, SnapshotGetError};
 
 #[derive(Debug)]
 pub struct ConceptError {
@@ -27,7 +27,6 @@ pub struct ConceptError {
 
 #[derive(Debug)]
 pub enum ConceptErrorKind {
-    SnapshotError { source: SnapshotError },
     AttributeValueTypeMismatch { attribute_type_value_type: Option<ValueType>, provided_value_type: ValueType },
 }
 
@@ -40,7 +39,6 @@ impl fmt::Display for ConceptError {
 impl Error for ConceptError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match &self.kind {
-            ConceptErrorKind::SnapshotError { source, .. } => Some(source),
             ConceptErrorKind::AttributeValueTypeMismatch { .. } => None,
         }
     }
@@ -49,6 +47,7 @@ impl Error for ConceptError {
 #[derive(Debug)]
 pub enum ConceptWriteError {
     SnapshotGet { source: SnapshotGetError },
+    SnapshotIterate { source: Arc<SnapshotIteratorError> },
 
     ValueTypeMismatch { expected: Option<ValueType>, provided: ValueType },
 }
@@ -63,7 +62,8 @@ impl Error for ConceptWriteError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::SnapshotGet { source, .. } => Some(source),
-            Self::ValueTypeMismatch { .. } => todo!(),
+            Self::SnapshotIterate { source, .. } => Some(source),
+            Self::ValueTypeMismatch { .. } => None,
         }
     }
 }
@@ -72,6 +72,7 @@ impl From<ConceptReadError> for ConceptWriteError {
     fn from(error: ConceptReadError) -> Self {
         match error {
             ConceptReadError::SnapshotGet { source } => Self::SnapshotGet { source },
+            ConceptReadError::SnapshotIterate { source } => Self::SnapshotIterate { source },
         }
     }
 }
@@ -79,6 +80,7 @@ impl From<ConceptReadError> for ConceptWriteError {
 #[derive(Debug)]
 pub enum ConceptReadError {
     SnapshotGet { source: SnapshotGetError },
+    SnapshotIterate { source: Arc<SnapshotIteratorError> },
 }
 
 impl fmt::Display for ConceptReadError {
@@ -91,6 +93,7 @@ impl Error for ConceptReadError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::SnapshotGet { source, .. } => Some(source),
+            Self::SnapshotIterate { source, .. } => Some(source),
         }
     }
 }

--- a/concept/iterator.rs
+++ b/concept/iterator.rs
@@ -15,15 +15,40 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+use std::{error::Error, fmt, sync::Arc};
+
+use storage::snapshot::iterator::SnapshotIteratorError;
+
+#[derive(Debug)]
+pub enum ConceptIteratorError {
+    SnapshotIterator { source: Arc<SnapshotIteratorError> },
+}
+
+impl fmt::Display for ConceptIteratorError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+impl Error for ConceptIteratorError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::SnapshotIterator { source } => Some(source),
+        }
+    }
+}
+
+// FIXME: exported macros must provide their own use-declarations or use fully qualified paths
+//        As it stands, this macro requires imports at point of use.
 #[macro_export]
 macro_rules! concept_iterator {
     ($name:ident, $concept_type:ident, $map_fn: expr) => {
         pub struct $name<'a, const S: usize> {
-            snapshot_iterator: Option<SnapshotRangeIterator<'a, S>>,
+            snapshot_iterator: Option<storage::snapshot::iterator::SnapshotRangeIterator<'a, S>>,
         }
 
         impl<'a, const S: usize> $name<'a, S> {
-            pub(crate) fn new(snapshot_iterator: SnapshotRangeIterator<'a, S>) -> Self {
+            pub(crate) fn new(snapshot_iterator: storage::snapshot::iterator::SnapshotRangeIterator<'a, S>) -> Self {
                 $name { snapshot_iterator: Some(snapshot_iterator) }
             }
 
@@ -31,21 +56,23 @@ macro_rules! concept_iterator {
                 $name { snapshot_iterator: None }
             }
 
-            pub fn peek(&mut self) -> Option<Result<$concept_type<'_>, ConceptError>> {
+            pub fn peek(&mut self) -> Option<Result<$concept_type<'_>, $crate::iterator::ConceptIteratorError>> {
+                use $crate::iterator::ConceptIteratorError::SnapshotIterator;
                 self.iter_peek().map(|result| {
-                    result.map(|(storage_key, _value_bytes)| $map_fn(storage_key)).map_err(|snapshot_error| {
-                        ConceptError { kind: ConceptErrorKind::SnapshotError { source: snapshot_error } }
-                    })
+                    result
+                        .map(|(storage_key, _value_bytes)| $map_fn(storage_key))
+                        .map_err(|error| SnapshotIterator { source: error })
                 })
             }
 
             // a lending iterator trait is infeasible with the current borrow checker
             #[allow(clippy::should_implement_trait)]
-            pub fn next(&mut self) -> Option<Result<$concept_type<'_>, ConceptError>> {
+            pub fn next(&mut self) -> Option<Result<$concept_type<'_>, $crate::iterator::ConceptIteratorError>> {
+                use $crate::iterator::ConceptIteratorError::SnapshotIterator;
                 self.iter_next().map(|result| {
-                    result.map(|(storage_key, _value_bytes)| $map_fn(storage_key)).map_err(|snapshot_error| {
-                        ConceptError { kind: ConceptErrorKind::SnapshotError { source: snapshot_error } }
-                    })
+                    result
+                        .map(|(storage_key, _value_bytes)| $map_fn(storage_key))
+                        .map_err(|error| SnapshotIterator { source: error })
                 })
             }
 
@@ -53,7 +80,14 @@ macro_rules! concept_iterator {
                 todo!()
             }
 
-            fn iter_peek(&mut self) -> Option<Result<(StorageKeyReference<'_>, ByteReference<'_>), SnapshotError>> {
+            fn iter_peek(
+                &mut self,
+            ) -> Option<
+                Result<
+                    (StorageKeyReference<'_>, bytes::byte_reference::ByteReference<'_>),
+                    std::sync::Arc<storage::snapshot::iterator::SnapshotIteratorError>,
+                >,
+            > {
                 if let Some(iter) = self.snapshot_iterator.as_mut() {
                     iter.peek()
                 } else {
@@ -61,7 +95,14 @@ macro_rules! concept_iterator {
                 }
             }
 
-            fn iter_next(&mut self) -> Option<Result<(StorageKeyReference<'_>, ByteReference<'_>), SnapshotError>> {
+            fn iter_next(
+                &mut self,
+            ) -> Option<
+                Result<
+                    (StorageKeyReference<'_>, bytes::byte_reference::ByteReference<'_>),
+                    std::sync::Arc<storage::snapshot::iterator::SnapshotIteratorError>,
+                >,
+            > {
                 if let Some(iter) = self.snapshot_iterator.as_mut() {
                     iter.next()
                 } else {

--- a/concept/tests/test_thing.rs
+++ b/concept/tests/test_thing.rs
@@ -203,8 +203,7 @@ fn write_entity_attributes(
         let name_type = type_manager.get_attribute_type(NAME_LABEL.get().unwrap()).unwrap().unwrap();
         let person = thing_manager.create_entity(person_type).unwrap();
         let age = thing_manager.create_attribute(age_type, Value::Long(100)).unwrap();
-        let name =
-            thing_manager.create_attribute(name_type, Value::String(String::from("abc").into_boxed_str())).unwrap();
+        let name = thing_manager.create_attribute(name_type, Value::String("abc".into())).unwrap();
         person.set_has(&thing_manager, &age).unwrap();
         person.set_has(&thing_manager, &name).unwrap();
     }

--- a/concept/tests/test_type.rs
+++ b/concept/tests/test_type.rs
@@ -112,7 +112,7 @@ fn entity_usage() {
     {
         // With cache, committed
         let snapshot: Rc<Snapshot<'_, _>> = Rc::new(Snapshot::Read(storage.open_snapshot_read()));
-        let type_cache = Arc::new(TypeCache::new(&storage, snapshot.open_sequence_number()));
+        let type_cache = Arc::new(TypeCache::new(&storage, snapshot.open_sequence_number()).unwrap());
         let type_manager = TypeManager::new(snapshot.clone(), &type_vertex_generator, Some(type_cache));
 
         let root_entity = type_manager.get_entity_type(&Kind::Entity.root_label()).unwrap().unwrap();
@@ -222,7 +222,7 @@ fn role_usage() {
     {
         // With cache, committed
         let snapshot: Rc<Snapshot<'_, _>> = Rc::new(Snapshot::Read(storage.open_snapshot_read()));
-        let type_cache = Arc::new(TypeCache::new(&storage, snapshot.open_sequence_number()));
+        let type_cache = Arc::new(TypeCache::new(&storage, snapshot.open_sequence_number()).unwrap());
         let type_manager = TypeManager::new(snapshot.clone(), &type_vertex_generator, Some(type_cache));
 
         // --- friendship sub relation, relates friend ---

--- a/concept/tests/test_type.rs
+++ b/concept/tests/test_type.rs
@@ -17,7 +17,7 @@
 
 #![deny(unused_must_use)]
 
-use std::{ops::Deref, rc::Rc, sync::Arc};
+use std::{rc::Rc, sync::Arc};
 
 use concept::type_::{
     annotation::AnnotationAbstract, entity_type::EntityTypeAnnotation, object_type::ObjectType, owns::Owns,
@@ -52,17 +52,17 @@ fn entity_usage() {
         let type_manager = TypeManager::new(snapshot.clone(), &type_vertex_generator, None);
 
         let root_entity = type_manager.get_entity_type(&Kind::Entity.root_label()).unwrap().unwrap();
-        assert_eq!(root_entity.get_label(&type_manager).deref(), &Kind::Entity.root_label());
-        assert!(root_entity.is_root(&type_manager));
+        assert_eq!(*root_entity.get_label(&type_manager).unwrap(), Kind::Entity.root_label());
+        assert!(root_entity.is_root(&type_manager).unwrap());
 
         // --- age sub attribute ---
         let age_label = Label::build("age");
         let age_type = type_manager.create_attribute_type(&age_label, false).unwrap();
         age_type.set_value_type(&type_manager, ValueType::Long).unwrap();
 
-        assert!(!age_type.is_root(&type_manager));
+        assert!(!age_type.is_root(&type_manager).unwrap());
         assert!(age_type.get_annotations(&type_manager).unwrap().is_empty());
-        assert_eq!(age_type.get_label(&type_manager).deref(), &age_label);
+        assert_eq!(*age_type.get_label(&type_manager).unwrap(), age_label);
         assert_eq!(age_type.get_value_type(&type_manager).unwrap(), Some(ValueType::Long));
 
         // --- person sub entity @abstract ---
@@ -70,38 +70,38 @@ fn entity_usage() {
         let person_type = type_manager.create_entity_type(&person_label, false).unwrap();
         person_type.set_annotation(&type_manager, EntityTypeAnnotation::Abstract(AnnotationAbstract::new())).unwrap();
 
-        assert!(!person_type.is_root(&type_manager));
+        assert!(!person_type.is_root(&type_manager).unwrap());
         assert!(person_type
             .get_annotations(&type_manager)
             .unwrap()
             .contains(&EntityTypeAnnotation::Abstract(AnnotationAbstract::new())));
-        assert_eq!(person_type.get_label(&type_manager).deref(), &person_label);
+        assert_eq!(*person_type.get_label(&type_manager).unwrap(), person_label);
 
-        let supertype = person_type.get_supertype(&type_manager);
-        assert_eq!(supertype.unwrap(), root_entity);
+        let supertype = person_type.get_supertype(&type_manager).unwrap().unwrap();
+        assert_eq!(supertype, root_entity);
 
         // --- child sub person ---
         let child_label = Label::build("child");
         let child_type = type_manager.create_entity_type(&child_label, false).unwrap();
         child_type.set_supertype(&type_manager, person_type.clone()).unwrap();
 
-        assert!(!child_type.is_root(&type_manager));
-        assert_eq!(child_type.get_label(&type_manager).deref(), &child_label);
+        assert!(!child_type.is_root(&type_manager).unwrap());
+        assert_eq!(*child_type.get_label(&type_manager).unwrap(), child_label);
 
-        let supertype = child_type.get_supertype(&type_manager);
-        assert_eq!(supertype.unwrap(), person_type);
-        let supertypes = child_type.get_supertypes(&type_manager);
+        let supertype = child_type.get_supertype(&type_manager).unwrap().unwrap();
+        assert_eq!(supertype, person_type);
+        let supertypes = child_type.get_supertypes(&type_manager).unwrap();
         assert_eq!(supertypes.len(), 2);
 
         // --- child owns age ---
         let owns = child_type.set_owns(&type_manager, age_type.clone().into_owned()).unwrap();
         // TODO: test 'owns' structure directly
 
-        let all_owns = child_type.get_owns(&type_manager);
+        let all_owns = child_type.get_owns(&type_manager).unwrap();
         assert_eq!(all_owns.len(), 1);
         assert!(all_owns.contains(&owns));
-        assert_eq!(child_type.get_owns_attribute(&type_manager, age_type.clone()), Some(owns));
-        assert!(child_type.has_owns_attribute(&type_manager, age_type.clone()));
+        assert_eq!(child_type.get_owns_attribute(&type_manager, age_type.clone()).unwrap(), Some(owns));
+        assert!(child_type.has_owns_attribute(&type_manager, age_type.clone()).unwrap());
     }
     if let Snapshot::Write(write_snapshot) = Rc::try_unwrap(snapshot).ok().unwrap() {
         write_snapshot.commit().unwrap();
@@ -116,50 +116,50 @@ fn entity_usage() {
         let type_manager = TypeManager::new(snapshot.clone(), &type_vertex_generator, Some(type_cache));
 
         let root_entity = type_manager.get_entity_type(&Kind::Entity.root_label()).unwrap().unwrap();
-        assert_eq!(root_entity.get_label(&type_manager).deref(), &Kind::Entity.root_label());
-        assert!(root_entity.is_root(&type_manager));
+        assert_eq!(*root_entity.get_label(&type_manager).unwrap(), Kind::Entity.root_label());
+        assert!(root_entity.is_root(&type_manager).unwrap());
 
         // --- age sub attribute ---
         let age_label = Label::build("age");
         let age_type = type_manager.get_attribute_type(&age_label).unwrap().unwrap();
 
-        assert!(!age_type.is_root(&type_manager));
+        assert!(!age_type.is_root(&type_manager).unwrap());
         assert!(age_type.get_annotations(&type_manager).unwrap().is_empty());
-        assert_eq!(age_type.get_label(&type_manager).deref(), &age_label);
+        assert_eq!(*age_type.get_label(&type_manager).unwrap(), age_label);
         assert_eq!(age_type.get_value_type(&type_manager).unwrap(), Some(ValueType::Long));
 
         // --- person sub entity ---
         let person_label = Label::build("person");
         let person_type = type_manager.get_entity_type(&person_label).unwrap().unwrap();
-        assert!(!person_type.is_root(&type_manager));
+        assert!(!person_type.is_root(&type_manager).unwrap());
         assert!(person_type
             .get_annotations(&type_manager)
             .unwrap()
             .contains(&EntityTypeAnnotation::Abstract(AnnotationAbstract::new())));
-        assert_eq!(person_type.get_label(&type_manager).deref(), &person_label);
+        assert_eq!(*person_type.get_label(&type_manager).unwrap(), person_label);
 
-        let supertype = person_type.get_supertype(&type_manager);
-        assert_eq!(supertype.unwrap(), root_entity);
+        let supertype = person_type.get_supertype(&type_manager).unwrap().unwrap();
+        assert_eq!(supertype, root_entity);
 
         // --- child sub person ---
         let child_label = Label::build("child");
         let child_type = type_manager.get_entity_type(&child_label).unwrap().unwrap();
 
-        assert!(!child_type.is_root(&type_manager));
-        assert_eq!(child_type.get_label(&type_manager).deref(), &child_label);
+        assert!(!child_type.is_root(&type_manager).unwrap());
+        assert_eq!(*child_type.get_label(&type_manager).unwrap(), child_label);
 
-        let supertype = child_type.get_supertype(&type_manager);
-        assert_eq!(supertype.unwrap(), person_type);
-        let supertypes = child_type.get_supertypes(&type_manager);
+        let supertype = child_type.get_supertype(&type_manager).unwrap().unwrap();
+        assert_eq!(supertype, person_type);
+        let supertypes = child_type.get_supertypes(&type_manager).unwrap();
         assert_eq!(supertypes.len(), 2);
 
         // --- child owns age ---
-        let all_owns = child_type.get_owns(&type_manager);
+        let all_owns = child_type.get_owns(&type_manager).unwrap();
         assert_eq!(all_owns.len(), 1);
         let expected_owns = Owns::new(ObjectType::Entity(child_type.clone()), age_type.clone());
         assert!(all_owns.contains(&expected_owns));
-        assert_eq!(child_type.get_owns_attribute(&type_manager, age_type.clone()), Some(expected_owns));
-        assert!(child_type.has_owns_attribute(&type_manager, age_type.clone()));
+        assert_eq!(child_type.get_owns_attribute(&type_manager, age_type.clone()).unwrap(), Some(expected_owns));
+        assert!(child_type.has_owns_attribute(&type_manager, age_type.clone()).unwrap());
     }
 }
 
@@ -180,24 +180,23 @@ fn role_usage() {
         // Without cache, uncommitted
         let type_manager = TypeManager::new(snapshot.clone(), &type_vertex_generator, None);
         let root_relation = type_manager.get_relation_type(&Kind::Relation.root_label()).unwrap().unwrap();
-        assert_eq!(root_relation.get_label(&type_manager).deref(), &Kind::Relation.root_label());
-        assert!(root_relation.is_root(&type_manager));
-        assert!(root_relation.get_supertype(&type_manager).is_none());
-        assert_eq!(root_relation.get_supertypes(&type_manager).len(), 0);
+        assert_eq!(*root_relation.get_label(&type_manager).unwrap(), Kind::Relation.root_label());
+        assert!(root_relation.is_root(&type_manager).unwrap());
+        assert!(root_relation.get_supertype(&type_manager).unwrap().is_none());
+        assert_eq!(root_relation.get_supertypes(&type_manager).unwrap().len(), 0);
         assert!(root_relation
             .get_annotations(&type_manager)
             .unwrap()
             .contains(&RelationTypeAnnotation::Abstract(AnnotationAbstract::new())));
 
         let root_role = type_manager.get_role_type(&Kind::Role.root_label()).unwrap().unwrap();
-        assert_eq!(root_role.get_label(&type_manager).deref(), &Kind::Role.root_label());
-        assert!(root_role.is_root(&type_manager));
-        assert!(root_role.get_supertype(&type_manager).is_none());
-        assert_eq!(root_role.get_supertypes(&type_manager).len(), 0);
+        assert_eq!(*root_role.get_label(&type_manager).unwrap(), Kind::Role.root_label());
+        assert!(root_role.is_root(&type_manager).unwrap());
+        assert!(root_role.get_supertype(&type_manager).unwrap().is_none());
+        assert_eq!(root_role.get_supertypes(&type_manager).unwrap().len(), 0);
         assert!(root_role
             .get_annotations(&type_manager)
             .unwrap()
-            .deref()
             .contains(&RoleTypeAnnotation::Abstract(AnnotationAbstract::new())));
 
         // --- friendship sub relation, relates friend ---
@@ -236,7 +235,7 @@ fn role_usage() {
 
         // --- person plays friendship:friend ---
         let person_type = type_manager.get_entity_type(&person_label).unwrap().unwrap();
-        let plays = person_type.get_plays_role(&type_manager, role_type.clone().into_owned()).unwrap();
+        let plays = person_type.get_plays_role(&type_manager, role_type.clone().into_owned()).unwrap().unwrap();
         debug_assert_eq!(plays.player(), ObjectType::Entity(person_type.clone()));
         debug_assert_eq!(plays.role(), role_type);
     }

--- a/concept/thing/attribute.rs
+++ b/concept/thing/attribute.rs
@@ -14,24 +14,24 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 use std::cmp::Ordering;
 
 use bytes::Bytes;
-use encoding::{AsBytes, graph::thing::vertex_attribute::AttributeVertex, value::value_type::ValueType};
-use encoding::graph::type_::vertex::{build_vertex_attribute_type, TypeVertex};
-use encoding::graph::Typed;
-use storage::{
-    key_value::StorageKeyReference,
-    snapshot::{iterator::SnapshotRangeIterator, SnapshotError},
+use encoding::{
+    graph::{thing::vertex_attribute::AttributeVertex, type_::vertex::build_vertex_attribute_type, Typed},
+    value::value_type::ValueType,
+    AsBytes,
 };
+use storage::key_value::StorageKeyReference;
 
 use crate::{
-    ByteReference,
     concept_iterator,
-    ConceptAPI,
-    error::{ConceptError, ConceptErrorKind, ConceptReadError}, thing::{thing_manager::ThingManager, value::Value},
+    error::ConceptReadError,
+    thing::{thing_manager::ThingManager, value::Value},
+    type_::attribute_type::AttributeType,
+    ByteReference, ConceptAPI,
 };
-use crate::type_::attribute_type::AttributeType;
 
 #[derive(Clone, Debug)]
 pub struct Attribute<'a> {
@@ -60,7 +60,7 @@ impl<'a> Attribute<'a> {
         thing_manager.get_attribute_value(self)
     }
 
-    pub fn get_owners<'m, D>(&self, thing_manager: &'m ThingManager<'_, '_, D>)  {
+    pub fn get_owners<'m, D>(&self, thing_manager: &'m ThingManager<'_, '_, D>) {
         // -> ObjectIterator<'m, 1>
         todo!()
     }
@@ -99,4 +99,5 @@ impl<'a> Ord for Attribute<'a> {
 fn storage_key_to_attribute<'a>(storage_key_ref: StorageKeyReference<'a>) -> Attribute<'a> {
     Attribute::new(AttributeVertex::new(Bytes::Reference(storage_key_ref.byte_ref())))
 }
+
 concept_iterator!(AttributeIterator, Attribute, storage_key_to_attribute);

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -16,26 +16,27 @@
  */
 
 use bytes::Bytes;
-use encoding::{AsBytes, Prefixed};
-use encoding::graph::thing::edge::ThingEdgeHas;
-use encoding::graph::thing::vertex_object::ObjectVertex;
-use encoding::graph::type_::vertex::build_vertex_entity_type;
-use encoding::graph::Typed;
-use encoding::layout::prefix::Prefix;
-use storage::{
-    key_value::StorageKeyReference,
-    snapshot::{iterator::SnapshotRangeIterator, SnapshotError},
+use encoding::{
+    graph::{
+        thing::{edge::ThingEdgeHas, vertex_object::ObjectVertex},
+        type_::vertex::build_vertex_entity_type,
+        Typed,
+    },
+    layout::prefix::Prefix,
+    AsBytes, Prefixed,
 };
+use storage::key_value::StorageKeyReference;
 
 use crate::{
-    ByteReference,
     concept_iterator,
-    ConceptAPI, error::{ConceptError, ConceptErrorKind},
+    error::ConceptWriteError,
+    thing::{
+        attribute::{Attribute, AttributeIterator},
+        thing_manager::ThingManager,
+    },
+    type_::entity_type::EntityType,
+    ByteReference, ConceptAPI,
 };
-use crate::error::ConceptWriteError;
-use crate::thing::attribute::{Attribute, AttributeIterator};
-use crate::thing::thing_manager::ThingManager;
-use crate::type_::entity_type::EntityType;
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Entity<'a> {
@@ -56,19 +57,27 @@ impl<'a> Entity<'a> {
         self.vertex.bytes()
     }
 
-    pub fn get_has<'m, D>(&self, thing_manager: &'m ThingManager<'_, '_, D>)
-                          -> AttributeIterator<'m, { ThingEdgeHas::LENGTH_PREFIX_FROM_OBJECT }> {
+    pub fn get_has<'m, D>(
+        &self,
+        thing_manager: &'m ThingManager<'_, '_, D>,
+    ) -> AttributeIterator<'m, { ThingEdgeHas::LENGTH_PREFIX_FROM_OBJECT }> {
         thing_manager.storage_get_has(self.vertex())
     }
 
-    pub fn set_has<D>(&self, thing_manager: &ThingManager<'_, '_, D>, attribute: &Attribute<'_>)
-                      -> Result<(), ConceptWriteError> {
+    pub fn set_has<D>(
+        &self,
+        thing_manager: &ThingManager<'_, '_, D>,
+        attribute: &Attribute<'_>,
+    ) -> Result<(), ConceptWriteError> {
         // TODO: validate schema
         thing_manager.storage_set_has(self.vertex(), attribute.vertex())
     }
 
-    pub fn delete_has<D>(&self, thing_manager: &ThingManager<'_, '_, D>, attribute: &Attribute<'_>)
-                         -> Result<(), ConceptWriteError> {
+    pub fn delete_has<D>(
+        &self,
+        thing_manager: &ThingManager<'_, '_, D>,
+        attribute: &Attribute<'_>,
+    ) -> Result<(), ConceptWriteError> {
         // TODO: validate schema
         todo!()
     }

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -85,26 +85,22 @@ impl<'txn, 'storage: 'txn, D> ThingManager<'txn, 'storage, D> {
                     }
                     Value::Long(long) => {
                         let encoded_long = Long::build(long);
-                        self.vertex_generator
-                            .create_attribute_long(
-                                Typed::type_id(attribute_type.vertex()),
-                                encoded_long,
-                                write_snapshot,
-                            )
-                            .map_err(|error| ConceptWriteError::EncodingWrite { source: error })?
+                        self.vertex_generator.create_attribute_long(
+                            Typed::type_id(attribute_type.vertex()),
+                            encoded_long,
+                            write_snapshot,
+                        )
                     }
                     Value::Double(_double) => {
                         todo!()
                     }
                     Value::String(string) => {
                         let encoded_string: StringBytes<'_, BUFFER_KEY_INLINE> = StringBytes::build_ref(&string);
-                        self.vertex_generator
-                            .create_attribute_string(
-                                Typed::type_id(attribute_type.vertex()),
-                                encoded_string,
-                                write_snapshot,
-                            )
-                            .map_err(|error| ConceptWriteError::EncodingWrite { source: error })?
+                        self.vertex_generator.create_attribute_string(
+                            Typed::type_id(attribute_type.vertex()),
+                            encoded_string,
+                            write_snapshot,
+                        )
                     }
                 };
                 Ok(Attribute::new(vertex))

--- a/concept/type_/attribute_type.rs
+++ b/concept/type_/attribute_type.rs
@@ -67,7 +67,7 @@ impl<'a> TypeAPI<'a> for AttributeType<'a> {
 }
 
 impl<'a> AttributeType<'a> {
-    pub fn is_root<D>(&self, type_manager: &TypeManager<'_, '_, D>) -> bool {
+    pub fn is_root<D>(&self, type_manager: &TypeManager<'_, '_, D>) -> Result<bool, ConceptReadError> {
         type_manager.get_attribute_type_is_root(self.clone().into_owned())
     }
 
@@ -86,7 +86,10 @@ impl<'a> AttributeType<'a> {
         type_manager.get_attribute_type_value_type(self.clone().into_owned())
     }
 
-    pub fn get_label<'m, D>(&self, type_manager: &'m TypeManager<'_, '_, D>) -> MaybeOwns<'m, Label<'static>> {
+    pub fn get_label<'m, D>(
+        &self,
+        type_manager: &'m TypeManager<'_, '_, D>,
+    ) -> Result<MaybeOwns<'m, Label<'static>>, ConceptReadError> {
         type_manager.get_attribute_type_label(self.clone().into_owned())
     }
 
@@ -95,7 +98,10 @@ impl<'a> AttributeType<'a> {
         type_manager.set_storage_label(self.vertex().clone().into_owned(), label)
     }
 
-    fn get_supertype<D>(&self, type_manager: &TypeManager<'_, '_, D>) -> Option<AttributeType<'static>> {
+    fn get_supertype<D>(
+        &self,
+        type_manager: &TypeManager<'_, '_, D>,
+    ) -> Result<Option<AttributeType<'static>>, ConceptReadError> {
         type_manager.get_attribute_type_supertype(self.clone().into_owned())
     }
 
@@ -110,7 +116,7 @@ impl<'a> AttributeType<'a> {
     fn get_supertypes<'m, D>(
         &self,
         type_manager: &'m TypeManager<'_, '_, D>,
-    ) -> MaybeOwns<'m, Vec<AttributeType<'static>>> {
+    ) -> Result<MaybeOwns<'m, Vec<AttributeType<'static>>>, ConceptReadError> {
         type_manager.get_attribute_type_supertypes(self.clone().into_owned())
     }
 
@@ -135,7 +141,11 @@ impl<'a> AttributeType<'a> {
         }
     }
 
-    fn delete_annotation<D>(&self, type_manager: &TypeManager<'_, '_, D>, annotation: AttributeTypeAnnotation) {
+    fn delete_annotation<D>(
+        &self,
+        type_manager: &TypeManager<'_, '_, D>,
+        annotation: AttributeTypeAnnotation,
+    ) -> Result<(), ConceptWriteError> {
         match annotation {
             AttributeTypeAnnotation::Abstract(_) => {
                 type_manager.delete_storage_annotation_abstract(self.vertex().clone().into_owned())
@@ -169,7 +179,7 @@ impl From<Annotation> for AttributeTypeAnnotation {
     fn from(annotation: Annotation) -> Self {
         match annotation {
             Annotation::Abstract(annotation) => AttributeTypeAnnotation::Abstract(annotation),
-            Annotation::Duplicate(_) => unreachable!("Duplicate annotation not ")
+            Annotation::Duplicate(_) => unreachable!("Duplicate annotation not available for Attribute type."),
         }
     }
 }

--- a/concept/type_/mod.rs
+++ b/concept/type_/mod.rs
@@ -21,7 +21,7 @@ use encoding::graph::type_::vertex::TypeVertex;
 use primitive::maybe_owns::MaybeOwns;
 
 use crate::{
-    error::ConceptWriteError,
+    error::{ConceptReadError, ConceptWriteError},
     type_::{attribute_type::AttributeType, owns::Owns, plays::Plays, role_type::RoleType, type_manager::TypeManager},
     ConceptAPI,
 };
@@ -51,22 +51,29 @@ pub trait OwnerAPI<'a> {
         attribute_type: AttributeType<'static>,
     ) -> Result<Owns<'static>, ConceptWriteError>;
 
-    fn delete_owns<D>(&self, type_manager: &TypeManager<'_, '_, D>, attribute_type: AttributeType<'static>);
+    fn delete_owns<D>(
+        &self,
+        type_manager: &TypeManager<'_, '_, D>,
+        attribute_type: AttributeType<'static>,
+    ) -> Result<(), ConceptWriteError>;
 
-    fn get_owns<'m, D>(&self, type_manager: &'m TypeManager<'_, '_, D>) -> MaybeOwns<'m, HashSet<Owns<'static>>>;
+    fn get_owns<'m, D>(
+        &self,
+        type_manager: &'m TypeManager<'_, '_, D>,
+    ) -> Result<MaybeOwns<'m, HashSet<Owns<'static>>>, ConceptReadError>;
 
     fn get_owns_attribute<D>(
         &self,
         type_manager: &TypeManager<'_, '_, D>,
         attribute_type: AttributeType<'static>,
-    ) -> Option<Owns<'static>>;
+    ) -> Result<Option<Owns<'static>>, ConceptReadError>;
 
     fn has_owns_attribute<D>(
         &self,
         type_manager: &TypeManager<'_, '_, D>,
         attribute_type: AttributeType<'static>,
-    ) -> bool {
-        self.get_owns_attribute(type_manager, attribute_type).is_some()
+    ) -> Result<bool, ConceptReadError> {
+        Ok(self.get_owns_attribute(type_manager, attribute_type)?.is_some())
     }
 }
 
@@ -77,17 +84,28 @@ pub trait PlayerAPI<'a> {
         role_type: RoleType<'static>,
     ) -> Result<Plays<'static>, ConceptWriteError>;
 
-    fn delete_plays<D>(&self, type_manager: &TypeManager<'_, '_, D>, role_type: RoleType<'static>);
+    fn delete_plays<D>(
+        &self,
+        type_manager: &TypeManager<'_, '_, D>,
+        role_type: RoleType<'static>,
+    ) -> Result<(), ConceptWriteError>;
 
-    fn get_plays<'m, D>(&self, type_manager: &'m TypeManager<'_, '_, D>) -> MaybeOwns<'m, HashSet<Plays<'static>>>;
+    fn get_plays<'m, D>(
+        &self,
+        type_manager: &'m TypeManager<'_, '_, D>,
+    ) -> Result<MaybeOwns<'m, HashSet<Plays<'static>>>, ConceptReadError>;
 
     fn get_plays_role<D>(
         &self,
         type_manager: &TypeManager<'_, '_, D>,
         role_type: RoleType<'static>,
-    ) -> Option<Plays<'static>>;
+    ) -> Result<Option<Plays<'static>>, ConceptReadError>;
 
-    fn has_plays_role<D>(&self, type_manager: &TypeManager<'_, '_, D>, role_type: RoleType<'static>) -> bool {
-        self.get_plays_role(type_manager, role_type).is_some()
+    fn has_plays_role<D>(
+        &self,
+        type_manager: &TypeManager<'_, '_, D>,
+        role_type: RoleType<'static>,
+    ) -> Result<bool, ConceptReadError> {
+        Ok(self.get_plays_role(type_manager, role_type)?.is_some())
     }
 }

--- a/concept/type_/object_type.rs
+++ b/concept/type_/object_type.rs
@@ -20,7 +20,7 @@ use std::collections::HashSet;
 use primitive::maybe_owns::MaybeOwns;
 
 use crate::{
-    error::ConceptWriteError,
+    error::{ConceptReadError, ConceptWriteError},
     type_::{
         attribute_type::AttributeType, entity_type::EntityType, owns::Owns, plays::Plays, relation_type::RelationType,
         role_type::RoleType, type_manager::TypeManager, OwnerAPI, PlayerAPI,
@@ -46,14 +46,21 @@ impl<'a> OwnerAPI<'a> for ObjectType<'a> {
         }
     }
 
-    fn delete_owns<D>(&self, type_manager: &TypeManager<'_, '_, D>, attribute_type: AttributeType<'static>) {
+    fn delete_owns<D>(
+        &self,
+        type_manager: &TypeManager<'_, '_, D>,
+        attribute_type: AttributeType<'static>,
+    ) -> Result<(), ConceptWriteError> {
         match self {
             ObjectType::Entity(entity) => entity.delete_owns(type_manager, attribute_type),
             ObjectType::Relation(relation) => relation.delete_owns(type_manager, attribute_type),
         }
     }
 
-    fn get_owns<'m, D>(&self, type_manager: &'m TypeManager<'_, '_, D>) -> MaybeOwns<'m, HashSet<Owns<'static>>> {
+    fn get_owns<'m, D>(
+        &self,
+        type_manager: &'m TypeManager<'_, '_, D>,
+    ) -> Result<MaybeOwns<'m, HashSet<Owns<'static>>>, ConceptReadError> {
         match self {
             ObjectType::Entity(entity) => entity.get_owns(type_manager),
             ObjectType::Relation(relation) => relation.get_owns(type_manager),
@@ -64,7 +71,7 @@ impl<'a> OwnerAPI<'a> for ObjectType<'a> {
         &self,
         type_manager: &TypeManager<'_, '_, D>,
         attribute_type: AttributeType<'static>,
-    ) -> Option<Owns<'static>> {
+    ) -> Result<Option<Owns<'static>>, ConceptReadError> {
         match self {
             ObjectType::Entity(entity) => entity.get_owns_attribute(type_manager, attribute_type),
             ObjectType::Relation(relation) => relation.get_owns_attribute(type_manager, attribute_type),
@@ -84,14 +91,21 @@ impl<'a> PlayerAPI<'a> for ObjectType<'a> {
         }
     }
 
-    fn delete_plays<D>(&self, type_manager: &TypeManager<'_, '_, D>, role_type: RoleType<'static>) {
+    fn delete_plays<D>(
+        &self,
+        type_manager: &TypeManager<'_, '_, D>,
+        role_type: RoleType<'static>,
+    ) -> Result<(), ConceptWriteError> {
         match self {
             ObjectType::Entity(entity) => entity.delete_plays(type_manager, role_type),
             ObjectType::Relation(relation) => relation.delete_plays(type_manager, role_type),
         }
     }
 
-    fn get_plays<'m, D>(&self, type_manager: &'m TypeManager<'_, '_, D>) -> MaybeOwns<'m, HashSet<Plays<'static>>> {
+    fn get_plays<'m, D>(
+        &self,
+        type_manager: &'m TypeManager<'_, '_, D>,
+    ) -> Result<MaybeOwns<'m, HashSet<Plays<'static>>>, ConceptReadError> {
         match self {
             ObjectType::Entity(entity) => entity.get_plays(type_manager),
             ObjectType::Relation(relation) => relation.get_plays(type_manager),
@@ -102,7 +116,7 @@ impl<'a> PlayerAPI<'a> for ObjectType<'a> {
         &self,
         type_manager: &TypeManager<'_, '_, D>,
         role_type: RoleType<'static>,
-    ) -> Option<Plays<'static>> {
+    ) -> Result<Option<Plays<'static>>, ConceptReadError> {
         match self {
             ObjectType::Entity(entity) => entity.get_plays_role(type_manager, role_type),
             ObjectType::Relation(relation) => relation.get_plays_role(type_manager, role_type),

--- a/concept/type_/type_cache.rs
+++ b/concept/type_/type_cache.rs
@@ -216,8 +216,7 @@ impl TypeCache {
             })
             .unwrap();
         let max_entity_id = entities.iter().map(|e| Typed::type_id(e.vertex()).as_u16()).max().unwrap();
-        let mut caches: Box<[Option<EntityTypeCache>]> =
-            (0..=max_entity_id).map(|_| None).collect::<Vec<_>>().into_boxed_slice();
+        let mut caches = (0..=max_entity_id).map(|_| None).collect::<Vec<_>>().into_boxed_slice();
         let supertypes = Self::fetch_supertypes(snapshot, Prefix::VertexEntityType, EntityType::new);
         let owns = Self::fetch_owns(snapshot, Prefix::VertexEntityType, |v| ObjectType::Entity(EntityType::new(v)));
         let plays = Self::fetch_plays(snapshot, Prefix::VertexEntityType, |v| ObjectType::Entity(EntityType::new(v)));
@@ -278,8 +277,7 @@ impl TypeCache {
             })
             .unwrap();
         let max_relation_id = relations.iter().map(|r| Typed::type_id(r.vertex()).as_u16()).max().unwrap();
-        let mut caches: Box<[Option<RelationTypeCache>]> =
-            (0..=max_relation_id).map(|_| None).collect::<Vec<_>>().into_boxed_slice();
+        let mut caches = (0..=max_relation_id).map(|_| None).collect::<Vec<_>>().into_boxed_slice();
         let supertypes = Self::fetch_supertypes(snapshot, Prefix::VertexRelationType, RelationType::new);
         let relates = snapshot
             .iterate_range(PrefixRange::new_within(build_edge_relates_prefix_prefix(Prefix::VertexRelationType)))
@@ -355,8 +353,7 @@ impl TypeCache {
             })
             .unwrap();
         let max_role_id = roles.iter().map(|r| Typed::type_id(r.vertex()).as_u16()).max().unwrap();
-        let mut caches: Box<[Option<RoleTypeCache>]> =
-            (0..=max_role_id).map(|_| None).collect::<Vec<_>>().into_boxed_slice();
+        let mut caches = (0..=max_role_id).map(|_| None).collect::<Vec<_>>().into_boxed_slice();
         let supertypes = Self::fetch_supertypes(snapshot, Prefix::VertexRoleType, RoleType::new);
         let relates = snapshot
             .iterate_range(PrefixRange::new_within(build_edge_relates_reverse_prefix_prefix(Prefix::VertexRoleType)))
@@ -421,8 +418,7 @@ impl TypeCache {
             })
             .unwrap();
         let max_attribute_id = attributes.iter().map(|a| Typed::type_id(a.vertex()).as_u16()).max().unwrap();
-        let mut caches: Box<[Option<AttributeTypeCache>]> =
-            (0..=max_attribute_id).map(|_| None).collect::<Vec<_>>().into_boxed_slice();
+        let mut caches = (0..=max_attribute_id).map(|_| None).collect::<Vec<_>>().into_boxed_slice();
         let supertypes = Self::fetch_supertypes(snapshot, Prefix::VertexAttributeType, AttributeType::new);
         for attribute in attributes {
             let label = Self::read_type_label(vertex_properties, attribute.vertex().clone());

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -272,10 +272,7 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
     ) -> Result<EntityType<'static>, ConceptWriteError> {
         // TODO: validate type doesn't exist already
         if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let type_vertex = self
-                .vertex_generator
-                .create_entity_type(write_snapshot)
-                .map_err(|error| ConceptWriteError::EncodingWrite { source: error })?;
+            let type_vertex = self.vertex_generator.create_entity_type(write_snapshot);
             self.set_storage_label(type_vertex.clone(), label)?;
             if !is_root {
                 self.set_storage_supertype(
@@ -297,10 +294,7 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
     ) -> Result<RelationType<'static>, ConceptWriteError> {
         // TODO: validate type doesn't exist already
         if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let type_vertex = self
-                .vertex_generator
-                .create_relation_type(write_snapshot)
-                .map_err(|error| ConceptWriteError::EncodingWrite { source: error })?;
+            let type_vertex = self.vertex_generator.create_relation_type(write_snapshot);
             self.set_storage_label(type_vertex.clone(), label)?;
             if !is_root {
                 self.set_storage_supertype(
@@ -322,10 +316,7 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
     ) -> Result<RoleType<'static>, ConceptWriteError> {
         // TODO: validate type doesn't exist already
         if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let type_vertex = self
-                .vertex_generator
-                .create_role_type(write_snapshot)
-                .map_err(|error| ConceptWriteError::EncodingWrite { source: error })?;
+            let type_vertex = self.vertex_generator.create_role_type(write_snapshot);
             self.set_storage_label(type_vertex.clone(), label)?;
             self.set_storage_relates(relation_type.into_vertex(), type_vertex.clone())?;
             if !is_root {
@@ -347,10 +338,7 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
     ) -> Result<AttributeType<'static>, ConceptWriteError> {
         // TODO: validate type doesn't exist already
         if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let type_vertex = self
-                .vertex_generator
-                .create_attribute_type(write_snapshot)
-                .map_err(|error| ConceptWriteError::EncodingWrite { source: error })?;
+            let type_vertex = self.vertex_generator.create_attribute_type(write_snapshot);
             self.set_storage_label(type_vertex.clone(), label)?;
             if !is_root {
                 self.set_storage_supertype(
@@ -477,15 +465,11 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
         if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
             let vertex_to_label_key = build_property_type_label(owner.clone());
             let label_value = ByteArray::from(label.scoped_name().bytes());
-            write_snapshot
-                .put_val(vertex_to_label_key.into_storage_key().into_owned_array(), label_value)
-                .map_err(|error| ConceptWriteError::SnapshotPut { source: error })?;
+            write_snapshot.put_val(vertex_to_label_key.into_storage_key().into_owned_array(), label_value);
 
             let label_to_vertex_key = LabelToTypeVertexIndex::build(label);
             let vertex_value = ByteArray::from(owner.bytes());
-            write_snapshot
-                .put_val(label_to_vertex_key.into_storage_key().into_owned_array(), vertex_value)
-                .map_err(|error| ConceptWriteError::SnapshotPut { source: error })?;
+            write_snapshot.put_val(label_to_vertex_key.into_storage_key().into_owned_array(), vertex_value);
         } else {
             panic!("Illegal state: creating types requires write snapshot")
         }
@@ -524,13 +508,9 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
         self.may_delete_storage_supertype(subtype.clone());
         if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
             let sub = build_edge_sub(subtype.clone(), supertype.clone());
-            write_snapshot
-                .put(sub.into_storage_key().into_owned_array())
-                .map_err(|error| ConceptWriteError::SnapshotPut { source: error })?;
+            write_snapshot.put(sub.into_storage_key().into_owned_array());
             let sub_reverse = build_edge_sub_reverse(supertype, subtype);
-            write_snapshot
-                .put(sub_reverse.into_storage_key().into_owned_array())
-                .map_err(|error| ConceptWriteError::SnapshotPut { source: error })?;
+            write_snapshot.put(sub_reverse.into_storage_key().into_owned_array());
         } else {
             panic!("Illegal state: creating supertype edge requires write snapshot")
         }
@@ -573,13 +553,9 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
     ) -> Result<(), ConceptWriteError> {
         if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
             let owns = build_edge_owns(owner.clone(), attribute.clone());
-            write_snapshot
-                .put(owns.into_storage_key().into_owned_array())
-                .map_err(|error| ConceptWriteError::SnapshotPut { source: error })?;
+            write_snapshot.put(owns.into_storage_key().into_owned_array());
             let owns_reverse = build_edge_owns_reverse(attribute, owner);
-            write_snapshot
-                .put(owns_reverse.into_storage_key().into_owned_array())
-                .map_err(|error| ConceptWriteError::SnapshotPut { source: error })?;
+            write_snapshot.put(owns_reverse.into_storage_key().into_owned_array());
         } else {
             panic!("Illegal state: creating owns edge requires write snapshot")
         }
@@ -619,13 +595,9 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
     ) -> Result<(), ConceptWriteError> {
         if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
             let plays = build_edge_plays(player.clone(), role.clone());
-            write_snapshot
-                .put(plays.into_storage_key().into_owned_array())
-                .map_err(|error| ConceptWriteError::SnapshotPut { source: error })?;
+            write_snapshot.put(plays.into_storage_key().into_owned_array());
             let plays_reverse = build_edge_plays_reverse(role, player);
-            write_snapshot
-                .put(plays_reverse.into_storage_key().into_owned_array())
-                .map_err(|error| ConceptWriteError::SnapshotPut { source: error })?;
+            write_snapshot.put(plays_reverse.into_storage_key().into_owned_array());
         } else {
             panic!("Illegal state: creating plays edge requires write snapshot")
         }
@@ -665,13 +637,9 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
     ) -> Result<(), ConceptWriteError> {
         if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
             let relates = build_edge_relates(relation.clone(), role.clone());
-            write_snapshot
-                .put(relates.into_storage_key().into_owned_array())
-                .map_err(|error| ConceptWriteError::SnapshotPut { source: error })?;
+            write_snapshot.put(relates.into_storage_key().into_owned_array());
             let relates_reverse = build_edge_relates_reverse(role, relation);
-            write_snapshot
-                .put(relates_reverse.into_storage_key().into_owned_array())
-                .map_err(|error| ConceptWriteError::SnapshotPut { source: error })?;
+            write_snapshot.put(relates_reverse.into_storage_key().into_owned_array());
         } else {
             panic!("Illegal state: creating relates edge requires write snapshot")
         }
@@ -705,9 +673,7 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
         if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
             let property_key = build_property_type_value_type(vertex).into_storage_key().into_owned_array();
             let property_value = ByteArray::copy(&value_type.value_type_id().bytes());
-            write_snapshot
-                .put_val(property_key, property_value)
-                .map_err(|error| ConceptWriteError::SnapshotPut { source: error })?;
+            write_snapshot.put_val(property_key, property_value);
         } else {
             panic!("Illegal state: setting value type requires write snapshot.")
         }
@@ -728,9 +694,7 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
     pub(crate) fn set_storage_annotation_abstract(&self, vertex: TypeVertex<'static>) -> Result<(), ConceptWriteError> {
         if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
             let annotation_property = build_property_type_annotation_abstract(vertex);
-            write_snapshot
-                .put(annotation_property.into_storage_key().into_owned_array())
-                .map_err(|error| ConceptWriteError::SnapshotPut { source: error })?;
+            write_snapshot.put(annotation_property.into_storage_key().into_owned_array());
         } else {
             panic!("Illegal state: setting annotation requires write snapshot.")
         }

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -15,7 +15,7 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::{collections::HashSet, ops::Deref, rc::Rc, sync::Arc};
+use std::{collections::HashSet, rc::Rc, sync::Arc};
 
 use bytes::{byte_array::ByteArray, Bytes};
 use durability::DurabilityService;
@@ -79,8 +79,8 @@ pub struct TypeManager<'txn, 'storage: 'txn, D> {
 
 macro_rules! get_type_methods {
     ($(
-        $method_name:ident, $cache_method:ident, $output_type:ident, $new_vertex_method:ident
-    );*) => {
+        fn $method_name:ident() -> $output_type:ident = $cache_method:ident | $new_vertex_method:ident;
+    )*) => {
         $(
             pub fn $method_name(&self, label: &Label<'_>) -> Result<Option<$output_type<'static>>, ConceptReadError> {
                 if let Some(cache) = &self.type_cache {
@@ -107,20 +107,20 @@ macro_rules! get_type_methods {
 
 macro_rules! get_supertype_methods {
     ($(
-        $method_name:ident, $cache_method:ident, $type_:ident
-    );*) => {
+        fn $method_name:ident() -> $type_:ident = $cache_method:ident;
+    )*) => {
         $(
             // WARN: supertypes currently do NOT include themselves
-            pub(crate) fn $method_name(&self, type_: $type_<'static>) -> Option<$type_<'static>> {
+            pub(crate) fn $method_name(&self, type_: $type_<'static>) -> Result<Option<$type_<'static>>, ConceptReadError> {
                 if let Some(cache) = &self.type_cache {
-                    cache.$cache_method(type_)
+                    Ok(cache.$cache_method(type_))
                 } else {
-                    // TODO: handle possible errors
-                    self.snapshot
+                    Ok(self
+                        .snapshot
                         .iterate_range(PrefixRange::new_within(build_edge_sub_prefix_from(type_.into_vertex().clone())))
                         .first_cloned()
-                        .unwrap()
-                        .map(|(key, _)| $type_::new(new_edge_sub(key.into_byte_array_or_ref()).to().into_owned()))
+                        .map_err(|error| ConceptReadError::SnapshotIterate { source: error })?
+                        .map(|(key, _)| $type_::new(new_edge_sub(key.into_byte_array_or_ref()).to().into_owned())))
                 }
             }
         )*
@@ -129,13 +129,13 @@ macro_rules! get_supertype_methods {
 
 macro_rules! get_supertypes_methods {
     ($(
-        $method_name:ident, $cache_method:ident, $type_:ident
-    );*) => {
+        fn $method_name:ident() -> $type_:ident = $cache_method:ident;
+    )*) => {
         $(
             // WARN: supertypes currently do NOT include themselves
-            pub(crate) fn $method_name<'this>(&'this self, type_: $type_<'static>) -> MaybeOwns<'this, Vec<$type_<'static>>> {
+            pub(crate) fn $method_name(&self, type_: $type_<'static>) -> Result<MaybeOwns<'_, Vec<$type_<'static>>>, ConceptReadError> {
                 if let Some(cache) = &self.type_cache {
-                    MaybeOwns::borrowed(cache.$cache_method(type_))
+                    Ok(MaybeOwns::borrowed(cache.$cache_method(type_)))
                 } else {
                     let mut supertypes = Vec::new();
                     let mut super_vertex = self.get_storage_supertype(type_.vertex().clone().into_owned());
@@ -144,7 +144,7 @@ macro_rules! get_supertypes_methods {
                         super_vertex = self.get_storage_supertype(super_type.vertex().clone());
                         supertypes.push(super_type);
                     }
-                    MaybeOwns::owned(supertypes)
+                    Ok(MaybeOwns::owned(supertypes))
                 }
             }
         )*
@@ -153,14 +153,14 @@ macro_rules! get_supertypes_methods {
 
 macro_rules! get_type_is_root_methods {
     ($(
-        $method_name:ident, $cache_method:ident, $type_:ident, $base_variant:expr
-    );*) => {
+        fn $method_name:ident() -> $type_:ident = $cache_method:ident | $base_variant:expr;
+    )*) => {
         $(
-            pub(crate) fn $method_name(&self, type_: $type_<'static>) -> bool {
+            pub(crate) fn $method_name(&self, type_: $type_<'static>) -> Result<bool, ConceptReadError> {
                 if let Some(cache) = &self.type_cache {
-                    cache.$cache_method(type_)
+                    Ok(cache.$cache_method(type_))
                 } else {
-                    type_.get_label(self).deref() == &$base_variant.root_label()
+                    Ok(*type_.get_label(self)? == $base_variant.root_label())
                 }
             }
         )*
@@ -169,14 +169,14 @@ macro_rules! get_type_is_root_methods {
 
 macro_rules! get_type_label_methods {
     ($(
-        $method_name:ident, $cache_method:ident, $type_:ident
-    );*) => {
+        fn $method_name:ident() -> $type_:ident = $cache_method:ident;
+    )*) => {
         $(
-            pub(crate) fn $method_name(&self, type_: $type_<'static>) -> MaybeOwns<'_, Label<'static>> {
+            pub(crate) fn $method_name(&self, type_: $type_<'static>) -> Result<MaybeOwns<'_, Label<'static>>, ConceptReadError> {
                 if let Some(cache) = &self.type_cache {
-                    MaybeOwns::borrowed(cache.$cache_method(type_))
+                    Ok(MaybeOwns::borrowed(cache.$cache_method(type_)))
                 } else {
-                    MaybeOwns::owned(self.get_storage_label(type_.into_vertex()).unwrap().unwrap())
+                    Ok(MaybeOwns::owned(self.get_storage_label(type_.into_vertex())?.unwrap()))
                 }
             }
         )*
@@ -185,8 +185,8 @@ macro_rules! get_type_label_methods {
 
 macro_rules! get_type_annotations {
     ($(
-        $method_name:ident, $cache_method:ident, $type_:ident, $annotation_type:ident
-    );*) => {
+        fn $method_name:ident() -> $type_:ident = $cache_method:ident | $annotation_type:ident;
+    )*) => {
         $(
             pub(crate) fn $method_name(
                 &self, type_: $type_<'static>
@@ -235,55 +235,52 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
                 .set_annotation(&type_manager, AttributeTypeAnnotation::Abstract(AnnotationAbstract::new()))?;
         }
         // TODO: handle error properly
-        if let Snapshot::Write(write_snapshot) = Rc::try_unwrap(snapshot).ok().unwrap() {
-            write_snapshot.commit().unwrap();
-        } else {
-            panic!()
-        }
+        let Snapshot::Write(write_snapshot) = Rc::try_unwrap(snapshot).ok().unwrap() else { panic!() };
+        write_snapshot.commit().unwrap();
         Ok(())
     }
 
-    get_type_methods!(
-        get_entity_type, get_entity_type, EntityType, new_vertex_entity_type;
-        get_relation_type, get_relation_type, RelationType, new_vertex_relation_type;
-        get_role_type, get_role_type, RoleType, new_vertex_role_type;
-        get_attribute_type, get_attribute_type, AttributeType, new_vertex_attribute_type
-    );
+    get_type_methods! {
+        fn get_entity_type() -> EntityType = get_entity_type | new_vertex_entity_type;
+        fn get_relation_type() -> RelationType = get_relation_type | new_vertex_relation_type;
+        fn get_role_type() -> RoleType = get_role_type | new_vertex_role_type;
+        fn get_attribute_type() -> AttributeType = get_attribute_type | new_vertex_attribute_type;
+    }
 
-    get_supertype_methods!(
-        get_entity_type_supertype, get_entity_type_supertype, EntityType;
-        get_relation_type_supertype, get_relation_type_supertype, RelationType;
-        get_role_type_supertype, get_role_type_supertype, RoleType;
-        get_attribute_type_supertype, get_attribute_type_supertype, AttributeType
-    );
+    get_supertype_methods! {
+        fn get_entity_type_supertype() -> EntityType = get_entity_type_supertype;
+        fn get_relation_type_supertype() -> RelationType = get_relation_type_supertype;
+        fn get_role_type_supertype() -> RoleType = get_role_type_supertype;
+        fn get_attribute_type_supertype() -> AttributeType = get_attribute_type_supertype;
+    }
 
-    get_supertypes_methods!(
-        get_entity_type_supertypes, get_entity_type_supertypes, EntityType;
-        get_relation_type_supertypes, get_relation_type_supertypes, RelationType;
-        get_role_type_supertypes, get_role_type_supertypes, RoleType;
-        get_attribute_type_supertypes, get_attribute_type_supertypes, AttributeType
-    );
+    get_supertypes_methods! {
+        fn get_entity_type_supertypes() -> EntityType = get_entity_type_supertypes;
+        fn get_relation_type_supertypes() -> RelationType = get_relation_type_supertypes;
+        fn get_role_type_supertypes() -> RoleType = get_role_type_supertypes;
+        fn get_attribute_type_supertypes() -> AttributeType = get_attribute_type_supertypes;
+    }
 
     pub fn create_entity_type(
         &self,
         label: &Label<'_>,
         is_root: bool,
     ) -> Result<EntityType<'static>, ConceptWriteError> {
-        // TODO: validate type doesn't exist already
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let type_vertex = self.vertex_generator.create_entity_type(write_snapshot);
-            self.set_storage_label(type_vertex.clone(), label)?;
-            if !is_root {
-                self.set_storage_supertype(
-                    type_vertex.clone(),
-                    self.get_entity_type(&Kind::Entity.root_label()).unwrap().unwrap().into_vertex(),
-                )?;
-            }
-            Ok(EntityType::new(type_vertex))
-        } else {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             // TODO: this should not crash the server, and be handled as an Error instead
             panic!("Illegal state: creating types requires write snapshot")
+        };
+
+        // TODO: validate type doesn't exist already
+        let type_vertex = self.vertex_generator.create_entity_type(write_snapshot);
+        self.set_storage_label(type_vertex.clone(), label)?;
+        if !is_root {
+            self.set_storage_supertype(
+                type_vertex.clone(),
+                self.get_entity_type(&Kind::Entity.root_label()).unwrap().unwrap().into_vertex(),
+            )?;
         }
+        Ok(EntityType::new(type_vertex))
     }
 
     pub fn create_relation_type(
@@ -291,20 +288,20 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
         label: &Label<'_>,
         is_root: bool,
     ) -> Result<RelationType<'static>, ConceptWriteError> {
-        // TODO: validate type doesn't exist already
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let type_vertex = self.vertex_generator.create_relation_type(write_snapshot);
-            self.set_storage_label(type_vertex.clone(), label)?;
-            if !is_root {
-                self.set_storage_supertype(
-                    type_vertex.clone(),
-                    self.get_relation_type(&Kind::Relation.root_label()).unwrap().unwrap().into_vertex(),
-                )?;
-            }
-            Ok(RelationType::new(type_vertex))
-        } else {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: creating types requires write snapshot")
+        };
+
+        // TODO: validate type doesn't exist already
+        let type_vertex = self.vertex_generator.create_relation_type(write_snapshot);
+        self.set_storage_label(type_vertex.clone(), label)?;
+        if !is_root {
+            self.set_storage_supertype(
+                type_vertex.clone(),
+                self.get_relation_type(&Kind::Relation.root_label())?.unwrap().into_vertex(),
+            )?;
         }
+        Ok(RelationType::new(type_vertex))
     }
 
     pub(crate) fn create_role_type(
@@ -313,21 +310,21 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
         relation_type: RelationType<'static>,
         is_root: bool,
     ) -> Result<RoleType<'static>, ConceptWriteError> {
-        // TODO: validate type doesn't exist already
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let type_vertex = self.vertex_generator.create_role_type(write_snapshot);
-            self.set_storage_label(type_vertex.clone(), label)?;
-            self.set_storage_relates(relation_type.into_vertex(), type_vertex.clone())?;
-            if !is_root {
-                self.set_storage_supertype(
-                    type_vertex.clone(),
-                    self.get_role_type(&Kind::Role.root_label()).unwrap().unwrap().into_vertex(),
-                )?;
-            }
-            Ok(RoleType::new(type_vertex))
-        } else {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: creating types requires write snapshot")
+        };
+
+        // TODO: validate type doesn't exist already
+        let type_vertex = self.vertex_generator.create_role_type(write_snapshot);
+        self.set_storage_label(type_vertex.clone(), label)?;
+        self.set_storage_relates(relation_type.into_vertex(), type_vertex.clone())?;
+        if !is_root {
+            self.set_storage_supertype(
+                type_vertex.clone(),
+                self.get_role_type(&Kind::Role.root_label()).unwrap().unwrap().into_vertex(),
+            )?;
         }
+        Ok(RoleType::new(type_vertex))
     }
 
     pub fn create_attribute_type(
@@ -335,92 +332,92 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
         label: &Label<'_>,
         is_root: bool,
     ) -> Result<AttributeType<'static>, ConceptWriteError> {
-        // TODO: validate type doesn't exist already
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let type_vertex = self.vertex_generator.create_attribute_type(write_snapshot);
-            self.set_storage_label(type_vertex.clone(), label)?;
-            if !is_root {
-                self.set_storage_supertype(
-                    type_vertex.clone(),
-                    self.get_attribute_type(&Kind::Attribute.root_label()).unwrap().unwrap().into_vertex(),
-                )?;
-            }
-            Ok(AttributeType::new(type_vertex))
-        } else {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: creating types requires write snapshot")
+        };
+
+        // TODO: validate type doesn't exist already
+        let type_vertex = self.vertex_generator.create_attribute_type(write_snapshot);
+        self.set_storage_label(type_vertex.clone(), label)?;
+        if !is_root {
+            self.set_storage_supertype(
+                type_vertex.clone(),
+                self.get_attribute_type(&Kind::Attribute.root_label())?.unwrap().into_vertex(),
+            )?;
         }
+        Ok(AttributeType::new(type_vertex))
     }
 
-    get_type_is_root_methods!(
-        get_entity_type_is_root, get_entity_type_is_root, EntityType, Kind::Entity;
-        get_relation_type_is_root, get_relation_type_is_root, RelationType, Kind::Relation;
-        get_role_type_is_root, get_role_type_is_root, RoleType, Kind::Role;
-        get_attribute_type_is_root, get_attribute_type_is_root, AttributeType, Kind::Attribute
-    );
+    get_type_is_root_methods! {
+        fn get_entity_type_is_root() -> EntityType = get_entity_type_is_root | Kind::Entity;
+        fn get_relation_type_is_root() -> RelationType = get_relation_type_is_root | Kind::Relation;
+        fn get_role_type_is_root() -> RoleType = get_role_type_is_root | Kind::Role;
+        fn get_attribute_type_is_root() -> AttributeType = get_attribute_type_is_root | Kind::Attribute;
+    }
 
-    get_type_label_methods!(
-        get_entity_type_label, get_entity_type_label, EntityType;
-        get_relation_type_label, get_relation_type_label, RelationType;
-        get_role_type_label, get_role_type_label, RoleType;
-        get_attribute_type_label, get_attribute_type_label, AttributeType
-    );
+    get_type_label_methods! {
+        fn get_entity_type_label() -> EntityType = get_entity_type_label;
+        fn get_relation_type_label() -> RelationType = get_relation_type_label;
+        fn get_role_type_label() -> RoleType = get_role_type_label;
+        fn get_attribute_type_label() -> AttributeType = get_attribute_type_label;
+    }
 
-    pub(crate) fn get_entity_type_owns<'this>(
-        &'this self,
+    pub(crate) fn get_entity_type_owns(
+        &self,
         entity_type: EntityType<'static>,
-    ) -> MaybeOwns<'this, HashSet<Owns<'static>>> {
+    ) -> Result<MaybeOwns<'_, HashSet<Owns<'static>>>, ConceptReadError> {
         if let Some(cache) = &self.type_cache {
-            MaybeOwns::borrowed(cache.get_entity_type_owns(entity_type))
+            Ok(MaybeOwns::borrowed(cache.get_entity_type_owns(entity_type)))
         } else {
             let owns = self.get_storage_owns(entity_type.clone().into_vertex(), |attr_vertex| {
                 Owns::new(ObjectType::Entity(entity_type.clone()), AttributeType::new(attr_vertex.clone().into_owned()))
-            });
-            MaybeOwns::owned(owns)
+            })?;
+            Ok(MaybeOwns::owned(owns))
         }
     }
 
-    pub(crate) fn get_relation_type_owns<'this>(
-        &'this self,
+    pub(crate) fn get_relation_type_owns(
+        &self,
         relation_type: RelationType<'static>,
-    ) -> MaybeOwns<'this, HashSet<Owns<'static>>> {
+    ) -> Result<MaybeOwns<'_, HashSet<Owns<'static>>>, ConceptReadError> {
         if let Some(cache) = &self.type_cache {
-            MaybeOwns::borrowed(cache.get_relation_type_owns(relation_type))
+            Ok(MaybeOwns::borrowed(cache.get_relation_type_owns(relation_type)))
         } else {
             let owns = self.get_storage_owns(relation_type.clone().into_vertex(), |attr_vertex| {
                 Owns::new(
                     ObjectType::Relation(relation_type.clone()),
                     AttributeType::new(attr_vertex.clone().into_owned()),
                 )
-            });
-            MaybeOwns::owned(owns)
+            })?;
+            Ok(MaybeOwns::owned(owns))
         }
     }
 
-    pub(crate) fn get_relation_type_relates<'this>(
-        &'this self,
+    pub(crate) fn get_relation_type_relates(
+        &self,
         relation_type: RelationType<'static>,
-    ) -> MaybeOwns<'this, HashSet<Relates<'static>>> {
+    ) -> Result<MaybeOwns<'_, HashSet<Relates<'static>>>, ConceptReadError> {
         if let Some(cache) = &self.type_cache {
-            MaybeOwns::borrowed(cache.get_relation_type_relates(relation_type))
+            Ok(MaybeOwns::borrowed(cache.get_relation_type_relates(relation_type)))
         } else {
             let relates = self.get_storage_relates(relation_type.clone().into_vertex(), |role_vertex| {
                 Relates::new(relation_type.clone(), RoleType::new(role_vertex.clone().into_owned()))
-            });
-            MaybeOwns::owned(relates)
+            })?;
+            Ok(MaybeOwns::owned(relates))
         }
     }
 
     pub(crate) fn get_entity_type_plays<'this>(
         &'this self,
         entity_type: EntityType<'static>,
-    ) -> MaybeOwns<'this, HashSet<Plays<'static>>> {
+    ) -> Result<MaybeOwns<'this, HashSet<Plays<'static>>>, ConceptReadError> {
         if let Some(cache) = &self.type_cache {
-            MaybeOwns::borrowed(cache.get_entity_type_plays(entity_type))
+            Ok(MaybeOwns::borrowed(cache.get_entity_type_plays(entity_type)))
         } else {
             let plays = self.get_storage_plays(entity_type.clone().into_vertex(), |role_vertex| {
                 Plays::new(ObjectType::Entity(entity_type.clone()), RoleType::new(role_vertex.clone().into_owned()))
-            });
-            MaybeOwns::owned(plays)
+            })?;
+            Ok(MaybeOwns::owned(plays))
         }
     }
 
@@ -435,12 +432,12 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
         }
     }
 
-    get_type_annotations!(
-       get_entity_type_annotations, get_entity_type_annotations, EntityType, EntityTypeAnnotation;
-       get_relation_type_annotations, get_relation_type_annotations, RelationType, RelationTypeAnnotation;
-       get_role_type_annotations, get_role_type_annotations, RoleType, RoleTypeAnnotation;
-       get_attribute_type_annotations, get_attribute_type_annotations, AttributeType, AttributeTypeAnnotation
-    );
+    get_type_annotations! {
+        fn get_entity_type_annotations() -> EntityType = get_entity_type_annotations | EntityTypeAnnotation;
+        fn get_relation_type_annotations() -> RelationType = get_relation_type_annotations | RelationTypeAnnotation;
+        fn get_role_type_annotations() -> RoleType = get_role_type_annotations | RoleTypeAnnotation;
+        fn get_attribute_type_annotations() -> AttributeType = get_attribute_type_annotations | AttributeTypeAnnotation;
+    }
 
     // --- storage operations ---
     // TODO: these should take Concepts instead of Vertices
@@ -460,32 +457,34 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
         owner: TypeVertex<'static>,
         label: &Label<'_>,
     ) -> Result<(), ConceptWriteError> {
-        self.may_delete_storage_label(owner.clone())?;
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let vertex_to_label_key = build_property_type_label(owner.clone());
-            let label_value = ByteArray::from(label.scoped_name().bytes());
-            write_snapshot.put_val(vertex_to_label_key.into_storage_key().into_owned_array(), label_value);
-
-            let label_to_vertex_key = LabelToTypeVertexIndex::build(label);
-            let vertex_value = ByteArray::from(owner.bytes());
-            write_snapshot.put_val(label_to_vertex_key.into_storage_key().into_owned_array(), vertex_value);
-        } else {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: creating types requires write snapshot")
-        }
+        };
+
+        self.may_delete_storage_label(owner.clone())?;
+
+        let vertex_to_label_key = build_property_type_label(owner.clone());
+        let label_value = ByteArray::from(label.scoped_name().bytes());
+        write_snapshot.put_val(vertex_to_label_key.into_storage_key().into_owned_array(), label_value);
+
+        let label_to_vertex_key = LabelToTypeVertexIndex::build(label);
+        let vertex_value = ByteArray::from(owner.bytes());
+        write_snapshot.put_val(label_to_vertex_key.into_storage_key().into_owned_array(), vertex_value);
+
         Ok(())
     }
 
     fn may_delete_storage_label(&self, owner: TypeVertex<'_>) -> Result<(), ConceptWriteError> {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
+            panic!("Illegal state: creating types requires write snapshot")
+        };
+
         let existing_label = self.get_storage_label(owner.clone())?;
         if let Some(label) = existing_label {
-            if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-                let vertex_to_label_key = build_property_type_label(owner.clone());
-                write_snapshot.delete(vertex_to_label_key.into_storage_key().into_owned_array());
-                let label_to_vertex_key = LabelToTypeVertexIndex::build(&label);
-                write_snapshot.delete(label_to_vertex_key.into_storage_key().into_owned_array());
-            } else {
-                panic!("Illegal state: creating types requires write snapshot")
-            }
+            let vertex_to_label_key = build_property_type_label(owner.clone());
+            write_snapshot.delete(vertex_to_label_key.into_storage_key().into_owned_array());
+            let label_to_vertex_key = LabelToTypeVertexIndex::build(&label);
+            write_snapshot.delete(label_to_vertex_key.into_storage_key().into_owned_array());
         }
         Ok(())
     }
@@ -504,33 +503,37 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
         subtype: TypeVertex<'static>,
         supertype: TypeVertex<'static>,
     ) -> Result<(), ConceptWriteError> {
-        self.may_delete_storage_supertype(subtype.clone());
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let sub = build_edge_sub(subtype.clone(), supertype.clone());
-            write_snapshot.put(sub.into_storage_key().into_owned_array());
-            let sub_reverse = build_edge_sub_reverse(supertype, subtype);
-            write_snapshot.put(sub_reverse.into_storage_key().into_owned_array());
-        } else {
+        self.may_delete_storage_supertype(subtype.clone())?;
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: creating supertype edge requires write snapshot")
+        };
+        let sub = build_edge_sub(subtype.clone(), supertype.clone());
+        write_snapshot.put(sub.into_storage_key().into_owned_array());
+        let sub_reverse = build_edge_sub_reverse(supertype, subtype);
+        write_snapshot.put(sub_reverse.into_storage_key().into_owned_array());
+        Ok(())
+    }
+
+    fn may_delete_storage_supertype(&self, subtype: TypeVertex<'static>) -> Result<(), ConceptWriteError> {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
+            panic!("Illegal state: deleting supertype edge requires write snapshot")
+        };
+
+        let supertype = self.get_storage_supertype(subtype.clone());
+        if let Some(supertype) = supertype {
+            let sub = build_edge_sub(subtype.clone(), supertype.clone());
+            write_snapshot.delete(sub.into_storage_key().into_owned_array());
+            let sub_reverse = build_edge_sub_reverse(supertype, subtype);
+            write_snapshot.delete(sub_reverse.into_storage_key().into_owned_array());
         }
         Ok(())
     }
 
-    fn may_delete_storage_supertype(&self, subtype: TypeVertex<'static>) {
-        let supertype = self.get_storage_supertype(subtype.clone());
-        if let Some(supertype) = supertype {
-            if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-                let sub = build_edge_sub(subtype.clone(), supertype.clone());
-                write_snapshot.delete(sub.into_storage_key().into_owned_array());
-                let sub_reverse = build_edge_sub_reverse(supertype, subtype);
-                write_snapshot.delete(sub_reverse.into_storage_key().into_owned_array());
-            } else {
-                panic!("Illegal state: deleting supertype edge requires write snapshot")
-            }
-        }
-    }
-
-    fn get_storage_owns<F>(&self, owner: TypeVertex<'static>, mapper: F) -> HashSet<Owns<'static>>
+    fn get_storage_owns<F>(
+        &self,
+        owner: TypeVertex<'static>,
+        mapper: F,
+    ) -> Result<HashSet<Owns<'static>>, ConceptReadError>
     where
         F: for<'b> Fn(TypeVertex<'b>) -> Owns<'static>,
     {
@@ -542,7 +545,7 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
                 let owns_edge = new_edge_owns(Bytes::Reference(key.byte_ref()));
                 mapper(owns_edge.to())
             })
-            .unwrap()
+            .map_err(|error| ConceptReadError::SnapshotIterate { source: error })
     }
 
     pub(crate) fn set_storage_owns(
@@ -550,41 +553,48 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
         owner: TypeVertex<'static>,
         attribute: TypeVertex<'static>,
     ) -> Result<(), ConceptWriteError> {
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let owns = build_edge_owns(owner.clone(), attribute.clone());
-            write_snapshot.put(owns.into_storage_key().into_owned_array());
-            let owns_reverse = build_edge_owns_reverse(attribute, owner);
-            write_snapshot.put(owns_reverse.into_storage_key().into_owned_array());
-        } else {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: creating owns edge requires write snapshot")
-        }
+        };
+        let owns = build_edge_owns(owner.clone(), attribute.clone());
+        write_snapshot.put(owns.into_storage_key().into_owned_array());
+        let owns_reverse = build_edge_owns_reverse(attribute, owner);
+        write_snapshot.put(owns_reverse.into_storage_key().into_owned_array());
         Ok(())
     }
 
-    pub(crate) fn delete_storage_owns(&self, owner: TypeVertex<'static>, attribute: TypeVertex<'static>) {
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let owns = build_edge_owns(owner.clone(), attribute.clone());
-            write_snapshot.delete(owns.into_storage_key().into_owned_array());
-            let owns_reverse = build_edge_owns_reverse(attribute, owner);
-            write_snapshot.delete(owns_reverse.into_storage_key().into_owned_array());
-        } else {
+    pub(crate) fn delete_storage_owns(
+        &self,
+        owner: TypeVertex<'static>,
+        attribute: TypeVertex<'static>,
+    ) -> Result<(), ConceptWriteError> {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: deleting owns edge requires write snapshot")
-        }
+        };
+
+        let owns = build_edge_owns(owner.clone(), attribute.clone());
+        write_snapshot.delete(owns.into_storage_key().into_owned_array());
+        let owns_reverse = build_edge_owns_reverse(attribute, owner);
+        write_snapshot.delete(owns_reverse.into_storage_key().into_owned_array());
+        Ok(())
     }
 
-    fn get_storage_plays<F>(&self, player: TypeVertex<'static>, mapper: F) -> HashSet<Plays<'static>>
+    fn get_storage_plays<F>(
+        &self,
+        player: TypeVertex<'static>,
+        mapper: F,
+    ) -> Result<HashSet<Plays<'static>>, ConceptReadError>
     where
         F: for<'b> Fn(TypeVertex<'b>) -> Plays<'static>,
     {
         let plays_prefix = build_edge_plays_prefix_from(player);
-        // TODO: handle possible errors
         self.snapshot
             .iterate_range(PrefixRange::new_within(plays_prefix))
             .collect_cloned_key_hashset(|key| {
                 let plays_edge = new_edge_plays(Bytes::Reference(key.byte_ref()));
                 mapper(plays_edge.to())
             })
-            .unwrap()
+            .map_err(|error| ConceptReadError::SnapshotIterate { source: error })
     }
 
     pub(crate) fn set_storage_plays(
@@ -592,41 +602,47 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
         player: TypeVertex<'static>,
         role: TypeVertex<'static>,
     ) -> Result<(), ConceptWriteError> {
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let plays = build_edge_plays(player.clone(), role.clone());
-            write_snapshot.put(plays.into_storage_key().into_owned_array());
-            let plays_reverse = build_edge_plays_reverse(role, player);
-            write_snapshot.put(plays_reverse.into_storage_key().into_owned_array());
-        } else {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: creating plays edge requires write snapshot")
-        }
+        };
+        let plays = build_edge_plays(player.clone(), role.clone());
+        write_snapshot.put(plays.into_storage_key().into_owned_array());
+        let plays_reverse = build_edge_plays_reverse(role, player);
+        write_snapshot.put(plays_reverse.into_storage_key().into_owned_array());
         Ok(())
     }
 
-    pub(crate) fn delete_storage_plays(&self, player: TypeVertex<'static>, role: TypeVertex<'static>) {
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let plays = build_edge_plays(player.clone(), role.clone());
-            write_snapshot.delete(plays.into_storage_key().into_owned_array());
-            let plays_reverse = build_edge_plays_reverse(role, player);
-            write_snapshot.delete(plays_reverse.into_storage_key().into_owned_array());
-        } else {
+    pub(crate) fn delete_storage_plays(
+        &self,
+        player: TypeVertex<'static>,
+        role: TypeVertex<'static>,
+    ) -> Result<(), ConceptWriteError> {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: deleting plays edge requires write snapshot")
-        }
+        };
+        let plays = build_edge_plays(player.clone(), role.clone());
+        write_snapshot.delete(plays.into_storage_key().into_owned_array());
+        let plays_reverse = build_edge_plays_reverse(role, player);
+        write_snapshot.delete(plays_reverse.into_storage_key().into_owned_array());
+        Ok(())
     }
 
-    fn get_storage_relates<F>(&self, relation: TypeVertex<'static>, mapper: F) -> HashSet<Relates<'static>>
+    fn get_storage_relates<F>(
+        &self,
+        relation: TypeVertex<'static>,
+        mapper: F,
+    ) -> Result<HashSet<Relates<'static>>, ConceptReadError>
     where
         F: for<'b> Fn(TypeVertex<'b>) -> Relates<'static>,
     {
         let relates_prefix = build_edge_relates_prefix_from(relation);
-        // TODO: handle possible errors
         self.snapshot
             .iterate_range(PrefixRange::new_within(relates_prefix))
             .collect_cloned_key_hashset(|key| {
                 let relates_edge = new_edge_relates(Bytes::Reference(key.byte_ref()));
                 mapper(relates_edge.to())
             })
-            .unwrap()
+            .map_err(|error| ConceptReadError::SnapshotIterate { source: error })
     }
 
     pub(crate) fn set_storage_relates(
@@ -634,26 +650,31 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
         relation: TypeVertex<'static>,
         role: TypeVertex<'static>,
     ) -> Result<(), ConceptWriteError> {
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let relates = build_edge_relates(relation.clone(), role.clone());
-            write_snapshot.put(relates.into_storage_key().into_owned_array());
-            let relates_reverse = build_edge_relates_reverse(role, relation);
-            write_snapshot.put(relates_reverse.into_storage_key().into_owned_array());
-        } else {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: creating relates edge requires write snapshot")
-        }
+        };
+
+        let relates = build_edge_relates(relation.clone(), role.clone());
+        write_snapshot.put(relates.into_storage_key().into_owned_array());
+        let relates_reverse = build_edge_relates_reverse(role, relation);
+        write_snapshot.put(relates_reverse.into_storage_key().into_owned_array());
         Ok(())
     }
 
-    pub(crate) fn delete_storage_relates(&self, relation: TypeVertex<'static>, role: TypeVertex<'static>) {
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let relates = build_edge_relates(relation.clone(), role.clone());
-            write_snapshot.delete(relates.into_storage_key().into_owned_array());
-            let relates_reverse = build_edge_relates_reverse(role, relation);
-            write_snapshot.delete(relates_reverse.into_storage_key().into_owned_array());
-        } else {
+    pub(crate) fn delete_storage_relates(
+        &self,
+        relation: TypeVertex<'static>,
+        role: TypeVertex<'static>,
+    ) -> Result<(), ConceptWriteError> {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: deleting relates edge requires write snapshot")
-        }
+        };
+
+        let relates = build_edge_relates(relation.clone(), role.clone());
+        write_snapshot.delete(relates.into_storage_key().into_owned_array());
+        let relates_reverse = build_edge_relates_reverse(role, relation);
+        write_snapshot.delete(relates_reverse.into_storage_key().into_owned_array());
+        Ok(())
     }
 
     fn get_storage_value_type(&self, vertex: TypeVertex<'static>) -> Result<Option<ValueType>, ConceptReadError> {
@@ -669,13 +690,13 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
         vertex: TypeVertex<'static>,
         value_type: ValueType,
     ) -> Result<(), ConceptWriteError> {
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let property_key = build_property_type_value_type(vertex).into_storage_key().into_owned_array();
-            let property_value = ByteArray::copy(&value_type.value_type_id().bytes());
-            write_snapshot.put_val(property_key, property_value);
-        } else {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: setting value type requires write snapshot.")
-        }
+        };
+
+        let property_key = build_property_type_value_type(vertex).into_storage_key().into_owned_array();
+        let property_value = ByteArray::copy(&value_type.value_type_id().bytes());
+        write_snapshot.put_val(property_key, property_value);
         Ok(())
     }
 
@@ -691,22 +712,24 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
     }
 
     pub(crate) fn set_storage_annotation_abstract(&self, vertex: TypeVertex<'static>) -> Result<(), ConceptWriteError> {
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let annotation_property = build_property_type_annotation_abstract(vertex);
-            write_snapshot.put(annotation_property.into_storage_key().into_owned_array());
-        } else {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: setting annotation requires write snapshot.")
-        }
+        };
+        let annotation_property = build_property_type_annotation_abstract(vertex);
+        write_snapshot.put(annotation_property.into_storage_key().into_owned_array());
         Ok(())
     }
 
-    pub(crate) fn delete_storage_annotation_abstract(&self, vertex: TypeVertex<'static>) {
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let annotation_property = build_property_type_annotation_abstract(vertex);
-            write_snapshot.delete(annotation_property.into_storage_key().into_owned_array());
-        } else {
+    pub(crate) fn delete_storage_annotation_abstract(
+        &self,
+        vertex: TypeVertex<'static>,
+    ) -> Result<(), ConceptWriteError> {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: deleting annotation requires write snapshot.")
-        }
+        };
+        let annotation_property = build_property_type_annotation_abstract(vertex);
+        write_snapshot.delete(annotation_property.into_storage_key().into_owned_array());
+        Ok(())
     }
 
     fn get_storage_vertex_annotation_duplicate(
@@ -724,21 +747,23 @@ impl<'txn, 'storage: 'txn, D> TypeManager<'txn, 'storage, D> {
         &self,
         vertex: TypeVertex<'static>,
     ) -> Result<(), ConceptWriteError> {
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let annotation_property = build_property_type_annotation_duplicate(vertex);
-            write_snapshot.put(annotation_property.into_storage_key().into_owned_array());
-        } else {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: setting annotation requires write snapshot.")
-        }
+        };
+        let annotation_property = build_property_type_annotation_duplicate(vertex);
+        write_snapshot.put(annotation_property.into_storage_key().into_owned_array());
         Ok(())
     }
 
-    pub(crate) fn delete_storage_annotation_duplicate(&self, vertex: TypeVertex<'static>) {
-        if let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() {
-            let annotation_property = build_property_type_annotation_duplicate(vertex);
-            write_snapshot.delete(annotation_property.into_storage_key().into_owned_array());
-        } else {
+    pub(crate) fn delete_storage_annotation_duplicate(
+        &self,
+        vertex: TypeVertex<'static>,
+    ) -> Result<(), ConceptWriteError> {
+        let Snapshot::Write(write_snapshot) = self.snapshot.as_ref() else {
             panic!("Illegal state: deleting annotation requires write snapshot.")
-        }
+        };
+        let annotation_property = build_property_type_annotation_duplicate(vertex);
+        write_snapshot.delete(annotation_property.into_storage_key().into_owned_array());
+        Ok(())
     }
 }

--- a/database/database.rs
+++ b/database/database.rs
@@ -42,8 +42,8 @@ pub struct Database<D> {
 }
 
 impl<D> fmt::Debug for Database<D> {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Database").field("name", &self.name).field("path", &self.path).finish_non_exhaustive()
     }
 }
 

--- a/database/database.rs
+++ b/database/database.rs
@@ -29,7 +29,7 @@ use encoding::{
     graph::{thing::vertex_generator::ThingVertexGenerator, type_::vertex_generator::TypeVertexGenerator},
     EncodingKeyspace,
 };
-use storage::{error::MVCCStorageError, snapshot::Snapshot, MVCCStorage};
+use storage::{error::MVCCStorageError, snapshot::Snapshot, MVCCStorage, StorageRecoverError};
 
 use crate::transaction::{TransactionRead, TransactionWrite};
 
@@ -56,10 +56,10 @@ impl<D> Database<D> {
 
         let name = database_name.as_ref();
         if !path.exists() {
-            fs::create_dir(path).map_err(|error| FailedToCreateDirectory { path: path.to_owned(), source: error })?;
+            fs::create_dir(path).map_err(|error| DirectoryCreate { path: path.to_owned(), source: error })?;
         }
-        let mut storage = MVCCStorage::recover::<EncodingKeyspace>(name, path)
-            .map_err(|error| FailedToCreateStorage { source: error })?;
+        let mut storage =
+            MVCCStorage::recover::<EncodingKeyspace>(name, path).map_err(|error| StorageRecover { source: error })?;
         let type_vertex_generator = TypeVertexGenerator::new();
         let thing_vertex_generator = ThingVertexGenerator::new();
         TypeManager::initialise_types(&mut storage, &type_vertex_generator).unwrap();
@@ -92,8 +92,8 @@ impl<D> Database<D> {
 
 #[derive(Debug)]
 pub enum DatabaseRecoverError {
-    FailedToCreateDirectory { path: PathBuf, source: io::Error },
-    FailedToCreateStorage { source: MVCCStorageError },
+    DirectoryCreate { path: PathBuf, source: io::Error },
+    StorageRecover { source: StorageRecoverError },
 }
 
 impl fmt::Display for DatabaseRecoverError {
@@ -105,8 +105,8 @@ impl fmt::Display for DatabaseRecoverError {
 impl Error for DatabaseRecoverError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            Self::FailedToCreateDirectory { source, .. } => Some(source),
-            Self::FailedToCreateStorage { source } => Some(source),
+            Self::DirectoryCreate { source, .. } => Some(source),
+            Self::StorageRecover { source } => Some(source),
         }
     }
 }

--- a/encoding/benches/benchmark.rs
+++ b/encoding/benches/benchmark.rs
@@ -37,7 +37,7 @@ fn vertex_generation<D>(
     type_id: TypeID,
     write_snapshot: &WriteSnapshot<'_, D>,
 ) -> ObjectVertex<'static> {
-    thing_vertex_generator.create_entity(type_id, write_snapshot).unwrap()
+    thing_vertex_generator.create_entity(type_id, write_snapshot)
 }
 
 fn vertex_generation_to_key<D>(
@@ -45,7 +45,7 @@ fn vertex_generation_to_key<D>(
     type_id: TypeID,
     write_snapshot: &WriteSnapshot<'_, D>,
 ) -> StorageKey<'static, { BUFFER_KEY_INLINE }> {
-    thing_vertex_generator.create_entity(type_id, write_snapshot).unwrap().into_storage_key()
+    thing_vertex_generator.create_entity(type_id, write_snapshot).into_storage_key()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/encoding/error.rs
+++ b/encoding/error.rs
@@ -17,8 +17,6 @@
 
 use std::{error::Error, fmt, str::Utf8Error};
 
-use storage::snapshot::SnapshotPutError;
-
 #[derive(Debug)]
 pub struct EncodingError {
     pub kind: EncodingErrorKind,
@@ -39,25 +37,6 @@ impl Error for EncodingError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match &self.kind {
             EncodingErrorKind::FailedUFT8Decode { source, .. } => Some(source),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum EncodingWriteError {
-    SnapshotPut { source: SnapshotPutError },
-}
-
-impl fmt::Display for EncodingWriteError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
-    }
-}
-
-impl Error for EncodingWriteError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match &self {
-            Self::SnapshotPut { source, .. } => Some(source),
         }
     }
 }

--- a/encoding/graph/thing/vertex_generator.rs
+++ b/encoding/graph/thing/vertex_generator.rs
@@ -25,7 +25,6 @@ use primitive::prefix_range::PrefixRange;
 use storage::snapshot::WriteSnapshot;
 
 use crate::{
-    error::EncodingWriteError,
     graph::{
         thing::{
             vertex_attribute::{AttributeID, AttributeID17, AttributeID8, AttributeVertex},
@@ -107,12 +106,11 @@ impl ThingVertexGenerator {
         type_id: TypeID,
         value: Long,
         snapshot: &WriteSnapshot<'_, D>,
-    ) -> Result<AttributeVertex<'static>, EncodingWriteError> {
+    ) -> AttributeVertex<'static> {
         let long_atribute_id = LongAttributeID::build(value);
         let vertex = AttributeVertex::build(ValueType::Long, type_id, long_atribute_id.as_attribute_id());
-        snapshot.put(vertex.as_storage_key().into_owned_array())
-            .map_err(|error| EncodingWriteError::SnapshotPut { source: error })?;
-        Ok(vertex)
+        snapshot.put(vertex.as_storage_key().into_owned_array());
+        vertex
     }
 
     ///
@@ -130,12 +128,11 @@ impl ThingVertexGenerator {
         type_id: TypeID,
         value: StringBytes<'_, INLINE_LENGTH>,
         snapshot: &WriteSnapshot<'_, D>,
-    ) -> Result<AttributeVertex<'static>, EncodingWriteError> {
+    ) -> AttributeVertex<'static> {
         let string_attribute_id = self.create_string_attribute_id(type_id, value.clone_as_ref(), snapshot);
         let vertex = AttributeVertex::build(ValueType::String, type_id, string_attribute_id.as_attribute_id());
-        snapshot.put_val(vertex.as_storage_key().into_owned_array(), ByteArray::from(value.bytes()))
-            .map_err(|error| EncodingWriteError::SnapshotPut { source: error })?;
-        Ok(vertex)
+        snapshot.put_val(vertex.as_storage_key().into_owned_array(), ByteArray::from(value.bytes()));
+        vertex
     }
 
     fn create_string_attribute_id<const INLINE_LENGTH: usize, D>(

--- a/encoding/graph/type_/vertex_generator.rs
+++ b/encoding/graph/type_/vertex_generator.rs
@@ -20,7 +20,6 @@ use std::sync::atomic::{AtomicU16, Ordering};
 use storage::{snapshot::WriteSnapshot, MVCCStorage};
 
 use crate::{
-    error::EncodingWriteError,
     graph::type_::vertex::{
         build_vertex_attribute_type, build_vertex_attribute_type_prefix, build_vertex_entity_type,
         build_vertex_entity_type_prefix, build_vertex_relation_type, build_vertex_relation_type_prefix,
@@ -92,51 +91,31 @@ impl TypeVertexGenerator {
         TypeVertexGenerator { next_entity, next_relation, next_role, next_attribute }
     }
 
-    pub fn create_entity_type<D>(
-        &self,
-        snapshot: &WriteSnapshot<'_, D>,
-    ) -> Result<TypeVertex<'static>, EncodingWriteError> {
+    pub fn create_entity_type<D>(&self, snapshot: &WriteSnapshot<'_, D>) -> TypeVertex<'static> {
         let next = TypeID::build(self.next_entity.fetch_add(1, Ordering::Relaxed));
         let vertex = build_vertex_entity_type(next);
-        snapshot
-            .put(vertex.as_storage_key().into_owned_array())
-            .map_err(|error| EncodingWriteError::SnapshotPut { source: error })?;
-        Ok(vertex)
+        snapshot.put(vertex.as_storage_key().into_owned_array());
+        vertex
     }
 
-    pub fn create_relation_type<D>(
-        &self,
-        snapshot: &WriteSnapshot<'_, D>,
-    ) -> Result<TypeVertex<'static>, EncodingWriteError> {
+    pub fn create_relation_type<D>(&self, snapshot: &WriteSnapshot<'_, D>) -> TypeVertex<'static> {
         let next = TypeID::build(self.next_relation.fetch_add(1, Ordering::Relaxed));
         let vertex = build_vertex_relation_type(next);
-        snapshot
-            .put(vertex.as_storage_key().into_owned_array())
-            .map_err(|error| EncodingWriteError::SnapshotPut { source: error })?;
-        Ok(vertex)
+        snapshot.put(vertex.as_storage_key().into_owned_array());
+        vertex
     }
 
-    pub fn create_role_type<D>(
-        &self,
-        snapshot: &WriteSnapshot<'_, D>,
-    ) -> Result<TypeVertex<'static>, EncodingWriteError> {
+    pub fn create_role_type<D>(&self, snapshot: &WriteSnapshot<'_, D>) -> TypeVertex<'static> {
         let next = TypeID::build(self.next_role.fetch_add(1, Ordering::Relaxed));
         let vertex = build_vertex_role_type(next);
-        snapshot
-            .put(vertex.as_storage_key().into_owned_array())
-            .map_err(|error| EncodingWriteError::SnapshotPut { source: error })?;
-        Ok(vertex)
+        snapshot.put(vertex.as_storage_key().into_owned_array());
+        vertex
     }
 
-    pub fn create_attribute_type<D>(
-        &self,
-        snapshot: &WriteSnapshot<'_, D>,
-    ) -> Result<TypeVertex<'static>, EncodingWriteError> {
+    pub fn create_attribute_type<D>(&self, snapshot: &WriteSnapshot<'_, D>) -> TypeVertex<'static> {
         let next = TypeID::build(self.next_attribute.fetch_add(1, Ordering::Relaxed));
         let vertex = build_vertex_attribute_type(next);
-        snapshot
-            .put(vertex.as_storage_key().into_owned_array())
-            .map_err(|error| EncodingWriteError::SnapshotPut { source: error })?;
-        Ok(vertex)
+        snapshot.put(vertex.as_storage_key().into_owned_array());
+        vertex
     }
 }

--- a/encoding/tests/test_attribute_vertex.rs
+++ b/encoding/tests/test_attribute_vertex.rs
@@ -47,9 +47,8 @@ fn generate_string_attribute_vertex() {
     {
         let short_string = "Hello";
         let short_string_bytes: StringBytes<'_, BUFFER_KEY_INLINE> = StringBytes::build_ref(short_string);
-        let vertex = thing_vertex_generator
-            .create_attribute_string(type_id, short_string_bytes.clone_as_ref(), &snapshot)
-            .unwrap();
+        let vertex =
+            thing_vertex_generator.create_attribute_string(type_id, short_string_bytes.clone_as_ref(), &snapshot);
         let vertex_id = StringAttributeID::new(vertex.attribute_id().unwrap_bytes_17());
         assert!(vertex_id.is_inline());
         assert_eq!(vertex_id.get_inline_length() as usize, short_string_bytes.length());
@@ -60,8 +59,7 @@ fn generate_string_attribute_vertex() {
     {
         let string = "Hello world, this is a long attribute string to be encoded.";
         let string_bytes: StringBytes<'_, BUFFER_KEY_INLINE> = StringBytes::build_ref(string);
-        let vertex =
-            thing_vertex_generator.create_attribute_string(type_id, string_bytes.clone_as_ref(), &snapshot).unwrap();
+        let vertex = thing_vertex_generator.create_attribute_string(type_id, string_bytes.clone_as_ref(), &snapshot);
         let vertex_id = StringAttributeID::new(vertex.attribute_id().unwrap_bytes_17());
         assert!(!vertex_id.is_inline());
         assert_eq!(
@@ -83,8 +81,7 @@ fn generate_string_attribute_vertex() {
     {
         let string = "Hello world, this is a long attribute string to be encoded with a constant hash.";
         let string_bytes: StringBytes<'_, BUFFER_KEY_INLINE> = StringBytes::build_ref(string);
-        let vertex =
-            thing_vertex_generator.create_attribute_string(type_id, string_bytes.clone_as_ref(), &snapshot).unwrap();
+        let vertex = thing_vertex_generator.create_attribute_string(type_id, string_bytes.clone_as_ref(), &snapshot);
 
         let vertex_id = StringAttributeID::new(vertex.attribute_id().unwrap_bytes_17());
         assert!(!vertex_id.is_inline());
@@ -100,9 +97,8 @@ fn generate_string_attribute_vertex() {
 
         let string_collide = "Hello world, this is using the same prefix and will collide.";
         let string_collide_bytes: StringBytes<'_, BUFFER_KEY_INLINE> = StringBytes::build_ref(string_collide);
-        let collide_vertex = thing_vertex_generator
-            .create_attribute_string(type_id, string_collide_bytes.clone_as_ref(), &snapshot)
-            .unwrap();
+        let collide_vertex =
+            thing_vertex_generator.create_attribute_string(type_id, string_collide_bytes.clone_as_ref(), &snapshot);
 
         let collide_id = StringAttributeID::new(collide_vertex.attribute_id().unwrap_bytes_17());
         assert!(!collide_id.is_inline());

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -60,8 +60,10 @@ impl Server {
     }
 
     pub fn serve(mut self) {
-        self.databases.insert("test".to_owned(), Database::recover(&self.data_directory.join("test"), "test").unwrap());
-        todo!()
+        self.databases
+            .entry("test".to_owned())
+            .or_insert_with(|| Database::recover(&self.data_directory.join("test"), "test").unwrap());
+        dbg!(self.databases);
     }
 }
 

--- a/storage/benches/bench_mvcc_storage.rs
+++ b/storage/benches/bench_mvcc_storage.rs
@@ -72,7 +72,7 @@ fn populate_storage(storage: &MVCCStorage<WAL>, keyspace: TestKeyspaceSet, key_c
             snapshot.commit().unwrap();
             snapshot = storage.open_snapshot_write();
         }
-        snapshot.put(random_key_24(keyspace)).unwrap();
+        snapshot.put(random_key_24(keyspace));
     }
     snapshot.commit().unwrap();
     println!("Keys written: {}", key_count);
@@ -112,7 +112,7 @@ fn bench_snapshot_read_iterate<const ITERATE_COUNT: usize>(
 fn bench_snapshot_write_put(storage: &MVCCStorage<WAL>, keyspace: TestKeyspaceSet, batch_size: usize) {
     let snapshot = storage.open_snapshot_write();
     for _ in 0..batch_size {
-        snapshot.put(random_key_24(keyspace)).unwrap();
+        snapshot.put(random_key_24(keyspace));
     }
     snapshot.commit().unwrap()
 }

--- a/storage/durability/wal.rs
+++ b/storage/durability/wal.rs
@@ -101,8 +101,8 @@ impl DurabilityService for WAL {
         Ok(seq)
     }
 
-    fn iter_from(&self, sequence_number: SequenceNumber) -> io::Result<impl Iterator<Item = io::Result<RawRecord>>> {
-        RecordIterator::new(self.files.read().unwrap(), sequence_number)
+    fn iter_from(&self, sequence_number: SequenceNumber) -> Result<impl Iterator<Item = io::Result<RawRecord>>> {
+        Ok(RecordIterator::new(self.files.read().unwrap(), sequence_number)?)
     }
 }
 

--- a/storage/error.rs
+++ b/storage/error.rs
@@ -66,7 +66,6 @@ impl Error for MVCCStorageError {
             MVCCStorageErrorKind::IsolationError { source, .. } => Some(source),
             MVCCStorageErrorKind::DurabilityError { source, .. } => Some(source),
             MVCCStorageErrorKind::KeyspaceDeleteError { source } => Some(source),
-            _ => todo!(),
         }
     }
 }

--- a/storage/error.rs
+++ b/storage/error.rs
@@ -19,7 +19,7 @@ use std::{error::Error, fmt, sync::Arc};
 
 use durability::DurabilityError;
 
-use crate::{isolation_manager::IsolationError, keyspace::keyspace::KeyspaceError};
+use crate::{isolation_manager::IsolationError, keyspace::KeyspaceError};
 
 #[derive(Debug)]
 pub struct MVCCStorageError {

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -181,7 +181,7 @@ impl IsolationManager {
                 if predecessor_write.is_some() {
                     match write {
                         Write::Insert { .. } => {}
-                        Write::InsertPreexisting { reinsert, .. } => {
+                        Write::Put { reinsert, .. } => {
                             // Re-insert the value if a predecessor has deleted it. This may create extra versions of a key
                             //  in the case that the predecessor ends up failing. However, this will be rare.
                             if matches!(predecessor_write.unwrap(), Write::Delete) {

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -32,7 +32,7 @@ use primitive::u80::U80;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    keyspace::keyspace::KeyspaceId,
+    keyspace::KeyspaceId,
     snapshot::{buffer::KeyspaceBuffers, write::Write},
 };
 

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -181,7 +181,7 @@ impl IsolationManager {
                 if predecessor_write.is_some() {
                     match write {
                         Write::Insert { .. } => {}
-                        Write::InsertPreexisting(_, reinsert) => {
+                        Write::InsertPreexisting { reinsert, .. } => {
                             // Re-insert the value if a predecessor has deleted it. This may create extra versions of a key
                             //  in the case that the predecessor ends up failing. However, this will be rare.
                             if matches!(predecessor_write.unwrap(), Write::Delete) {

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -21,7 +21,7 @@ use std::{
     fmt,
     io::Read,
     sync::{
-        atomic::{AtomicU64, AtomicU8, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering},
         Arc, OnceLock, RwLock,
     },
 };
@@ -31,10 +31,7 @@ use logger::result::ResultExt;
 use primitive::u80::U80;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    keyspace::KeyspaceId,
-    snapshot::{buffer::KeyspaceBuffers, write::Write},
-};
+use crate::snapshot::{buffer::KeyspaceBuffers, write::Write};
 
 #[derive(Debug)]
 pub(crate) struct IsolationManager {
@@ -58,11 +55,11 @@ impl IsolationManager {
         IsolationManager { timeline: Timeline::new(next_sequence_number) }
     }
 
-    pub(crate) fn opened(&self, open_sequence_number: &SequenceNumber) {
+    pub(crate) fn opened(&self, open_sequence_number: SequenceNumber) {
         self.timeline.record_reader(open_sequence_number);
     }
 
-    pub(crate) fn closed(&self, open_sequence_number: &SequenceNumber) {
+    pub(crate) fn closed(&self, open_sequence_number: SequenceNumber) {
         self.timeline.remove_reader(open_sequence_number);
     }
 
@@ -72,89 +69,92 @@ impl IsolationManager {
         commit_record: CommitRecord,
     ) -> Result<(), IsolationError> {
         let open_sequence_number = commit_record.open_sequence_number;
-        let commit_window = self.pending(&commit_sequence_number, commit_record);
+        let commit_window = self.pending(commit_sequence_number, commit_record);
         let validation_result =
-            self.validate_all_concurrent(&commit_sequence_number, commit_window.get_record(&commit_sequence_number));
+            self.validate_all_concurrent(commit_sequence_number, commit_window.get_record(commit_sequence_number));
 
         if validation_result.is_ok() {
-            self.committed(&commit_sequence_number);
-            Ok(())
+            self.committed(commit_sequence_number);
         } else {
-            self.commit_failed(&commit_sequence_number, &open_sequence_number);
-            validation_result
+            self.commit_failed(commit_sequence_number, open_sequence_number);
         }
-    }
 
-    fn commit_failed(&self, commit_sequence_number: &SequenceNumber, open_sequence_number: &SequenceNumber) {
-        let self1 = &self.timeline;
-        let window = self1.get_window(commit_sequence_number);
-        window.set_closed(commit_sequence_number);
-        self.timeline.remove_reader(open_sequence_number);
+        validation_result.map_err(IsolationError::Conflict)
     }
 
     fn validate_all_concurrent(
         &self,
-        commit_sequence_number: &SequenceNumber,
+        commit_sequence_number: SequenceNumber,
         commit_record: &CommitRecord,
-    ) -> Result<(), IsolationError> {
+    ) -> Result<(), IsolationConflict> {
         debug_assert!(commit_record.open_sequence_number() < commit_sequence_number);
         // TODO: decide if we should block until all predecessors finish, allow out of order (non-Calvin model/traditional model)
         //       We could also validate against all predecessors even if they are validating and fail eagerly.
 
         let mut at = SequenceNumber::new(commit_record.open_sequence_number.number() + 1);
-        let Some(mut predecessor_window) = self.timeline.try_get_window(&at) else {
+        let Some(mut predecessor_window) = self.timeline.try_get_window(at) else {
             return Ok(()); // nothing to validate
         };
-        while at < *commit_sequence_number {
-            if !predecessor_window.contains(&at) {
-                predecessor_window = self.timeline.get_window(&at);
+        while at < commit_sequence_number {
+            if !predecessor_window.contains(at) {
+                predecessor_window = self.timeline.get_window(at);
             }
-            self.validate_concurrent(commit_record, &at, &predecessor_window)?;
+            if let Some(conflict) = self.resolve_concurrent(commit_record, at, &predecessor_window) {
+                return Err(conflict);
+            }
             at = SequenceNumber::new(at.number() + 1);
         }
         Ok(())
     }
 
-    fn validate_concurrent(
+    fn resolve_concurrent(
         &self,
         commit_record: &CommitRecord,
-        predecessor_sequence_number: &SequenceNumber,
-        predecessor_window: &Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>,
-    ) -> Result<(), IsolationError> {
+        predecessor_sequence_number: SequenceNumber,
+        predecessor_window: &TimelineWindow<TIMELINE_WINDOW_SIZE>,
+    ) -> Option<IsolationConflict> {
         let predecessor_status = predecessor_window.get_status(predecessor_sequence_number);
-        match predecessor_status {
-            CommitStatus::Empty => {
-                unreachable!("A concurrent status should never be empty at commit time")
-            }
+        let isolation_dependency = match predecessor_status {
+            CommitStatus::Empty => unreachable!("A concurrent status should never be empty at commit time"),
             CommitStatus::Pending(predecessor_record) => {
-                let result = self.validate_isolation(commit_record, predecessor_record);
-                if result.is_err() && self.await_pending_status_commits(predecessor_sequence_number, predecessor_window)
-                {
-                    result
-                } else {
-                    Ok(())
+                match self.compute_dependency(commit_record, predecessor_record) {
+                    IsolationDependency::Independent => IsolationDependency::Independent,
+                    result => {
+                        if self.await_pending_status_commits(predecessor_sequence_number, predecessor_window) {
+                            result
+                        } else {
+                            IsolationDependency::Independent
+                        }
+                    }
                 }
             }
-            CommitStatus::Committed(predecessor_record) => self.validate_isolation(commit_record, predecessor_record),
-            CommitStatus::Closed => Ok(()),
+            CommitStatus::Committed(predecessor_record) => self.compute_dependency(commit_record, predecessor_record),
+            CommitStatus::Closed => IsolationDependency::Independent,
+        };
+        match isolation_dependency {
+            IsolationDependency::Independent => None,
+            IsolationDependency::DependentPuts { puts } => {
+                puts.into_iter().for_each(|DependentPut { flag, value }| flag.store(value, Ordering::Release));
+                None
+            }
+            IsolationDependency::Conflict(conflict) => Some(conflict),
         }
     }
 
     fn await_pending_status_commits(
         &self,
-        predecessor_sequence_number: &SequenceNumber,
-        predecessor_window: &Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>,
+        predecessor_sequence_number: SequenceNumber,
+        predecessor_window: &TimelineWindow<TIMELINE_WINDOW_SIZE>,
     ) -> bool {
         debug_assert!(!matches!(predecessor_window.get_status(predecessor_sequence_number), CommitStatus::Empty));
         loop {
-            let status = predecessor_window.get_status(predecessor_sequence_number);
-            match status {
-                CommitStatus::Empty => unreachable!("Illegal state - commit status cannot move from pending"),
+            match predecessor_window.get_status(predecessor_sequence_number) {
+                CommitStatus::Empty => unreachable!("Illegal state - commit status cannot move from pending to empty"),
                 CommitStatus::Pending(_) => {
                     // TODO: we can improve the spin lock with async/await
                     // Note we only expect to have long waits in long chains of overlapping transactions that would conflict
                     // could also do a little sleep in the spin lock, for example if the validating is still far away
-                    continue;
+                    std::hint::spin_loop();
                 }
                 CommitStatus::Committed(_) => return true,
                 CommitStatus::Closed => return false,
@@ -162,68 +162,76 @@ impl IsolationManager {
         }
     }
 
-    fn validate_isolation(&self, record: &CommitRecord, predecessor: &CommitRecord) -> Result<(), IsolationError> {
-        // TODO: this can be optimised by some kind of bit-wise NAND of two bloom filter-like data structures first, since we assume few clashes this should mostly succeed
+    fn compute_dependency(&self, record: &CommitRecord, predecessor: &CommitRecord) -> IsolationDependency {
+        // TODO: this can be optimised by some kind of bit-wise NAND of two bloom filter-like data
+        // structures first, since we assume few clashes this should mostly succeed
         // TODO: can be optimised with an intersection of two sorted iterators instead of iterate + gets
-        for (index, buffer) in record.buffers().iter().enumerate() {
+
+        let mut puts_to_update = Vec::new();
+
+        for (buffer, predecessor_buffer) in record.buffers().iter().zip(predecessor.buffers()) {
             let map = buffer.map().read().unwrap();
             if map.is_empty() {
                 continue;
             }
 
-            let predecessor_map = predecessor.buffers.get(KeyspaceId(index as _)).map().read().unwrap();
+            let predecessor_map = predecessor_buffer.map().read().unwrap();
             if predecessor_map.is_empty() {
                 continue;
             }
 
             for (key, write) in map.iter() {
-                let predecessor_write = predecessor_map.get(key.bytes());
-                if predecessor_write.is_some() {
-                    match write {
-                        Write::Insert { .. } => {}
-                        Write::Put { reinsert, .. } => {
-                            // Re-insert the value if a predecessor has deleted it. This may create extra versions of a key
-                            //  in the case that the predecessor ends up failing. However, this will be rare.
-                            if matches!(predecessor_write.unwrap(), Write::Delete) {
-                                reinsert.store(true, Ordering::SeqCst);
-                            }
+                if let Some(predecessor_write) = predecessor_map.get(key.bytes()) {
+                    match (predecessor_write, write) {
+                        (Write::Delete, Write::RequireExists { .. }) => {
+                            return IsolationDependency::Conflict(IsolationConflict::DeleteRequired);
                         }
-                        Write::RequireExists { .. } => {
-                            if matches!(predecessor_write.unwrap(), Write::Delete) {
-                                return Err(IsolationError { kind: IsolationErrorKind::DeleteRequiredViolation });
-                            }
-                        }
-                        Write::Delete => {
-                            // we escalate delete-required to failure, since requires imply dependencies that may be broken
+                        (Write::RequireExists { .. }, Write::Delete) => {
+                            // we escalate required-delete to failure, since requires implies dependencies that may be broken
                             // TODO: maybe RequireExists should be RequireDependency to capture this?
-                            if matches!(predecessor_write.unwrap(), Write::RequireExists { .. }) {
-                                return Err(IsolationError { kind: IsolationErrorKind::RequiredDeleteViolation });
-                            }
+                            return IsolationDependency::Conflict(IsolationConflict::RequiredDelete);
                         }
+                        (Write::Insert { .. } | Write::Put { .. }, Write::Put { reinsert, .. }) => {
+                            puts_to_update.push(DependentPut { flag: reinsert.clone(), value: false });
+                        }
+                        (Write::Delete, Write::Put { reinsert, .. }) => {
+                            puts_to_update.push(DependentPut { flag: reinsert.clone(), value: true });
+                        }
+                        _ => (),
                     }
                 }
             }
         }
-        Ok(())
+
+        if puts_to_update.is_empty() {
+            IsolationDependency::Independent
+        } else {
+            IsolationDependency::DependentPuts { puts: puts_to_update }
+        }
     }
 
     fn pending(
         &self,
-        commit_sequence_number: &SequenceNumber,
+        commit_sequence_number: SequenceNumber,
         commit_record: CommitRecord,
     ) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
         self.timeline.record_pending(commit_sequence_number, commit_record)
     }
 
-    fn committed(&self, commit_sequence_number: &SequenceNumber) {
+    fn committed(&self, commit_sequence_number: SequenceNumber) {
         self.timeline.record_committed(commit_sequence_number)
+    }
+
+    fn commit_failed(&self, commit_sequence_number: SequenceNumber, open_sequence_number: SequenceNumber) {
+        self.timeline.get_window(commit_sequence_number).set_closed(commit_sequence_number);
+        self.timeline.remove_reader(open_sequence_number);
     }
 
     pub(crate) fn watermark(&self) -> SequenceNumber {
         self.timeline.watermark()
     }
 
-    pub(crate) fn apply_to_commit_record<F, T>(&self, sequence_number: &SequenceNumber, function: F) -> T
+    pub(crate) fn apply_to_commit_record<F, T>(&self, sequence_number: SequenceNumber, function: F) -> T
     where
         F: FnOnce(&CommitRecord) -> T,
     {
@@ -232,6 +240,38 @@ impl IsolationManager {
         function(record)
     }
 }
+
+#[derive(Debug)]
+struct DependentPut {
+    flag: Arc<AtomicBool>,
+    value: bool,
+}
+
+#[derive(Debug)]
+enum IsolationDependency {
+    Independent,
+    DependentPuts { puts: Vec<DependentPut> },
+    Conflict(IsolationConflict),
+}
+
+#[derive(Debug)]
+pub enum IsolationConflict {
+    DeleteRequired,
+    RequiredDelete,
+}
+
+#[derive(Debug)]
+pub enum IsolationError {
+    Conflict(IsolationConflict),
+}
+
+impl fmt::Display for IsolationError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+impl Error for IsolationError {}
 
 //
 // We can adjust the Window size to amortise the cost of the read-write locks to maintain the timeline
@@ -267,7 +307,7 @@ impl Timeline {
         debug_assert!(starting_sequence_number.number() > 0);
         let last_sequence_number_value = starting_sequence_number.number() - U80::new(1);
         let initial_window = Arc::new(TimelineWindow::new(SequenceNumber::new(last_sequence_number_value)));
-        let next_window_start = *initial_window.end();
+        let next_window_start = initial_window.end();
         let mut windows = VecDeque::new();
         windows.push_back(initial_window);
 
@@ -275,8 +315,8 @@ impl Timeline {
 
         // initialise the one virtual 'predecessor' so snapshots have a sequence number to open against
         let sequence_number = SequenceNumber::new(last_sequence_number_value);
-        let window = timeline.get_window(&sequence_number);
-        window.set_closed(&sequence_number);
+        let window = timeline.get_window(sequence_number);
+        window.set_closed(sequence_number);
         timeline
     }
 
@@ -314,14 +354,14 @@ impl Timeline {
             .unwrap_or_else(|| SequenceNumber::new(next_sequence_number.number() - U80::new(1)))
     }
 
-    fn record_reader(&self, sequence_number: &SequenceNumber) {
+    fn record_reader(&self, sequence_number: SequenceNumber) {
         let window = self.get_or_create_window(sequence_number);
         window.increment_readers();
     }
 
     fn record_pending(
         &self,
-        sequence_number: &SequenceNumber,
+        sequence_number: SequenceNumber,
         commit_record: CommitRecord,
     ) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
         let window = self.get_or_create_window(sequence_number);
@@ -329,21 +369,21 @@ impl Timeline {
         window
     }
 
-    fn record_committed(&self, sequence_number: &SequenceNumber) {
+    fn record_committed(&self, sequence_number: SequenceNumber) {
         let window = self.get_or_create_window(sequence_number);
         window.set_committed(sequence_number);
         self.remove_window_reader(sequence_number, &window);
     }
 
-    fn remove_reader(&self, reader_sequence_number: &SequenceNumber) {
+    fn remove_reader(&self, reader_sequence_number: SequenceNumber) {
         let read_window = self.get_window(reader_sequence_number);
         self.remove_window_reader(reader_sequence_number, &read_window);
     }
 
     fn remove_window_reader(
         &self,
-        reader_sequence_number: &SequenceNumber,
-        reader_window: &Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>,
+        reader_sequence_number: SequenceNumber,
+        reader_window: &TimelineWindow<TIMELINE_WINDOW_SIZE>,
     ) {
         debug_assert!(reader_window.contains(reader_sequence_number));
         let _readers_remaining = reader_window.decrement_readers();
@@ -359,27 +399,27 @@ impl Timeline {
         windows[windows.len() - 1].clone()
     }
 
-    fn get_or_create_window(&self, sequence_number: &SequenceNumber) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
+    fn get_or_create_window(&self, sequence_number: SequenceNumber) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
         self.try_get_window(sequence_number).clone().unwrap_or_else(|| self.create_windows_to(sequence_number))
     }
 
-    fn get_window(&self, sequence_number: &SequenceNumber) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
+    fn get_window(&self, sequence_number: SequenceNumber) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
         self.try_get_window(sequence_number).unwrap()
     }
 
-    fn try_get_window(&self, sequence_number: &SequenceNumber) -> Option<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>> {
+    fn try_get_window(&self, sequence_number: SequenceNumber) -> Option<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>> {
         let (_, windows) = &*self.next_window_and_windows.read().unwrap_or_log();
         Self::find_window(sequence_number, windows)
     }
 
     fn find_window(
-        sequence_number: &SequenceNumber,
+        sequence_number: SequenceNumber,
         windows: &VecDeque<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>,
     ) -> Option<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>> {
         windows.iter().rev().find(|window| window.contains(sequence_number)).cloned()
     }
 
-    fn create_windows_to(&self, sequence_number: &SequenceNumber) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
+    fn create_windows_to(&self, sequence_number: SequenceNumber) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
         let (next_window, windows) = &mut *self.next_window_and_windows.write().unwrap_or_log();
 
         // re-check if another thread created required window before we acquired lock
@@ -405,8 +445,8 @@ impl Timeline {
     }
 
     fn next_window_sequence_number(&self) -> SequenceNumber {
-        let (next_window_sequence_number, _) = &*self.next_window_and_windows.read().unwrap_or_log();
-        *next_window_sequence_number
+        let (next_window_sequence_number, _) = *self.next_window_and_windows.read().unwrap_or_log();
+        next_window_sequence_number
     }
 }
 
@@ -438,17 +478,17 @@ impl<const SIZE: usize> TimelineWindow<SIZE> {
     }
 
     /// Sequence number start of window (inclusive)
-    fn start(&self) -> &SequenceNumber {
-        &self.starting_sequence_number
+    fn start(&self) -> SequenceNumber {
+        self.starting_sequence_number
     }
 
     /// Sequence number end of window (exclusive)
-    fn end(&self) -> &SequenceNumber {
-        &self.end_sequence_number
+    fn end(&self) -> SequenceNumber {
+        self.end_sequence_number
     }
 
-    fn contains(&self, sequence_number: &SequenceNumber) -> bool {
-        self.starting_sequence_number <= *sequence_number && *sequence_number < self.end_sequence_number
+    fn contains(&self, sequence_number: SequenceNumber) -> bool {
+        self.starting_sequence_number <= sequence_number && sequence_number < self.end_sequence_number
     }
 
     fn is_finished(&self) -> bool {
@@ -467,34 +507,34 @@ impl<const SIZE: usize> TimelineWindow<SIZE> {
         })
     }
 
-    fn set_pending(&self, sequence_number: &SequenceNumber, commit_record: CommitRecord) {
+    fn set_pending(&self, sequence_number: SequenceNumber, commit_record: CommitRecord) {
         debug_assert!(self.contains(sequence_number));
         let index = self.index_of(sequence_number);
         self.commit_records[index].set(commit_record).unwrap_or_log();
         self.slots[index].store(SlotMarker::Pending.as_u8(), Ordering::SeqCst);
     }
 
-    fn set_committed(&self, sequence_number: &SequenceNumber) {
+    fn set_committed(&self, sequence_number: SequenceNumber) {
         debug_assert!(self.contains(sequence_number));
         let index = self.index_of(sequence_number);
         self.slots[index].store(SlotMarker::Committed.as_u8(), Ordering::SeqCst);
         self.available_slots.fetch_sub(1, Ordering::SeqCst);
     }
 
-    fn set_closed(&self, sequence_number: &SequenceNumber) {
+    fn set_closed(&self, sequence_number: SequenceNumber) {
         debug_assert!(self.contains(sequence_number));
         let index = self.index_of(sequence_number);
         self.slots[index].store(SlotMarker::Closed.as_u8(), Ordering::SeqCst);
         self.available_slots.fetch_sub(1, Ordering::SeqCst);
     }
 
-    fn get_record(&self, sequence_number: &SequenceNumber) -> &CommitRecord {
+    fn get_record(&self, sequence_number: SequenceNumber) -> &CommitRecord {
         debug_assert!(self.contains(sequence_number));
         let index = self.index_of(sequence_number);
         self.commit_records[index].get().unwrap()
     }
 
-    fn get_status<'this>(&'this self, sequence_number: &SequenceNumber) -> CommitStatus<'this> {
+    fn get_status(&self, sequence_number: SequenceNumber) -> CommitStatus<'_> {
         debug_assert!(self.contains(sequence_number));
         let index = self.index_of(sequence_number);
         let status = SlotMarker::from(self.slots[index].load(Ordering::SeqCst));
@@ -514,7 +554,7 @@ impl<const SIZE: usize> TimelineWindow<SIZE> {
         self.readers.fetch_sub(1, Ordering::SeqCst)
     }
 
-    fn index_of(&self, sequence_number: &SequenceNumber) -> usize {
+    fn index_of(&self, sequence_number: SequenceNumber) -> usize {
         debug_assert!(sequence_number.number() - self.starting_sequence_number.number() < usize::MAX as u128);
         (sequence_number.number() - self.starting_sequence_number.number()).number() as usize
     }
@@ -573,8 +613,8 @@ impl CommitRecord {
         &self.buffers
     }
 
-    pub(crate) fn open_sequence_number(&self) -> &SequenceNumber {
-        &self.open_sequence_number
+    pub(crate) fn open_sequence_number(&self) -> SequenceNumber {
+        self.open_sequence_number
     }
 
     fn deserialise_from(record_type: DurabilityRecordType, reader: impl Read)
@@ -608,34 +648,5 @@ impl DurabilityRecord for CommitRecord {
         let mut buf = Vec::new();
         reader.read_to_end(&mut buf).unwrap();
         bincode::deserialize(&buf)
-    }
-}
-
-#[derive(Debug)]
-pub struct IsolationError {
-    pub kind: IsolationErrorKind,
-}
-
-#[derive(Debug)]
-pub enum IsolationErrorKind {
-    DeleteRequiredViolation,
-    RequiredDeleteViolation,
-}
-
-impl fmt::Display for IsolationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.kind {
-            IsolationErrorKind::DeleteRequiredViolation => write!(f, "Isolation violation: Delete-Require conflict. A preceding concurrent commit has deleted a key required by this transaction. Please retry."),
-            IsolationErrorKind::RequiredDeleteViolation => write!(f, "Isolation violation: Require-Delete conflict. This commit has deleted a key required by a preceding concurrent transaction. Please retry."),
-        }
-    }
-}
-
-impl Error for IsolationError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match &self.kind {
-            IsolationErrorKind::DeleteRequiredViolation => None,
-            IsolationErrorKind::RequiredDeleteViolation => None,
-        }
     }
 }

--- a/storage/iterator.rs
+++ b/storage/iterator.rs
@@ -8,10 +8,7 @@ use primitive::prefix_range::PrefixRange;
 use super::{MVCCKey, MVCCStorage, StorageOperation, MVCC_KEY_INLINE_SIZE};
 use crate::{
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
-    keyspace::{
-        iterator::KeyspaceRangeIterator,
-        Keyspace, KeyspaceError,
-    },
+    keyspace::{iterator::KeyspaceRangeIterator, Keyspace, KeyspaceError},
 };
 
 pub(crate) struct MVCCRangeIterator<'storage, const PS: usize> {
@@ -120,8 +117,7 @@ impl<'storage, const P: usize> MVCCRangeIterator<'storage, P> {
             self.advance();
         }
         while matches!(&self.state, State::Init | State::ItemUsed) {
-            let peek = self.iterator.peek();
-            match peek {
+            match self.iterator.peek() {
                 None => self.state = State::Done,
                 Some(Ok((key, _))) => {
                     let mvcc_key = MVCCKey::wrap_slice(key);
@@ -145,7 +141,7 @@ impl<'storage, const P: usize> MVCCRangeIterator<'storage, P> {
     fn advance(&mut self) {
         match self.iterator.next() {
             None => self.state = State::Done,
-            Some(Ok(_)) => {}
+            Some(Ok(_)) => (),
             Some(Err(error)) => self.state = State::Error(Arc::new(error)),
         }
     }

--- a/storage/iterator.rs
+++ b/storage/iterator.rs
@@ -126,12 +126,12 @@ impl<'storage, const P: usize> MVCCRangeIterator<'storage, P> {
                 Some(Ok((key, _))) => {
                     let mvcc_key = MVCCKey::wrap_slice(key);
                     let is_visible = mvcc_key.is_visible_to(self.open_sequence_number)
-                        && !self.last_visible_key.as_ref().is_some_and(|key| key == mvcc_key.bytes());
+                        && !self.last_visible_key.as_ref().is_some_and(|key| key == mvcc_key.key());
                     if is_visible {
                         self.last_visible_key = Some(ByteArray::copy(mvcc_key.key()));
                         match mvcc_key.operation() {
                             StorageOperation::Insert => self.state = State::ItemReady,
-                            StorageOperation::Delete => {}
+                            StorageOperation::Delete => self.advance(),
                         }
                     } else {
                         self.advance()

--- a/storage/iterator.rs
+++ b/storage/iterator.rs
@@ -10,7 +10,7 @@ use crate::{
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
     keyspace::{
         iterator::KeyspaceRangeIterator,
-        keyspace::{Keyspace, KeyspaceError},
+        Keyspace, KeyspaceError,
     },
 };
 

--- a/storage/key_value.rs
+++ b/storage/key_value.rs
@@ -21,7 +21,7 @@ use bytes::{byte_array::ByteArray, byte_reference::ByteReference, Bytes};
 use primitive::prefix_range::Prefix;
 use serde::{Deserialize, Serialize};
 
-use crate::{keyspace::keyspace::KeyspaceId, KeyspaceSet};
+use crate::{keyspace::KeyspaceId, KeyspaceSet};
 
 #[derive(Debug, Clone)]
 pub enum StorageKey<'bytes, const S: usize> {

--- a/storage/keyspace/keyspace.rs
+++ b/storage/keyspace/keyspace.rs
@@ -79,29 +79,22 @@ impl Keyspace {
 
     pub(crate) fn open(
         storage_path: &Path,
-        keyspace_id: impl KeyspaceSet,
+        keyspace: impl KeyspaceSet,
         options: &Options,
     ) -> Result<Keyspace, KeyspaceOpenError> {
         use KeyspaceOpenError::SpeeDB;
-        let name = keyspace_id.name();
+        let name = keyspace.name();
         let path = storage_path.join(name);
-        let kv_storage = DB::open(options, &path).map_err(|error| SpeeDB { source: error })?;
-        Ok(Self::new(path, keyspace_id, kv_storage))
+        let kv_storage = DB::open(options, &path).map_err(|error| SpeeDB { name, source: error })?;
+        Ok(Self::new(path, keyspace, kv_storage))
     }
 
-    fn new(path: PathBuf, keyspace_id: impl KeyspaceSet, kv_storage: DB) -> Self {
+    fn new(path: PathBuf, keyspace: impl KeyspaceSet, kv_storage: DB) -> Self {
         // initial read options, should be customised to this storage's properties
         let read_options = ReadOptions::default();
         let mut write_options = WriteOptions::default();
         write_options.disable_wal(true);
-        Self {
-            path,
-            name: keyspace_id.name(),
-            id: KeyspaceId(keyspace_id.id()),
-            kv_storage,
-            read_options,
-            write_options,
-        }
+        Self { path, name: keyspace.name(), id: KeyspaceId(keyspace.id()), kv_storage, read_options, write_options }
     }
 
     // TODO: we want to be able to pass new options, since Rocks can handle rebooting with new options
@@ -224,7 +217,7 @@ impl Error for KeyspaceCreateError {
 
 #[derive(Debug)]
 pub enum KeyspaceOpenError {
-    SpeeDB { source: speedb::Error },
+    SpeeDB { name: &'static str, source: speedb::Error },
 }
 
 impl fmt::Display for KeyspaceOpenError {
@@ -236,7 +229,7 @@ impl fmt::Display for KeyspaceOpenError {
 impl Error for KeyspaceOpenError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            Self::SpeeDB { source } => Some(source),
+            Self::SpeeDB { source, .. } => Some(source),
         }
     }
 }

--- a/storage/keyspace/keyspace.rs
+++ b/storage/keyspace/keyspace.rs
@@ -59,24 +59,6 @@ pub(crate) struct Keyspace {
 }
 
 impl Keyspace {
-    pub(crate) fn create(
-        storage_path: &Path,
-        keyspace_id: impl KeyspaceSet,
-        options: &Options,
-    ) -> Result<Keyspace, KeyspaceCreateError> {
-        use KeyspaceCreateError::{AlreadyExists, SpeeDB};
-
-        let name = keyspace_id.name();
-        let path = storage_path.join(name);
-
-        if path.exists() {
-            return Err(AlreadyExists { name });
-        }
-
-        let kv_storage = DB::open(options, &path).map_err(|error| SpeeDB { name, source: error })?;
-        Ok(Self::new(path, keyspace_id, kv_storage))
-    }
-
     pub(crate) fn open(
         storage_path: &Path,
         keyspace: impl KeyspaceSet,
@@ -188,30 +170,6 @@ impl Keyspace {
 impl fmt::Debug for Keyspace {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Keyspace[name={}, path={}, id={}]", self.name(), self.path.to_str().unwrap(), self.id,)
-    }
-}
-
-#[derive(Debug)]
-pub enum KeyspaceCreateError {
-    AlreadyExists { name: &'static str },
-    SpeeDB { name: &'static str, source: speedb::Error },
-}
-
-impl fmt::Display for KeyspaceCreateError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::AlreadyExists { .. } => todo!(),
-            Self::SpeeDB { .. } => todo!(),
-        }
-    }
-}
-
-impl Error for KeyspaceCreateError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::AlreadyExists { .. } => None,
-            Self::SpeeDB { source, .. } => Some(source),
-        }
     }
 }
 

--- a/storage/keyspace/mod.rs
+++ b/storage/keyspace/mod.rs
@@ -16,4 +16,9 @@
  */
 
 pub mod iterator;
-pub mod keyspace;
+mod keyspace;
+
+pub(crate) use keyspace::{
+    Keyspace, KeyspaceCheckpointError, KeyspaceError, KeyspaceId, KeyspaceOpenError, KEYSPACE_ID_MAX,
+    KEYSPACE_ID_RESERVED_UNSET, KEYSPACE_MAXIMUM_COUNT,
+};

--- a/storage/snapshot/buffer.rs
+++ b/storage/snapshot/buffer.rs
@@ -92,7 +92,7 @@ impl KeyspaceBuffer {
     }
 
     pub(crate) fn insert_preexisting(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
-        self.buffer.write().unwrap().insert(key, Write::InsertPreexisting(value, Arc::new(AtomicBool::new(false))));
+        self.buffer.write().unwrap().insert(key, Write::InsertPreexisting { value, reinsert: Arc::default() });
     }
 
     pub(crate) fn require_exists(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
@@ -116,9 +116,9 @@ impl KeyspaceBuffer {
     pub(crate) fn get<const INLINE_BYTES: usize>(&self, key: &[u8]) -> Option<ByteArray<INLINE_BYTES>> {
         let map = self.buffer.read().unwrap();
         match map.get(key) {
-            Some(Write::Insert { value }) => Some(ByteArray::copy(value.bytes())),
-            Some(Write::InsertPreexisting(value, _)) => Some(ByteArray::copy(value.bytes())),
-            Some(Write::RequireExists { value }) => Some(ByteArray::copy(value.bytes())),
+            | Some(Write::Insert { value })
+            | Some(Write::InsertPreexisting { value, .. })
+            | Some(Write::RequireExists { value }) => Some(ByteArray::copy(value.bytes())),
             Some(Write::Delete) | None => None,
         }
     }

--- a/storage/snapshot/buffer.rs
+++ b/storage/snapshot/buffer.rs
@@ -91,13 +91,13 @@ impl KeyspaceBuffer {
         self.buffer.write().unwrap().insert(key, Write::Insert { value });
     }
 
-    pub(crate) fn insert_preexisting(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
-        self.buffer.write().unwrap().insert(key, Write::InsertPreexisting { value, reinsert: Arc::default() });
+    pub(crate) fn put(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
+        self.buffer.write().unwrap().insert(key, Write::Put { value, reinsert: Arc::default() });
     }
 
     pub(crate) fn require_exists(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
         let mut map = self.buffer.write().unwrap();
-        // TODO: what if it already has been inserted? Ie. InsertPreexisting?
+        // TODO: what if it already has been inserted? Ie. Put?
         map.insert(key, Write::RequireExists { value });
     }
 
@@ -116,9 +116,9 @@ impl KeyspaceBuffer {
     pub(crate) fn get<const INLINE_BYTES: usize>(&self, key: &[u8]) -> Option<ByteArray<INLINE_BYTES>> {
         let map = self.buffer.read().unwrap();
         match map.get(key) {
-            | Some(Write::Insert { value })
-            | Some(Write::InsertPreexisting { value, .. })
-            | Some(Write::RequireExists { value }) => Some(ByteArray::copy(value.bytes())),
+            Some(Write::Insert { value }) | Some(Write::Put { value, .. }) | Some(Write::RequireExists { value }) => {
+                Some(ByteArray::copy(value.bytes()))
+            }
             Some(Write::Delete) | None => None,
         }
     }

--- a/storage/snapshot/buffer.rs
+++ b/storage/snapshot/buffer.rs
@@ -21,7 +21,7 @@ use std::{
     collections::{BTreeMap, Bound},
     fmt, mem,
     mem::MaybeUninit,
-    sync::{atomic::AtomicBool, Arc, RwLock},
+    sync::{Arc, RwLock},
 };
 
 use bytes::{byte_array::ByteArray, util::increment, Bytes};
@@ -37,7 +37,7 @@ use serde::{
 
 use crate::{
     key_value::StorageKeyArray,
-    keyspace::keyspace::{KeyspaceId, KEYSPACE_MAXIMUM_COUNT},
+    keyspace::{KeyspaceId, KEYSPACE_MAXIMUM_COUNT},
     snapshot::{snapshot::SnapshotError, write::Write},
 };
 

--- a/storage/snapshot/buffer.rs
+++ b/storage/snapshot/buffer.rs
@@ -100,13 +100,13 @@ impl KeyspaceBuffer {
         self.buffer.write().unwrap().insert(key, Write::Insert { value });
     }
 
-    pub(crate) fn put(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
-        self.buffer.write().unwrap().insert(key, Write::Put { value, reinsert: Arc::default() });
+    pub(crate) fn insert_preexisting(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
+        self.buffer.write().unwrap().insert(key, Write::InsertPreexisting { value, reinsert: Arc::default() });
     }
 
     pub(crate) fn require_exists(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
         let mut map = self.buffer.write().unwrap();
-        // TODO: what if it already has been inserted? Ie. Put?
+        // TODO: what if it already has been inserted? Ie. InsertPreexisting?
         map.insert(key, Write::RequireExists { value });
     }
 
@@ -125,9 +125,9 @@ impl KeyspaceBuffer {
     pub(crate) fn get<const INLINE_BYTES: usize>(&self, key: &[u8]) -> Option<ByteArray<INLINE_BYTES>> {
         let map = self.buffer.read().unwrap();
         match map.get(key) {
-            Some(Write::Insert { value }) | Some(Write::Put { value, .. }) | Some(Write::RequireExists { value }) => {
-                Some(ByteArray::copy(value.bytes()))
-            }
+            Some(Write::Insert { value })
+            | Some(Write::InsertPreexisting { value, .. })
+            | Some(Write::RequireExists { value }) => Some(ByteArray::copy(value.bytes())),
             Some(Write::Delete) | None => None,
         }
     }

--- a/storage/snapshot/buffer.rs
+++ b/storage/snapshot/buffer.rs
@@ -35,6 +35,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
+use super::iterator::SnapshotIteratorError;
 use crate::{
     key_value::StorageKeyArray,
     keyspace::{KeyspaceId, KEYSPACE_MAXIMUM_COUNT},
@@ -183,7 +184,9 @@ impl BufferedPrefixIterator {
         Self { state: State::Init, index: 0, range }
     }
 
-    pub(crate) fn peek(&mut self) -> Option<Result<(&StorageKeyArray<BUFFER_KEY_INLINE>, &Write), SnapshotError>> {
+    pub(crate) fn peek(
+        &mut self,
+    ) -> Option<Result<(&StorageKeyArray<BUFFER_KEY_INLINE>, &Write), SnapshotIteratorError>> {
         match &self.state {
             State::Done => None,
             State::Init => {

--- a/storage/snapshot/iterator.rs
+++ b/storage/snapshot/iterator.rs
@@ -18,6 +18,8 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, HashSet},
+    error::Error,
+    fmt,
     hash::Hash,
     sync::Arc,
 };
@@ -27,9 +29,9 @@ use iterator::State;
 use resource::constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE};
 
 use crate::{
-    iterator::MVCCRangeIterator,
+    iterator::{MVCCRangeIterator, MVCCReadError},
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
-    snapshot::{buffer::BufferedPrefixIterator, snapshot::SnapshotError, write::Write},
+    snapshot::{buffer::BufferedPrefixIterator, write::Write},
 };
 
 pub struct SnapshotRangeIterator<'a, const PS: usize> {
@@ -50,14 +52,16 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
         }
     }
 
-    pub fn peek(&mut self) -> Option<Result<(StorageKeyReference<'_>, ByteReference<'_>), SnapshotError>> {
+    pub fn peek(&mut self) -> Option<Result<(StorageKeyReference<'_>, ByteReference<'_>), Arc<SnapshotIteratorError>>> {
         match self.iterator_state.state().clone() {
             State::Init => {
                 self.find_next_state();
                 self.peek()
             }
             State::ItemReady => match self.iterator_state.source() {
-                ReadyItemSource::Storage | ReadyItemSource::Both => Self::storage_peek(&mut self.storage_iterator),
+                ReadyItemSource::Storage | ReadyItemSource::Both => {
+                    Self::storage_peek(&mut self.storage_iterator).map(|some| some.map_err(Arc::new))
+                }
                 ReadyItemSource::Buffered => {
                     Some(Ok(Self::get_buffered_peek(self.buffered_iterator.as_mut().unwrap())))
                 }
@@ -66,14 +70,14 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
                 self.advance_and_find_next_state();
                 self.peek()
             }
-            State::Error(error) => Some(Err(SnapshotError::Iterate { source: error.clone() })),
+            State::Error(error) => Some(Err(error.clone())),
             State::Done => None,
         }
     }
 
     // a lending iterator trait is infeasible with the current borrow checker
     #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> Option<Result<(StorageKeyReference<'_>, ByteReference<'_>), SnapshotError>> {
+    pub fn next(&mut self) -> Option<Result<(StorageKeyReference<'_>, ByteReference<'_>), Arc<SnapshotIteratorError>>> {
         match self.iterator_state.state().clone() {
             State::Init => {
                 self.find_next_state();
@@ -81,7 +85,9 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
             }
             State::ItemReady => {
                 let item = match self.iterator_state.source() {
-                    ReadyItemSource::Storage | ReadyItemSource::Both => Self::storage_peek(&mut self.storage_iterator),
+                    ReadyItemSource::Storage | ReadyItemSource::Both => {
+                        Self::storage_peek(&mut self.storage_iterator).map(|some| some.map_err(Arc::new))
+                    }
                     ReadyItemSource::Buffered => {
                         Some(Ok(Self::get_buffered_peek(self.buffered_iterator.as_mut().unwrap())))
                     }
@@ -93,7 +99,7 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
                 self.advance_and_find_next_state();
                 self.next()
             }
-            State::Error(error) => Some(Err(SnapshotError::Iterate { source: error.clone() })),
+            State::Error(error) => Some(Err(error.clone())),
             State::Done => None,
         }
     }
@@ -176,7 +182,7 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
 
     fn buffered_peek(
         buffered_iterator: &mut Option<BufferedPrefixIterator>,
-    ) -> Option<Result<(StorageKeyReference<'_>, &Write), SnapshotError>> {
+    ) -> Option<Result<(StorageKeyReference<'_>, &Write), SnapshotIteratorError>> {
         if let Some(buffered_iterator) = buffered_iterator {
             let buffered_peek = buffered_iterator.peek();
             match buffered_peek {
@@ -191,12 +197,12 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
 
     fn storage_peek<'this>(
         storage_iterator: &'this mut MVCCRangeIterator<'_, PS>,
-    ) -> Option<Result<(StorageKeyReference<'this>, ByteReference<'this>), SnapshotError>> {
+    ) -> Option<Result<(StorageKeyReference<'this>, ByteReference<'this>), SnapshotIteratorError>> {
         let storage_peek = storage_iterator.peek();
         match storage_peek {
             None => None,
             Some(Ok((key, value))) => Some(Ok((key, value))),
-            Some(Err(error)) => Some(Err(SnapshotError::MVCC { source: error })),
+            Some(Err(error)) => Some(Err(SnapshotIteratorError::MVCCRead { source: error })),
         }
     }
 
@@ -224,7 +230,7 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
         (StorageKeyReference::from(key), ByteReference::from(write.get_value()))
     }
 
-    pub fn collect_cloned_vec<F, M>(mut self, mapper: F) -> Result<Vec<M>, SnapshotError>
+    pub fn collect_cloned_vec<F, M>(mut self, mapper: F) -> Result<Vec<M>, Arc<SnapshotIteratorError>>
     where
         F: for<'b> Fn(StorageKeyReference<'b>, ByteReference<'b>) -> M,
     {
@@ -233,7 +239,7 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
             let item = self.next();
             match item {
                 None => break,
-                Some(Err(e)) => return Err(e),
+                Some(Err(error)) => return Err(error),
                 Some(Ok((key, value))) => {
                     vec.push(mapper(key, value));
                 }
@@ -242,7 +248,7 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
         Ok(vec)
     }
 
-    pub fn collect_cloned_bmap<F, M, N>(mut self, mapper: F) -> Result<BTreeMap<M, N>, SnapshotError>
+    pub fn collect_cloned_bmap<F, M, N>(mut self, mapper: F) -> Result<BTreeMap<M, N>, Arc<SnapshotIteratorError>>
     where
         F: for<'b> Fn(StorageKeyReference<'b>, ByteReference<'b>) -> (M, N),
         M: Ord + Eq + PartialEq,
@@ -252,7 +258,7 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
             let item = self.next();
             match item {
                 None => break,
-                Some(Err(e)) => return Err(e),
+                Some(Err(error)) => return Err(error),
                 Some(Ok((key, value))) => {
                     let (m, n) = mapper(key, value);
                     btree_map.insert(m, n);
@@ -262,7 +268,7 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
         Ok(btree_map)
     }
 
-    pub fn collect_cloned_key_hashset<F, M>(mut self, mapper: F) -> Result<HashSet<M>, SnapshotError>
+    pub fn collect_cloned_key_hashset<F, M>(mut self, mapper: F) -> Result<HashSet<M>, Arc<SnapshotIteratorError>>
     where
         F: for<'b> Fn(StorageKeyReference<'b>) -> M,
         M: Hash + Eq + PartialEq,
@@ -272,7 +278,7 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
             let item = self.next();
             match item {
                 None => break,
-                Some(Err(e)) => return Err(e),
+                Some(Err(error)) => return Err(error),
                 Some(Ok((key, _))) => {
                     set.insert(mapper(key));
                 }
@@ -283,7 +289,10 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
 
     pub fn first_cloned(
         mut self,
-    ) -> Result<Option<(StorageKey<'static, BUFFER_KEY_INLINE>, ByteArray<BUFFER_VALUE_INLINE>)>, SnapshotError> {
+    ) -> Result<
+        Option<(StorageKey<'static, BUFFER_KEY_INLINE>, ByteArray<BUFFER_VALUE_INLINE>)>,
+        Arc<SnapshotIteratorError>,
+    > {
         let item = self.next();
         item.transpose().map(|option| {
             option.map(|(key, value)| (StorageKey::Array(StorageKeyArray::from(key)), ByteArray::from(value)))
@@ -303,7 +312,7 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
 
 #[derive(Debug)]
 struct IteratorState {
-    state: State<Arc<SnapshotError>>,
+    state: State<Arc<SnapshotIteratorError>>,
     ready_item_source: ReadyItemSource,
 }
 
@@ -312,7 +321,7 @@ impl IteratorState {
         IteratorState { state: State::Init, ready_item_source: ReadyItemSource::Storage }
     }
 
-    fn state(&self) -> &State<Arc<SnapshotError>> {
+    fn state(&self) -> &State<Arc<SnapshotIteratorError>> {
         &self.state
     }
 
@@ -337,7 +346,7 @@ impl IteratorState {
         self.state = State::Done;
     }
 
-    fn set_error(&mut self, error: Arc<SnapshotError>) {
+    fn set_error(&mut self, error: Arc<SnapshotIteratorError>) {
         self.state = State::Error(error)
     }
 }
@@ -347,4 +356,23 @@ enum ReadyItemSource {
     Storage,
     Buffered,
     Both,
+}
+
+#[derive(Debug)]
+pub enum SnapshotIteratorError {
+    MVCCRead { source: MVCCReadError },
+}
+
+impl fmt::Display for SnapshotIteratorError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+impl Error for SnapshotIteratorError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::MVCCRead { source, .. } => Some(source),
+        }
+    }
 }

--- a/storage/snapshot/iterator.rs
+++ b/storage/snapshot/iterator.rs
@@ -225,8 +225,8 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
     }
 
     pub fn collect_cloned_vec<F, M>(mut self, mapper: F) -> Result<Vec<M>, SnapshotError>
-        where
-            F: for<'b> Fn(StorageKeyReference<'b>, ByteReference<'b>) -> M,
+    where
+        F: for<'b> Fn(StorageKeyReference<'b>, ByteReference<'b>) -> M,
     {
         let mut vec = Vec::new();
         loop {
@@ -243,9 +243,9 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
     }
 
     pub fn collect_cloned_bmap<F, M, N>(mut self, mapper: F) -> Result<BTreeMap<M, N>, SnapshotError>
-        where
-            F: for<'b> Fn(StorageKeyReference<'b>, ByteReference<'b>) -> (M, N),
-            M: Ord + Eq + PartialEq,
+    where
+        F: for<'b> Fn(StorageKeyReference<'b>, ByteReference<'b>) -> (M, N),
+        M: Ord + Eq + PartialEq,
     {
         let mut btree_map = BTreeMap::new();
         loop {
@@ -263,9 +263,9 @@ impl<'a, const PS: usize> SnapshotRangeIterator<'a, PS> {
     }
 
     pub fn collect_cloned_key_hashset<F, M>(mut self, mapper: F) -> Result<HashSet<M>, SnapshotError>
-        where
-            F: for<'b> Fn(StorageKeyReference<'b>) -> M,
-            M: Hash + Eq + PartialEq,
+    where
+        F: for<'b> Fn(StorageKeyReference<'b>) -> M,
+        M: Hash + Eq + PartialEq,
     {
         let mut set = HashSet::new();
         loop {

--- a/storage/snapshot/mod.rs
+++ b/storage/snapshot/mod.rs
@@ -20,4 +20,4 @@ pub mod iterator;
 mod snapshot;
 pub(crate) mod write;
 
-pub use snapshot::{ReadSnapshot, Snapshot, SnapshotError, SnapshotGetError, SnapshotPutError, WriteSnapshot};
+pub use snapshot::{ReadSnapshot, Snapshot, SnapshotError, SnapshotGetError, WriteSnapshot};

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::{error::Error, fmt, sync::Arc};
+use std::{error::Error, fmt};
 
 use bytes::{byte_array::ByteArray, byte_reference::ByteReference};
 use durability::{DurabilityService, SequenceNumber};
@@ -270,24 +270,12 @@ impl<'storage, D> WriteSnapshot<'storage, D> {
 
 #[derive(Debug)]
 pub enum SnapshotError {
-    Iterate { source: Arc<SnapshotError> },
-    Get { source: MVCCStorageError },
-    Put { source: MVCCStorageError },
-    MVCC { source: MVCCReadError },
     Commit { source: MVCCStorageError },
 }
 
 impl fmt::Display for SnapshotError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
-            Self::Iterate { source, .. } => {
-                write!(f, "SnapshotError::Iterate caused by: {}", source)
-            }
-            Self::Get { source, .. } => write!(f, "SnapshotError::Get caused by: {}", source),
-            Self::Put { source, .. } => write!(f, "SnapshotError::Put caused by: {}", source),
-            Self::MVCC { source, .. } => {
-                write!(f, "SnapshotError::MVCC caused by: {}", source)
-            }
             Self::Commit { source, .. } => {
                 write!(f, "SnapshotError::Commit caused by: {}", source)
             }
@@ -298,10 +286,6 @@ impl fmt::Display for SnapshotError {
 impl Error for SnapshotError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            Self::Iterate { source, .. } => Some(source),
-            Self::Get { source, .. } => Some(source),
-            Self::Put { source, .. } => Some(source),
-            Self::MVCC { source, .. } => Some(source),
             Self::Commit { source, .. } => Some(source),
         }
     }

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::{collections::btree_map::Entry, error::Error, fmt, sync::Arc};
+use std::{error::Error, fmt, sync::Arc};
 
 use bytes::{byte_array::ByteArray, byte_reference::ByteReference};
 use durability::{DurabilityService, SequenceNumber};
@@ -28,7 +28,6 @@ use crate::{
     isolation_manager::CommitRecord,
     iterator::MVCCReadError,
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
-    snapshot::write::Write,
     MVCCStorage,
 };
 
@@ -137,7 +136,7 @@ pub struct WriteSnapshot<'storage, D> {
 
 impl<'storage, D> WriteSnapshot<'storage, D> {
     pub(crate) fn new(storage: &'storage MVCCStorage<D>, open_sequence_number: SequenceNumber) -> Self {
-        storage.isolation_manager.opened(&open_sequence_number);
+        storage.isolation_manager.opened(open_sequence_number);
         WriteSnapshot { storage, buffers: KeyspaceBuffers::new(), open_sequence_number }
     }
 
@@ -251,8 +250,8 @@ impl<'storage, D> WriteSnapshot<'storage, D> {
         CommitRecord::new(self.buffers, self.open_sequence_number)
     }
 
-    pub(crate) fn open_sequence_number(&self) -> &SequenceNumber {
-        &self.open_sequence_number
+    pub(crate) fn open_sequence_number(&self) -> SequenceNumber {
+        self.open_sequence_number
     }
 
     pub fn close_resources(&self) {

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -158,9 +158,25 @@ impl<'storage, D> WriteSnapshot<'storage, D> {
     }
 
     pub fn put_val(&self, key: StorageKeyArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
-        let keyspace_id = key.keyspace_id();
-        let byte_array = key.into_byte_array();
-        self.buffers.get(keyspace_id).put(byte_array, value);
+        let buffer = self.buffers.get(key.keyspace_id());
+        if buffer.contains(key.byte_array()) {
+            // TODO: replace existing buffered write. If it contains a preexisting, we can continue to use it
+            todo!()
+        } else {
+            let wrapped = StorageKeyReference::from(&key);
+            let existing_stored = self
+                .storage
+                .get(wrapped, self.open_sequence_number, |reference| {
+                    // Only copy if the value is the same
+                    (reference.bytes() == value.bytes()).then(|| ByteArray::from(reference))
+                })
+                .unwrap();
+            if let Some(Some(existing_stored)) = existing_stored {
+                buffer.insert_preexisting(key.into_byte_array(), existing_stored);
+            } else {
+                buffer.insert(key.into_byte_array(), value);
+            }
+        }
     }
 
     /// Insert a delete marker for the key with a new version

--- a/storage/snapshot/write.rs
+++ b/storage/snapshot/write.rs
@@ -31,7 +31,7 @@ pub(crate) enum Write {
     // Insert KeyValue with a new version. Never conflicts.
     Insert { value: ByteArray<BUFFER_VALUE_INLINE> },
     // Insert KeyValue with new version if a concurrent Txn deletes Key. Boolean indicates requires re-insertion. Never conflicts.
-    InsertPreexisting { value: ByteArray<BUFFER_VALUE_INLINE>, reinsert: Arc<AtomicBool> },
+    Put { value: ByteArray<BUFFER_VALUE_INLINE>, reinsert: Arc<AtomicBool> },
     // Delete with a new version. Conflicts with Require.
     Delete,
 }
@@ -41,10 +41,9 @@ impl PartialEq for Write {
         match (self, other) {
             (Self::RequireExists { value }, Self::RequireExists { value: other_value }) => value == other_value,
             (Self::Insert { value }, Self::Insert { value: other_value }) => value == other_value,
-            (
-                Self::InsertPreexisting { value, reinsert },
-                Self::InsertPreexisting { value: other_value, reinsert: other_reinsert },
-            ) => other_value == value && reinsert.load(Ordering::Acquire) == other_reinsert.load(Ordering::Acquire),
+            (Self::Put { value, reinsert }, Self::Put { value: other_value, reinsert: other_reinsert }) => {
+                other_value == value && reinsert.load(Ordering::Acquire) == other_reinsert.load(Ordering::Acquire)
+            }
             (Self::Delete, Self::Delete) => true,
             _ => false,
         }
@@ -58,8 +57,8 @@ impl Write {
         matches!(self, Write::Insert { .. })
     }
 
-    pub(crate) fn is_insert_preexisting(&self) -> bool {
-        matches!(self, Write::InsertPreexisting { .. })
+    pub(crate) fn is_put(&self) -> bool {
+        matches!(self, Write::Put { .. })
     }
 
     pub(crate) fn is_delete(&self) -> bool {
@@ -68,7 +67,7 @@ impl Write {
 
     pub(crate) fn get_value(&self) -> &ByteArray<BUFFER_VALUE_INLINE> {
         match self {
-            Write::Insert { value } | Write::InsertPreexisting { value, .. } | Write::RequireExists { value } => value,
+            Write::Insert { value } | Write::Put { value, .. } | Write::RequireExists { value } => value,
             Write::Delete => panic!("Buffered delete does not have a value."),
         }
     }

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -244,7 +244,7 @@ impl<D> MVCCStorage<D> {
         WriteSnapshot::new(self, open_sequence_number)
     }
 
-    pub fn open_snapshot_write_at(&self, sequence_number: SequenceNumber) -> Result<WriteSnapshot<'_, D>, MVCCStorageError> {
+    pub fn open_snapshot_write_at(&self, sequence_number: SequenceNumber) -> Result<WriteSnapshot<'_, D>, WriteSnapshotOpenError> {
         // TODO: Support waiting for watermark to catch up to sequence number when we support causal reading.
         assert!(sequence_number <= self.read_watermark());
         Ok(WriteSnapshot::new(self, sequence_number))
@@ -255,7 +255,7 @@ impl<D> MVCCStorage<D> {
         ReadSnapshot::new(self, open_sequence_number)
     }
 
-    pub fn open_snapshot_read_at(&self, sequence_number: SequenceNumber) -> Result<ReadSnapshot<'_, D>, MVCCStorageError> {
+    pub fn open_snapshot_read_at(&self, sequence_number: SequenceNumber) -> Result<ReadSnapshot<'_, D>, ReadSnapshotOpenError> {
         // TODO: Support waiting for watermark to catch up to sequence number when we support causal reading.
         assert!(sequence_number <= self.read_watermark());
         Ok(ReadSnapshot::new(self, sequence_number))
@@ -529,6 +529,36 @@ impl<D> MVCCStorage<D> {
     ) -> KeyspaceRangeIterator<'this, PREFIX_INLINE> {
         debug_assert!(!range.start().bytes().is_empty());
         self.get_keyspace(range.start().keyspace_id()).iterate_range(range.map(|k| k.into_byte_array_or_ref()))
+    }
+}
+
+#[derive(Debug)]
+pub enum ReadSnapshotOpenError {}
+
+impl fmt::Display for ReadSnapshotOpenError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {}
+    }
+}
+
+impl Error for ReadSnapshotOpenError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match *self {}
+    }
+}
+
+#[derive(Debug)]
+pub enum WriteSnapshotOpenError {}
+
+impl fmt::Display for WriteSnapshotOpenError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {}
+    }
+}
+
+impl Error for WriteSnapshotOpenError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match *self {}
     }
 }
 

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -244,7 +244,10 @@ impl<D> MVCCStorage<D> {
         WriteSnapshot::new(self, open_sequence_number)
     }
 
-    pub fn open_snapshot_write_at(&self, sequence_number: SequenceNumber) -> Result<WriteSnapshot<'_, D>, WriteSnapshotOpenError> {
+    pub fn open_snapshot_write_at(
+        &self,
+        sequence_number: SequenceNumber,
+    ) -> Result<WriteSnapshot<'_, D>, WriteSnapshotOpenError> {
         // TODO: Support waiting for watermark to catch up to sequence number when we support causal reading.
         assert!(sequence_number <= self.read_watermark());
         Ok(WriteSnapshot::new(self, sequence_number))
@@ -255,7 +258,10 @@ impl<D> MVCCStorage<D> {
         ReadSnapshot::new(self, open_sequence_number)
     }
 
-    pub fn open_snapshot_read_at(&self, sequence_number: SequenceNumber) -> Result<ReadSnapshot<'_, D>, ReadSnapshotOpenError> {
+    pub fn open_snapshot_read_at(
+        &self,
+        sequence_number: SequenceNumber,
+    ) -> Result<ReadSnapshot<'_, D>, ReadSnapshotOpenError> {
         // TODO: Support waiting for watermark to catch up to sequence number when we support causal reading.
         assert!(sequence_number <= self.read_watermark());
         Ok(ReadSnapshot::new(self, sequence_number))

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -34,7 +34,6 @@ use chrono::Utc;
 use durability::{DurabilityError, DurabilityService, SequenceNumber};
 use iterator::MVCCReadError;
 use itertools::Itertools;
-use keyspace::keyspace::KeyspaceOpenError;
 use logger::{error, result::ResultExt};
 use primitive::{prefix_range::PrefixRange, u80::U80};
 use resource::constants::snapshot::BUFFER_VALUE_INLINE;
@@ -46,11 +45,8 @@ use crate::{
     iterator::MVCCRangeIterator,
     key_value::{StorageKey, StorageKeyReference},
     keyspace::{
-        iterator::KeyspaceRangeIterator,
-        keyspace::{
-            Keyspace, KeyspaceCheckpointError, KeyspaceId, KEYSPACE_ID_MAX, KEYSPACE_ID_RESERVED_UNSET,
-            KEYSPACE_MAXIMUM_COUNT,
-        },
+        iterator::KeyspaceRangeIterator, Keyspace, KeyspaceCheckpointError, KeyspaceId, KeyspaceOpenError,
+        KEYSPACE_ID_MAX, KEYSPACE_ID_RESERVED_UNSET, KEYSPACE_MAXIMUM_COUNT,
     },
     snapshot::{buffer::KeyspaceBuffers, write::Write, ReadSnapshot, WriteSnapshot},
 };

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -184,8 +184,8 @@ impl<D> MVCCStorage<D> {
             fs::create_dir_all(&storage_dir).map_err(|_error| todo!())?;
         }
 
-        let mut durability_service = D::recover(path.join(Self::WAL_DIR_NAME)).expect("Could not create WAL directory");
         // FIXME proper error
+        let mut durability_service = D::recover(path.join(Self::WAL_DIR_NAME)).expect("Could not create WAL directory");
         durability_service.register_record_type::<CommitRecord>();
 
         let name = name.as_ref();

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -318,7 +318,7 @@ impl<D> MVCCStorage<D> {
                     match write {
                         Write::Insert { value } => write_batch
                             .put(MVCCKey::build(key.bytes(), seq, StorageOperation::Insert).bytes(), value.bytes()),
-                        Write::InsertPreexisting(value, reinsert) => {
+                        Write::InsertPreexisting { value, reinsert } => {
                             if reinsert.load(Ordering::SeqCst) {
                                 write_batch.put(
                                     MVCCKey::build(key.bytes(), seq, StorageOperation::Insert).bytes(),

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -326,7 +326,7 @@ impl<D> MVCCStorage<D> {
                     match write {
                         Write::Insert { value } => write_batch
                             .put(MVCCKey::build(key.bytes(), seq, StorageOperation::Insert).bytes(), value.bytes()),
-                        Write::InsertPreexisting { value, reinsert } => {
+                        Write::Put { value, reinsert } => {
                             if reinsert.load(Ordering::SeqCst) {
                                 write_batch.put(
                                     MVCCKey::build(key.bytes(), seq, StorageOperation::Insert).bytes(),

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -31,9 +31,10 @@ use std::{
 
 use bytes::{byte_array::ByteArray, byte_reference::ByteReference, Bytes};
 use chrono::Utc;
-use durability::{DurabilityService, SequenceNumber};
+use durability::{DurabilityError, DurabilityService, SequenceNumber};
 use iterator::MVCCReadError;
 use itertools::Itertools;
+use keyspace::keyspace::KeyspaceOpenError;
 use logger::{error, result::ResultExt};
 use primitive::{prefix_range::PrefixRange, u80::U80};
 use resource::constants::snapshot::BUFFER_VALUE_INLINE;
@@ -87,56 +88,63 @@ pub trait KeyspaceSet: Copy {
 }
 
 fn validate_new_keyspace(
-    storage_name: &str,
     keyspace_id: impl KeyspaceSet,
     keyspaces: &[Keyspace],
     keyspaces_index: &[Option<KeyspaceId>],
-) -> Result<(), MVCCStorageError> {
-    let keyspace_name = keyspace_id.name();
-    let keyspace_id = KeyspaceId(keyspace_id.id());
+) -> Result<(), KeyspaceValidationError> {
+    use KeyspaceValidationError::{IdExists, IdReserved, IdTooLarge, NameExists};
 
-    if keyspace_id == KEYSPACE_ID_RESERVED_UNSET {
-        return Err(MVCCStorageError {
-            storage_name: storage_name.to_owned(),
-            kind: MVCCStorageErrorKind::KeyspaceIdReserved { keyspace_name, keyspace_id: keyspace_id.0 },
-        });
+    let name = keyspace_id.name();
+    let id = KeyspaceId(keyspace_id.id());
+
+    if id == KEYSPACE_ID_RESERVED_UNSET {
+        return Err(IdReserved { name, id: id.0 });
     }
 
-    if keyspace_id > KEYSPACE_ID_MAX {
-        return Err(MVCCStorageError {
-            storage_name: storage_name.to_owned(),
-            kind: MVCCStorageErrorKind::KeyspaceIdTooLarge {
-                keyspace_name,
-                keyspace_id: keyspace_id.0,
-                max_keyspace_id: KEYSPACE_ID_MAX.0,
-            },
-        });
+    if id > KEYSPACE_ID_MAX {
+        return Err(IdTooLarge { name, id: id.0, max_id: KEYSPACE_ID_MAX.0 });
     }
 
-    for (existing_keyspace_id, existing_keyspace_index) in keyspaces_index.iter().enumerate() {
-        if let Some(existing_keyspace_index) = existing_keyspace_index {
-            let keyspace = &keyspaces[existing_keyspace_index.0 as usize];
-            if keyspace.name() == keyspace_name {
-                return Err(MVCCStorageError {
-                    storage_name: storage_name.to_owned(),
-                    kind: MVCCStorageErrorKind::KeyspaceNameExists { keyspace_name },
-                });
+    for (existing_id, existing_keyspace_index) in keyspaces_index.iter().enumerate() {
+        if let Some(existing_index) = existing_keyspace_index {
+            let keyspace = &keyspaces[existing_index.0 as usize];
+            if keyspace.name() == name {
+                return Err(NameExists { name });
             }
-
-            if existing_keyspace_id == keyspace_id.0 as usize {
-                return Err(MVCCStorageError {
-                    storage_name: storage_name.to_owned(),
-                    kind: MVCCStorageErrorKind::KeyspaceIdExists {
-                        new_keyspace_name: keyspace_name,
-                        keyspace_id: keyspace_id.0,
-                        existing_keyspace_name: keyspace.name(),
-                    },
-                });
+            if existing_id == id.0 as usize {
+                return Err(IdExists { new_name: name, id: id.0, existing_name: keyspace.name() });
             }
         }
     }
     Ok(())
 }
+
+#[derive(Debug)]
+pub enum KeyspaceValidationError {
+    IdReserved { name: &'static str, id: u8 },
+    IdTooLarge { name: &'static str, id: u8, max_id: u8 },
+    NameExists { name: &'static str },
+    IdExists { new_name: &'static str, id: u8, existing_name: &'static str },
+}
+
+impl fmt::Display for KeyspaceValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NameExists { name, .. } => write!(f, "keyspace '{name}' is defined multiple times."),
+            Self::IdReserved { name, id, .. } => write!(f, "reserved keyspace id '{id}' cannot be used for new keyspace '{name}'."),
+            Self::IdTooLarge { name, id, max_id, .. } => write!(
+                f, "keyspace id '{id}' cannot be used for new keyspace '{name}' since it is larger than maximum keyspace id '{max_id}'.",
+            ),
+            Self::IdExists { new_name, id, existing_name, .. } => write!(
+                f,
+                "keyspace id '{}' cannot be used for new keyspace '{}' since it is already used by keyspace '{}'.",
+                id, new_name, existing_name
+            ),
+        }
+    }
+}
+
+impl Error for KeyspaceValidationError {}
 
 fn db_options() -> Options {
     let mut options = Options::default();
@@ -148,66 +156,70 @@ fn db_options() -> Options {
 }
 
 fn recover_keyspaces<KS: KeyspaceSet>(
-    storage_name: &str,
     storage_dir: impl AsRef<Path>,
-) -> Result<(Vec<Keyspace>, [Option<KeyspaceId>; KEYSPACE_MAXIMUM_COUNT]), MVCCStorageError> {
+) -> Result<(Vec<Keyspace>, [Option<KeyspaceId>; KEYSPACE_MAXIMUM_COUNT]), StorageRecoverError> {
+    use StorageRecoverError::*;
+
     let path = storage_dir.as_ref();
     let mut keyspaces = Vec::new();
     let mut keyspaces_index = core::array::from_fn(|_| None);
     let options = db_options();
     for keyspace_id in KS::iter() {
-        validate_new_keyspace(storage_name, keyspace_id, &keyspaces, &keyspaces_index)?;
-        keyspaces.push(Keyspace::open(path, keyspace_id, &options).map_err(|err| MVCCStorageError {
-            storage_name: storage_name.to_owned(),
-            kind: MVCCStorageErrorKind::KeyspaceOpenError { source: Arc::new(err), keyspace_name: keyspace_id.name() },
-        })?);
+        validate_new_keyspace(keyspace_id, &keyspaces, &keyspaces_index)
+            .map_err(|error| KeyspaceValidation { source: error })?;
+        keyspaces.push(Keyspace::open(path, keyspace_id, &options).map_err(|error| KeyspaceOpen { source: error })?);
         keyspaces_index[keyspace_id.id() as usize] = Some(KeyspaceId(keyspaces.len() as u8 - 1));
     }
     Ok((keyspaces, keyspaces_index))
 }
 
 impl<D> MVCCStorage<D> {
+    const WAL_DIR_NAME: &'static str = "wal";
     const STORAGE_DIR_NAME: &'static str = "storage";
     const CHECKPOINT_DIR_NAME: &'static str = "checkpoint";
     const CHECKPOINT_METADATA_FILE_NAME: &'static str = "METADATA";
 
-    pub fn recover<KS: KeyspaceSet>(name: impl AsRef<str>, path: &Path) -> Result<Self, MVCCStorageError>
+    pub fn recover<KS: KeyspaceSet>(name: impl AsRef<str>, path: &Path) -> Result<Self, StorageRecoverError>
     where
         D: DurabilityService,
     {
         let storage_dir = path.join(Self::STORAGE_DIR_NAME);
-
         if !storage_dir.exists() {
             fs::create_dir_all(&storage_dir).map_err(|_error| todo!())?;
         }
 
-        let mut durability_service = D::recover(path.join("wal")).expect("Could not create WAL directory"); // FIXME proper error
+        let mut durability_service = D::recover(path.join(Self::WAL_DIR_NAME)).expect("Could not create WAL directory");
+        // FIXME proper error
         durability_service.register_record_type::<CommitRecord>();
 
         let name = name.as_ref();
-        let (keyspaces, keyspaces_index) = recover_keyspaces::<KS>(name, &storage_dir)?;
-
+        let (keyspaces, keyspaces_index) = recover_keyspaces::<KS>(&storage_dir)?;
         let isolation_manager = IsolationManager::new(SequenceNumber::from(1));
 
         let name = name.to_owned();
-
-        let storage =
-            Self { name, path: path.to_owned(), keyspaces, keyspaces_index, isolation_manager, durability_service };
+        let path = path.to_owned();
+        let storage = Self { name, path, keyspaces, keyspaces_index, isolation_manager, durability_service };
 
         storage.reload()?;
 
         Ok(storage)
     }
 
-    fn reload(&self) -> Result<(), MVCCStorageError>
+    fn reload(&self) -> Result<(), StorageRecoverError>
     where
         D: DurabilityService,
     {
-        for record in self.durability_service.iter_type_from_start::<CommitRecord>().unwrap() {
-            if let Ok((commit_sequence_number, commit_record)) = record {
-                self.write_commit_record(commit_sequence_number, commit_record)?;
-            } else {
-                record.unwrap(); // FIXME
+        use StorageRecoverError::DurabilityServiceRead;
+        let records = self
+            .durability_service
+            .iter_type_from_start::<CommitRecord>()
+            .map_err(|error| DurabilityServiceRead { source: error })?;
+        for record in records {
+            match record {
+                Ok((commit_sequence_number, commit_record)) => {
+                    self.write_commit_record(commit_sequence_number, commit_record).unwrap();
+                }
+                Err(error) => return Err(DurabilityServiceRead { source: error }),
             }
         }
         Ok(())
@@ -502,6 +514,29 @@ impl<D> MVCCStorage<D> {
     ) -> KeyspaceRangeIterator<'this, PREFIX_INLINE> {
         debug_assert!(!range.start().bytes().is_empty());
         self.get_keyspace(range.start().keyspace_id()).iterate_range(range.map(|k| k.into_byte_array_or_ref()))
+    }
+}
+
+#[derive(Debug)]
+pub enum StorageRecoverError {
+    KeyspaceValidation { source: KeyspaceValidationError },
+    KeyspaceOpen { source: KeyspaceOpenError },
+    DurabilityServiceRead { source: DurabilityError },
+}
+
+impl fmt::Display for StorageRecoverError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+impl Error for StorageRecoverError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::KeyspaceValidation { source, .. } => Some(source),
+            Self::KeyspaceOpen { source, .. } => Some(source),
+            Self::DurabilityServiceRead { source, .. } => Some(source),
+        }
     }
 }
 

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -273,26 +273,6 @@ impl<D> MVCCStorage<D> {
     {
         let commit_record = snapshot.into_commit_record();
 
-        // 0. Assign whether the put operations need to be performed given storage contents at open
-        //    sequence number
-        for buffer in commit_record.buffers() {
-            let writes = buffer.map().write().unwrap();
-            let puts = writes.iter().filter_map(|(key, write)| match write {
-                Write::Put { value, reinsert } => Some((key, value, reinsert)),
-                _ => None,
-            });
-            for (key, value, reinsert) in puts {
-                let wrapped = StorageKeyReference::new_raw(buffer.keyspace_id, ByteReference::new(key.bytes()));
-                let existing_stored: Option<Option<ByteArray<BUFFER_VALUE_INLINE>>> = self
-                    .get(wrapped, commit_record.open_sequence_number(), |reference| {
-                        // Only copy if the value is the same
-                        (reference.bytes() == value.bytes()).then(|| ByteArray::from(reference))
-                    })
-                    .unwrap(); // TODO
-                reinsert.store(existing_stored.flatten().is_none(), Ordering::Release);
-            }
-        }
-
         //  1. make durable and get sequence number
         let commit_sequence_number =
             self.durability_service.sequenced_write(&commit_record).map_err(|err| MVCCStorageError {
@@ -351,7 +331,7 @@ impl<D> MVCCStorage<D> {
                     match write {
                         Write::Insert { value } => write_batch
                             .put(MVCCKey::build(key.bytes(), seq, StorageOperation::Insert).bytes(), value.bytes()),
-                        Write::Put { value, reinsert } => {
+                        Write::InsertPreexisting { value, reinsert } => {
                             if reinsert.load(Ordering::SeqCst) {
                                 write_batch.put(
                                     MVCCKey::build(key.bytes(), seq, StorageOperation::Insert).bytes(),

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -154,7 +154,7 @@ fn db_options() -> Options {
 fn recover_keyspaces<KS: KeyspaceSet>(
     storage_dir: impl AsRef<Path>,
 ) -> Result<(Vec<Keyspace>, [Option<KeyspaceId>; KEYSPACE_MAXIMUM_COUNT]), StorageRecoverError> {
-    use StorageRecoverError::*;
+    use StorageRecoverError::{KeyspaceOpen, KeyspaceValidation};
 
     let path = storage_dir.as_ref();
     let mut keyspaces = Vec::new();

--- a/storage/tests/BUILD
+++ b/storage/tests/BUILD
@@ -67,6 +67,7 @@ rust_test(
         "//common/logger",
         "//common/primitive",
         "//storage",
+        "//storage/durability",
         "//resource",
         "//util/test:test_utils",
         "@crates//:rand",

--- a/storage/tests/test_isolation.rs
+++ b/storage/tests/test_isolation.rs
@@ -23,7 +23,7 @@ use primitive::prefix_range::PrefixRange;
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
 use storage::{
     error::{MVCCStorageError, MVCCStorageErrorKind},
-    isolation_manager::{IsolationError, IsolationConflict},
+    isolation_manager::IsolationError,
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
     snapshot::SnapshotError,
     KeyspaceSet, MVCCStorage,
@@ -128,10 +128,7 @@ fn g0_update_conflicts_fail() {
             Err(
                 SnapshotError::Commit {
                     source: MVCCStorageError {
-                        kind: MVCCStorageErrorKind::IsolationError {
-                            source: IsolationError::Conflict(IsolationConflict::RequiredDelete),
-                            ..
-                        },
+                        kind: MVCCStorageErrorKind::IsolationError { source: IsolationError::RequiredDelete, .. },
                         ..
                     },
                     ..

--- a/storage/tests/test_isolation.rs
+++ b/storage/tests/test_isolation.rs
@@ -62,8 +62,8 @@ fn setup_storage(storage_path: &Path) -> MVCCStorage<WAL> {
     let storage = MVCCStorage::recover::<TestKeyspaceSet>("storage", storage_path).unwrap();
 
     let snapshot = storage.open_snapshot_write();
-    snapshot.put_val(StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_1)), ByteArray::copy(&VALUE_1)).unwrap();
-    snapshot.put_val(StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_2)), ByteArray::copy(&VALUE_2)).unwrap();
+    snapshot.put_val(StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_1)), ByteArray::copy(&VALUE_1));
+    snapshot.put_val(StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_2)), ByteArray::copy(&VALUE_2));
     snapshot.commit().unwrap();
 
     storage
@@ -80,7 +80,7 @@ fn commits_isolated() {
 
     let key_3 = StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_3));
     let value_3 = ByteArray::copy(&VALUE_3);
-    snapshot_1.put_val(key_3.clone(), value_3.clone()).unwrap();
+    snapshot_1.put_val(key_3.clone(), value_3.clone());
     snapshot_1.commit().unwrap();
 
     let get: Option<ByteArray<BUFFER_KEY_INLINE>> = snapshot_2.get(StorageKeyReference::from(&key_3)).unwrap();

--- a/storage/tests/test_mvcc.rs
+++ b/storage/tests/test_mvcc.rs
@@ -77,8 +77,7 @@ const VALUE_1: [u8; 1] = [0x1];
 const VALUE_2: [u8; 1] = [0x2];
 
 fn setup_storage(storage_path: &Path) -> MVCCStorage<WAL> {
-    let storage = MVCCStorage::recover::<TestKeyspaceSet>("storage", storage_path).unwrap();
-    storage
+    MVCCStorage::recover::<TestKeyspaceSet>("storage", storage_path).unwrap()
 }
 
 #[test]
@@ -89,10 +88,10 @@ fn test_commit_increments_watermark() {
     let wm_initial = storage.read_watermark();
     let snapshot_0 = storage.open_snapshot_write();
     let key_1 = StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_1));
-    snapshot_0.put_val(key_1.clone(), ByteArray::copy(&VALUE_1)).unwrap();
+    snapshot_0.put_val(key_1.clone(), ByteArray::copy(&VALUE_1));
     snapshot_0.commit().unwrap();
 
-    assert_eq!(wm_initial.next().number().number() + 1, storage.read_watermark().number().number());
+    assert_eq!(wm_initial.number() + 1, storage.read_watermark().number());
 }
 
 #[test]
@@ -104,7 +103,7 @@ fn test_reading_snapshots() {
     let key_1: &StorageKey<'_, 48> = &StorageKey::Reference(StorageKeyReference::new(Keyspace, ByteReference::new(&KEY_1)));
 
     let snapshot_write_0 = storage.open_snapshot_write();
-    snapshot_write_0.put_val(StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_1)), ByteArray::copy(&VALUE_0)).unwrap();
+    snapshot_write_0.put_val(StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_1)), ByteArray::copy(&VALUE_0));
     snapshot_write_0.commit().unwrap();
 
     let watermark_0 = storage.read_watermark();
@@ -113,7 +112,7 @@ fn test_reading_snapshots() {
     assert_eq!(snapshot_read_0.get::<128>(key_1.as_reference()).unwrap().unwrap().bytes(), VALUE_0);
 
     let snapshot_write_1 = storage.open_snapshot_write();
-    snapshot_write_1.put_val(StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_1)), ByteArray::copy(&VALUE_1)).unwrap();
+    snapshot_write_1.put_val(StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_1)), ByteArray::copy(&VALUE_1));
     let snapshot_read_01 = storage.open_snapshot_read();
     assert_eq!(snapshot_read_0.get::<128>(key_1.as_reference()).unwrap().unwrap().bytes(), VALUE_0);
     assert_eq!(snapshot_read_01.get::<128>(key_1.as_reference()).unwrap().unwrap().bytes(), VALUE_0);
@@ -146,7 +145,7 @@ fn test_conflicting_update_fails() {
     let key_2 = StorageKey::new_owned(Keyspace, ByteArray::copy(&KEY_2));
 
     let snapshot_write_0 = storage.open_snapshot_write();
-    snapshot_write_0.put_val(key_1.clone().into_owned_array(), ByteArray::copy(&VALUE_0)).unwrap();
+    snapshot_write_0.put_val(key_1.clone().into_owned_array(), ByteArray::copy(&VALUE_0));
     snapshot_write_0.commit().unwrap();
 
     let watermark_after_initial_write = storage.read_watermark();
@@ -156,7 +155,7 @@ fn test_conflicting_update_fails() {
         let snapshot_write_21 = storage.open_snapshot_write();
         snapshot_write_11.delete(key_1.clone().into_owned_array());
         snapshot_write_21.get_required(key_1.clone()).unwrap();
-        snapshot_write_21.put_val(key_2.clone().into_owned_array(), ByteArray::copy(&VALUE_2)).unwrap();
+        snapshot_write_21.put_val(key_2.clone().into_owned_array(), ByteArray::copy(&VALUE_2));
         let result_write_11 = snapshot_write_11.commit();
         assert!(result_write_11.is_ok());
         let result_write_21 = snapshot_write_21.commit();
@@ -167,7 +166,7 @@ fn test_conflicting_update_fails() {
         // Try the same, with the snapshot opened in the past
         let snapshot_write_at_0 = storage.open_snapshot_write_at(watermark_after_initial_write).unwrap();
         snapshot_write_at_0.get_required(key_1.clone()).unwrap();
-        snapshot_write_at_0.put_val(key_2.clone().into_owned_array(), ByteArray::copy(&VALUE_2)).unwrap();
+        snapshot_write_at_0.put_val(key_2.clone().into_owned_array(), ByteArray::copy(&VALUE_2));
         let result_write_at_0 = snapshot_write_at_0.commit();
         assert!(result_write_at_0.is_err());
     }

--- a/storage/tests/test_snapshot.rs
+++ b/storage/tests/test_snapshot.rs
@@ -95,7 +95,7 @@ fn snapshot_buffered_put_iterate() {
     snapshot.put(key_4.clone());
 
     let key_prefix = StorageKeyArray::<BUFFER_KEY_INLINE>::from((vec![0x1], Keyspace));
-    let items: Result<Vec<(StorageKeyArray<BUFFER_KEY_INLINE>, ByteArray<BUFFER_VALUE_INLINE>)>, SnapshotError> =
+    let items: Result<Vec<(StorageKeyArray<BUFFER_KEY_INLINE>, ByteArray<BUFFER_VALUE_INLINE>)>, _> =
         snapshot
             .iterate_range(PrefixRange::new_within(StorageKey::Array(key_prefix)))
             .collect_cloned_vec(|k, v| (StorageKeyArray::from(k), ByteArray::from(v)));

--- a/storage/tests/test_snapshot.rs
+++ b/storage/tests/test_snapshot.rs
@@ -64,10 +64,10 @@ fn snapshot_buffered_put_get() {
     let key_3 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((vec![0x1, 0x0, 0xff], Keyspace));
     let key_4 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((vec![0x2, 0x0, 0xff], Keyspace));
     let value_1 = ByteArray::copy(&[0, 0, 0, 0]);
-    snapshot.put_val(key_1.clone(), value_1.clone()).unwrap();
-    snapshot.put(key_2.clone()).unwrap();
-    snapshot.put(key_3).unwrap();
-    snapshot.put(key_4).unwrap();
+    snapshot.put_val(key_1.clone(), value_1.clone());
+    snapshot.put(key_2.clone());
+    snapshot.put(key_3);
+    snapshot.put(key_4);
 
     assert_eq!(snapshot.get(StorageKey::Array(key_1).as_reference()).unwrap(), Some(value_1));
     assert_eq!(snapshot.get::<48>(StorageKey::Array(key_2).as_reference()).unwrap(), Some(ByteArray::empty()));
@@ -89,10 +89,10 @@ fn snapshot_buffered_put_iterate() {
     let key_2 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((vec![0x1, 0x0, 0x10], Keyspace));
     let key_3 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((vec![0x1, 0x0, 0xff], Keyspace));
     let key_4 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((vec![0x2, 0x0, 0xff], Keyspace));
-    snapshot.put(key_1).unwrap();
-    snapshot.put(key_2.clone()).unwrap();
-    snapshot.put(key_3.clone()).unwrap();
-    snapshot.put(key_4.clone()).unwrap();
+    snapshot.put(key_1);
+    snapshot.put(key_2.clone());
+    snapshot.put(key_3.clone());
+    snapshot.put(key_4.clone());
 
     let key_prefix = StorageKeyArray::<BUFFER_KEY_INLINE>::from((vec![0x1], Keyspace));
     let items: Result<Vec<(StorageKeyArray<BUFFER_KEY_INLINE>, ByteArray<BUFFER_VALUE_INLINE>)>, SnapshotError> =
@@ -115,10 +115,10 @@ fn snapshot_buffered_delete() {
     let key_2 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((vec![0x1, 0x0, 0x10], Keyspace));
     let key_3 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((vec![0x1, 0x0, 0xff], Keyspace));
     let key_4 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((vec![0x2, 0x0, 0xff], Keyspace));
-    snapshot.put(key_1).unwrap();
-    snapshot.put(key_2.clone()).unwrap();
-    snapshot.put(key_3.clone()).unwrap();
-    snapshot.put(key_4.clone()).unwrap();
+    snapshot.put(key_1);
+    snapshot.put(key_2.clone());
+    snapshot.put(key_3.clone());
+    snapshot.put(key_4.clone());
 
     snapshot.delete(key_3.clone());
 
@@ -145,17 +145,17 @@ fn snapshot_read_through() {
     let key_4 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((vec![0x2, 0x0, 0xff], Keyspace));
 
     let snapshot = storage.open_snapshot_write();
-    snapshot.put(key_1.clone()).unwrap();
-    snapshot.put(key_2.clone()).unwrap();
-    snapshot.put(key_3.clone()).unwrap();
-    snapshot.put(key_4.clone()).unwrap();
+    snapshot.put(key_1.clone());
+    snapshot.put(key_2.clone());
+    snapshot.put(key_3.clone());
+    snapshot.put(key_4.clone());
     snapshot.commit().unwrap_or_log();
 
     let key_5 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((vec![0x1, 0x2, 0x0], Keyspace));
 
     // test put - iterate read-through
     let snapshot = storage.open_snapshot_write();
-    snapshot.put(key_5.clone()).unwrap();
+    snapshot.put(key_5.clone());
 
     let key_prefix = StorageKeyArray::<BUFFER_KEY_INLINE>::from((vec![0x1], Keyspace));
     let key_values: Vec<(StorageKeyArray<BUFFER_KEY_INLINE>, ByteArray<BUFFER_VALUE_INLINE>)> = snapshot
@@ -192,11 +192,11 @@ fn snapshot_delete_reinserted() {
     let value_1 = ByteArray::copy(&[0, 0, 0, 1]);
 
     let snapshot_0 = storage.open_snapshot_write();
-    snapshot_0.put_val(key_1.clone(), value_0).unwrap();
+    snapshot_0.put_val(key_1.clone(), value_0);
     snapshot_0.commit().unwrap();
 
     let snapshot_1 = storage.open_snapshot_write();
-    snapshot_1.put_val(key_1.clone(), value_1).unwrap();
+    snapshot_1.put_val(key_1.clone(), value_1);
     snapshot_1.delete(key_1.clone());
     snapshot_1.commit().unwrap();
 

--- a/storage/tests/test_storage.rs
+++ b/storage/tests/test_storage.rs
@@ -20,9 +20,8 @@ use durability::wal::WAL;
 use itertools::Itertools;
 use primitive::prefix_range::PrefixRange;
 use storage::{
-    error::{MVCCStorageError, MVCCStorageErrorKind},
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
-    KeyspaceSet, MVCCStorage,
+    KeyspaceSet, KeyspaceValidationError, MVCCStorage, StorageRecoverError,
 };
 use test_utils::{create_tmp_dir, init_logging};
 
@@ -85,7 +84,10 @@ fn create_keyspaces_duplicate_name_error() {
     let storage_path = create_tmp_dir();
     let create_result = MVCCStorage::<WAL>::recover::<TestKeyspaceSet>("storage", &storage_path);
     assert!(
-        matches!(create_result, Err(MVCCStorageError { kind: MVCCStorageErrorKind::KeyspaceNameExists { .. }, .. })),
+        matches!(
+            create_result,
+            Err(StorageRecoverError::KeyspaceValidation { source: KeyspaceValidationError::NameExists { .. } })
+        ),
         "{}",
         create_result.unwrap_err()
     );
@@ -102,7 +104,10 @@ fn create_keyspaces_duplicate_id_error() {
     let storage_path = create_tmp_dir();
     let create_result = MVCCStorage::<WAL>::recover::<TestKeyspaceSet>("storage", &storage_path);
     assert!(
-        matches!(create_result, Err(MVCCStorageError { kind: MVCCStorageErrorKind::KeyspaceIdExists { .. }, .. })),
+        matches!(
+            create_result,
+            Err(StorageRecoverError::KeyspaceValidation { source: KeyspaceValidationError::IdExists { .. } })
+        ),
         "{}",
         create_result.unwrap_err()
     );


### PR DESCRIPTION
## Usage and product changes

We introduce new error types, moving towards the new preferred error strategy:

- `SnapshotError` is partially dissolved into `SnapshotIteratorError` and `SnapshotGetError`. `SnapshotPutError` is removed.
- All fallible interactions with the storage from the concept layer now wrap the error (in future with additional data) into one of `ConceptReadError`, `ConceptWriteError` (treated as a superset of the former), or `ConceptIteratorError`.