### PR TITLE
Disable using type information from IID in type inference

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -138,10 +138,10 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-22.04
-      filter:
-        owner: vaticle
-        branch: [master, development]
-      dependencies: [test-assembly-linux-targz]
+#      filter:
+#        owner: vaticle
+#        branch: [master, development]
+#      dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -138,10 +138,10 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
-#      dependencies: [test-assembly-linux-targz]
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD

--- a/concept/thing/Thing.java
+++ b/concept/thing/Thing.java
@@ -27,7 +27,6 @@ public interface Thing extends Concept, Comparable<Thing> {
      */
     ByteArray getIID();
 
-
     /**
      * Returns the {@code IID} of this {@code Thing} as hexadecimal string.
      *

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -36,5 +36,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "5abdb7aa4b654f8a1626e508cf4020eca641a351",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "a5f67cccf19ed1fbf74045ff18eaed386b002e7b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/logic/tool/TypeInference.java
+++ b/logic/tool/TypeInference.java
@@ -59,6 +59,7 @@ import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.ROL
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.TypeRead.TYPE_NOT_FOUND;
 import static com.vaticle.typedb.core.common.iterator.Iterators.iterate;
 import static com.vaticle.typeql.lang.common.TypeQLToken.Type.ATTRIBUTE;
+import static com.vaticle.typeql.lang.common.TypeQLToken.Type.THING;
 import static java.util.Collections.emptySet;
 
 public class TypeInference {
@@ -152,6 +153,7 @@ public class TypeInference {
 
     private static class InferenceTraversal {
 
+        private static final Identifier.Variable ROOT_THING_ID = Identifier.Variable.label(ATTRIBUTE.toString());
         private static final Identifier.Variable ROOT_ATTRIBUTE_ID = Identifier.Variable.label(ATTRIBUTE.toString());
 
         private final Conjunction conjunction;
@@ -366,10 +368,10 @@ public class TypeInference {
         }
 
         /**
-         * We only extract the type of the IID, and include this information in the type inference
-         * We only look at the type prefix because the static type checker (this class) only read schema, not data
+         * We do not include type inference based on the type embedded in the IID, since
+         * usually we want to check whether the data instance is compatible with type constraints in the query.
          */
-        private void registerIID(TypeVariable resolver, IIDConstraint constraint) {
+        private void registerIID(TypeVariable inferenceVar, IIDConstraint constraint) {
             VertexIID.Thing iid = VertexIID.Thing.of(constraint.iid());
             TypeVertex type = graphMgr.schema().convert(iid.type());
             if (type == null) {
@@ -382,8 +384,7 @@ public class TypeInference {
             if (vertex == null || !vertex.type().equals(type)) {
                 conjunction.setAnswerable(false);
             }
-            // Note: we should not include type inference based on the type embedded in the IID, since
-            //       usually we want to check whether the data instance is compatible with type constraints in the query.
+            registerSubThing(inferenceVar);
         }
 
         private void registerHas(TypeVariable inferenceVar, HasConstraint hasConstraint) {
@@ -432,6 +433,11 @@ public class TypeInference {
         private void registerSubAttribute(Variable inferenceVar) {
             traversal.labels(ROOT_ATTRIBUTE_ID, Label.of(ATTRIBUTE.toString()));
             traversal.sub(inferenceVar.id(), ROOT_ATTRIBUTE_ID, true);
+        }
+
+        private void registerSubThing(Variable inferenceVar) {
+            traversal.labels(ROOT_THING_ID, Label.of(THING.toString()));
+            traversal.sub(inferenceVar.id(), ROOT_THING_ID, true);
         }
 
         private void register(ValueVariable var) {

--- a/logic/tool/TypeInference.java
+++ b/logic/tool/TypeInference.java
@@ -382,7 +382,8 @@ public class TypeInference {
             if (vertex == null || !vertex.type().equals(type)) {
                 conjunction.setAnswerable(false);
             }
-            restrictTypes(resolver.id(), iterate(type).map(TypeVertex::properLabel));
+            // Note: we should not include type inference based on the type embedded in the IID, since
+            //       usually we want to check whether the data instance is compatible with type constraints in the query.
         }
 
         private void registerHas(TypeVariable inferenceVar, HasConstraint hasConstraint) {

--- a/test/behaviour/query/TypeQLSteps.java
+++ b/test/behaviour/query/TypeQLSteps.java
@@ -616,6 +616,18 @@ public class TypeQLSteps {
         }
     }
 
+    @Then("get answers of templated typeql get")
+    public void get_answers_of_templated_typeql_get(String templatedTypeQLQuery) {
+        String templatedQuery = String.join("\n", templatedTypeQLQuery);
+        if (getAnswers.size() > 1) {
+            throw new ScenarioDefinitionException("Answers of templated typeql get requires only 1 previous answer exists.");
+        }
+        ConceptMap answer = getAnswers.get(0);
+        String queryString = applyQueryTemplate(templatedQuery, answer);
+        TypeQLGet query = TypeQL.parseQuery(queryString).asGet();
+        getAnswers = tx().query().get(query).toList();
+    }
+
     @Then("each answer does not satisfy")
     public void each_answer_does_not_satisfy(String templatedTypeQLQuery) {
         String templatedQuery = String.join("\n", templatedTypeQLQuery);

--- a/test/integration/logic/TypeInferenceTest.java
+++ b/test/integration/logic/TypeInferenceTest.java
@@ -195,30 +195,6 @@ public class TypeInferenceTest {
     }
 
     @Test
-    public void iid_inference() throws IOException {
-        define_standard_schema("basic-schema");
-        transaction.commit();
-        session.close();
-        session = databaseMgr.session(database, DATA);
-        transaction = session.transaction(WRITE);
-        Entity person = transaction.concepts().getEntityType("person").create();
-
-        TypeInference typeInference = transaction.logic().typeInference();
-
-        // using a person IID, the attribute can only be a name or email, but not a dog label
-        String queryString = "match $p iid " + person.getIID().toHexString() + "; $p has $a; get;";
-        Disjunction disjunction = createDisjunction(queryString);
-        typeInference.applyCombination(disjunction);
-
-        Map<String, Set<String>> expected = map(
-                pair("$p", set("person")),
-                pair("$a", set("name", "email"))
-        );
-
-        assertEquals(expected, resolvedTypeMap(disjunction.conjunctions().get(0)));
-    }
-
-    @Test
     public void has_inference() throws IOException {
         define_standard_schema("basic-schema");
         TypeInference typeInference = transaction.logic().typeInference();


### PR DESCRIPTION
## Usage and product changes

We decide to ignore IID information when performing type inference. This comes from the idea that IIDs are _data_, and the user may be trying to check whether the data conforms to a specific part of the schema. Previously, this will cause a query to throw an error due to type checking incompatibility, which made common expressions in fetch subqueries very difficult

Fetching stocks for books that are able to have stock (some subtypes of books do not have stock, such as 'ebook'):
```
match
$x isa book;
fetch:
stock: { 
  match $x isa! $t; $t owns stock;
  fetch $x: stock;
};
```

Which will retrieve stock for books, if the polymorphically selected book instance is able to own 'stock' attributes.

This expression now returns an empty list for instances of books that cannot own stocks instead of returning an error.

## Implementation

- We remove the use of type information extracted from query IIDs from impacting type inference