### PR TITLE
Isolation manager timeline optimisation

### DIFF
--- a/common/primitive/u80.rs
+++ b/common/primitive/u80.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 ///  TODO: we will have to see if its more efficient to always represent as a number (if most operations will be numbers)
 ///        or most of the time we will be serialising into byte arrays, so we should keep as byte array
 ///
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct U80 {
     number: u128,
 }

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -13,6 +13,10 @@ pub mod snapshot {
     pub const BUFFER_VALUE_INLINE: usize = 64;
 }
 
+pub mod storage {
+    pub const TIMELINE_WINDOW_SIZE: usize = 100;
+}
+
 pub mod encoding {
     pub const LABEL_NAME_STRING_INLINE: usize = 64;
     pub const LABEL_SCOPE_STRING_INLINE: usize = 64;

--- a/storage/durability/durability.rs
+++ b/storage/durability/durability.rs
@@ -115,7 +115,7 @@ pub trait SequencedDurabilityRecord: DurabilityRecord {}
 
 pub trait UnsequencedDurabilityRecord: DurabilityRecord {}
 
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct SequenceNumber {
     number: U80,
 }

--- a/storage/durability/durability.rs
+++ b/storage/durability/durability.rs
@@ -50,6 +50,10 @@ pub trait DurabilityService: Sequencer {
         where
             Record: SequencedDurabilityRecord;
 
+    fn is_empty(&self) -> bool {
+        self.previous() == SequenceNumber::MIN
+    }
+
     fn iter_from(&self, sequence_number: SequenceNumber) -> Result<impl Iterator<Item = io::Result<RawRecord>>>;
 
     fn iter_from_start(&self) -> Result<impl Iterator<Item = io::Result<RawRecord>>> {

--- a/storage/durability/wal.rs
+++ b/storage/durability/wal.rs
@@ -46,8 +46,8 @@ impl WAL {
         let files = RwLock::new(files);
         let next = RecordIterator::new(files.read().unwrap(), SequenceNumber::MIN)?
             .last()
-            .map(|rr| rr.unwrap().sequence_number.number().number() as u64 + 1)
-            .unwrap_or(1);
+            .map(|rr| rr.unwrap().sequence_number.next().number().number() as u64)
+            .unwrap_or(SequenceNumber::MIN.next().number.number() as u64);
 
         Ok(Self { registered_types: HashMap::new(), next_sequence_number: AtomicU64::new(next), files })
     }
@@ -125,7 +125,7 @@ impl Files {
         files.sort_unstable_by(|lhs, rhs| lhs.path.cmp(&rhs.path));
 
         if files.is_empty() {
-            files.push(File::open_at(directory.clone(), SequenceNumber::from(1))?);
+            files.push(File::open_at(directory.clone(), SequenceNumber::from(SequenceNumber::MIN.next()))?);
         }
 
         let writer = files.last().unwrap().writer()?;

--- a/storage/durability/wal.rs
+++ b/storage/durability/wal.rs
@@ -79,6 +79,16 @@ impl DurabilityService for WAL {
         self.registered_types.insert(Record::RECORD_TYPE, Record::RECORD_NAME);
     }
 
+    fn unsequenced_write<Record>(&self, record: &Record) -> Result<()>
+    where
+        Record: DurabilityRecord,
+    {
+        debug_assert!(self.registered_types.get(&Record::RECORD_TYPE) == Some(&Record::RECORD_NAME));
+        let mut files = self.files.write().unwrap();
+        files.write_record(record, SequenceNumber::from(0))?;
+        Ok(())
+    }
+
     fn sequenced_write<Record>(&self, record: &Record) -> Result<SequenceNumber>
     where
         Record: DurabilityRecord,

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -663,7 +663,7 @@ pub(crate) struct CommitRecord {
 
 impl Clone for CommitRecord {
     fn clone(&self) -> Self {
-        todo!()
+        unimplemented!("Do not call into_owned on a commit that's owned by the timeline.")
     }
 }
 

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -4,20 +4,23 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+// TODO: Check atomic Ordering constraints. We're using SeqCst where we don't have to
+// TODO: Benchmark with many small commits to see if the read-write locks affect latency.
+
 use std::{
-    collections::VecDeque,
+    borrow::Cow,
+    collections::{HashMap, VecDeque},
     error::Error,
     fmt,
     io::Read,
     sync::{
-        atomic::{AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering},
         Arc, OnceLock, RwLock,
     },
 };
 
-use durability::{DurabilityRecord, DurabilityRecordType, SequenceNumber};
+use durability::{DurabilityRecord, DurabilityRecordType, DurabilityService, SequenceNumber};
 use logger::result::ResultExt;
-use primitive::u80::U80;
 use serde::{Deserialize, Serialize};
 
 use crate::snapshot::{buffer::KeyspaceBuffers, write::Write};
@@ -29,22 +32,17 @@ pub(crate) struct IsolationManager {
 
 impl fmt::Display for IsolationManager {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Timeline[windows={}, next_window_sequence_number={}, watermark={}]",
-            self.timeline.window_count(),
-            self.timeline.next_window_sequence_number(),
-            self.watermark()
-        )
+        write!(f, "Timeline[windows={}, watermark={}]", self.timeline.window_count(), self.watermark())
     }
 }
 
 impl IsolationManager {
-    pub(crate) fn new(next_sequence_number: SequenceNumber) -> IsolationManager {
-        IsolationManager { timeline: Timeline::new(next_sequence_number) }
+    pub(crate) fn new(next_relative_index: i64) -> IsolationManager {
+        IsolationManager { timeline: Timeline::new(next_relative_index) }
     }
 
     pub(crate) fn opened(&self, open_sequence_number: SequenceNumber) {
+        debug_assert!(open_sequence_number <= self.watermark());
         self.timeline.record_reader(open_sequence_number);
     }
 
@@ -52,107 +50,253 @@ impl IsolationManager {
         self.timeline.remove_reader(open_sequence_number);
     }
 
-    pub(crate) fn try_commit(
+    pub(crate) fn load_applied(
         &self,
-        commit_sequence_number: SequenceNumber,
+        relative_index: i64,
+        sequence_number: SequenceNumber,
         commit_record: CommitRecord,
-    ) -> Result<(), IsolationError> {
-        let open_sequence_number = commit_record.open_sequence_number;
-        let commit_window = self.pending(commit_sequence_number, commit_record);
-        let validation_result =
-            self.validate_all_concurrent(commit_sequence_number, commit_window.get_record(commit_sequence_number));
-
-        match &validation_result {
-            Ok(()) => self.committed(commit_sequence_number),
-            Err(_) => self.commit_failed(commit_sequence_number, open_sequence_number),
-        }
-
-        validation_result
+    ) {
+        let (window, slot_index) = self.timeline.get_or_create_window(relative_index);
+        window.insert_pending(slot_index, sequence_number, commit_record);
+        window.set_applied(slot_index);
+        self.timeline.may_increment_watermark(relative_index);
     }
 
-    fn validate_all_concurrent(
+    pub(crate) fn load_aborted(&self, relative_index: i64, sequence_number: SequenceNumber) {
+        let (window, slot_index) = self.timeline.get_or_create_window(relative_index);
+        window.insert_pending(slot_index, sequence_number, CommitRecord::new(KeyspaceBuffers::new(), sequence_number));
+        window.set_closed(slot_index);
+        self.timeline.may_increment_watermark(relative_index);
+    }
+
+    pub(crate) fn notify_applied(&self, relative_index: i64) {
+        let (window, slot_index) = self.timeline.try_get_window(relative_index).unwrap();
+        window.set_applied(slot_index);
+        self.timeline.may_increment_watermark(relative_index);
+    }
+
+    pub(crate) fn try_commit<D>(
         &self,
+        relative_index: i64,
         commit_sequence_number: SequenceNumber,
+        commit_record: CommitRecord,
+        durability_service: &D,
+    ) -> Result<(), IsolationError>
+    where
+        D: DurabilityService,
+    {
+        let (window, slot_index) = self.timeline.get_or_create_window(relative_index);
+        window.insert_pending(slot_index, commit_sequence_number.clone(), commit_record);
+        if let CommitStatus::Pending(_, commit_record) = window.get_status(slot_index) {
+            let validation_result = self.validate_all_concurrent(relative_index, &commit_record, durability_service);
+            if validation_result.is_ok() {
+                window.set_validated(slot_index);
+                // We can't increment watermark here till the status is "applied"
+            } else {
+                window.set_closed(slot_index);
+                self.timeline.may_increment_watermark(relative_index);
+            }
+            self.timeline.remove_reader(commit_record.open_sequence_number);
+            validation_result
+        } else {
+            unreachable!()
+        }
+    }
+
+    fn validate_all_concurrent<D>(
+        &self,
+        commit_relative_index: i64,
         commit_record: &CommitRecord,
-    ) -> Result<(), IsolationError> {
-        debug_assert!(commit_record.open_sequence_number() < commit_sequence_number);
+        durability_service: &D,
+    ) -> Result<(), IsolationError>
+    where
+        D: DurabilityService,
+    {
         // TODO: decide if we should block until all predecessors finish, allow out of order (non-Calvin model/traditional model)
         //       We could also validate against all predecessors even if they are validating and fail eagerly.
-
-        let mut at = SequenceNumber::new(commit_record.open_sequence_number.number() + 1);
-        let Some(mut predecessor_window) = self.timeline.try_get_window(at) else {
-            return Ok(()); // nothing to validate
-        };
-
-        while at < commit_sequence_number {
-            if !predecessor_window.contains(at) {
-                predecessor_window = self.timeline.get_window(at);
-            }
-            resolve_concurrent(commit_record, at, &predecessor_window)?;
-            at = SequenceNumber::new(at.number() + 1);
+        // TODO: Should we validate from the timeline before going to disk?
+        // Pre-collect all the ARCs so we can validate against them.
+        let (windows, first_window_relative_index): (Vec<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>, i64) =
+            self.timeline.collect_concurrent_windows(commit_record.open_sequence_number, commit_relative_index);
+        let first_windowed_seq = *windows.get(0).unwrap().starting_sequence_number().unwrap();
+        if commit_record.open_sequence_number() < first_windowed_seq {
+            self.validate_concurrent_from_disk(commit_record, first_windowed_seq, durability_service)?;
         }
 
+        self.validate_concurrent_from_windows(
+            commit_record,
+            commit_relative_index,
+            &windows,
+            first_window_relative_index,
+        )
+    }
+
+    fn validate_concurrent_from_disk<D>(
+        &self,
+        commit_record: &CommitRecord,
+        stop_sequence_number: SequenceNumber,
+        durability_service: &D,
+    ) -> Result<(), IsolationError>
+    where
+        D: DurabilityService,
+    {
+        for raw_record in
+            Self::iterate_commit_status_from_disk(durability_service, commit_record.open_sequence_number).unwrap()
+        {
+            if let Ok(commit_status) = raw_record {
+                match commit_status {
+                    CommitStatus::Applied(predecessor_seq, _) | CommitStatus::Closed(predecessor_seq) => {
+                        if predecessor_seq >= stop_sequence_number { break; }
+                    },
+                    CommitStatus::Pending(_, _) => unreachable!("Evicted records cannot be pending"),
+                    CommitStatus::Empty | CommitStatus::Validated(_, _) => unreachable!(),
+                }
+                let commit_dependency = match commit_status {
+                    CommitStatus::Applied(_, predecessor_record) => {
+                        commit_record.compute_dependency(&predecessor_record)
+                    }
+                    CommitStatus::Closed(_) => CommitDependency::Independent,
+                    CommitStatus::Pending(_, _) | CommitStatus::Empty | CommitStatus::Validated(_, _) => unreachable!(),
+                };
+                handle_dependency(commit_dependency)?;
+            } else {
+                todo!()
+            }
+        }
         Ok(())
     }
 
-    fn pending(
+    fn validate_concurrent_from_windows(
         &self,
-        commit_sequence_number: SequenceNumber,
-        commit_record: CommitRecord,
-    ) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
-        self.timeline.record_pending(commit_sequence_number, commit_record)
-    }
-
-    fn committed(&self, commit_sequence_number: SequenceNumber) {
-        self.timeline.record_committed(commit_sequence_number)
-    }
-
-    fn commit_failed(&self, commit_sequence_number: SequenceNumber, open_sequence_number: SequenceNumber) {
-        self.timeline.get_window(commit_sequence_number).set_closed(commit_sequence_number);
-        self.timeline.remove_reader(open_sequence_number);
+        commit_record: &CommitRecord,
+        commit_relative_index: i64,
+        windows: &Vec<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>,
+        first_window_relative_index: i64,
+    ) -> Result<(), IsolationError> {
+        let mut window_index = 0;
+        let mut slot_index = 0;
+        while window_index < windows.len() {
+            match windows[window_index].get_status(slot_index) {
+                CommitStatus::Pending(seq, _)
+                | CommitStatus::Validated(seq, _)
+                | CommitStatus::Applied(seq, _)
+                | CommitStatus::Closed(seq) => {
+                    if seq.number() >= commit_record.open_sequence_number.number() {
+                        break;
+                    }
+                }
+                CommitStatus::Empty => {}
+            }
+            slot_index += 1;
+            if slot_index >= TIMELINE_WINDOW_SIZE {
+                window_index += 1;
+                slot_index = 0;
+                debug_assert!(window_index < windows.len());
+            }
+        }
+        debug_assert!(window_index < windows.len() && slot_index < TIMELINE_WINDOW_SIZE);
+        let start_record = first_window_relative_index + (window_index * TIMELINE_WINDOW_SIZE + slot_index) as i64;
+        for _at in start_record..commit_relative_index {
+            debug_assert!(window_index < windows.len());
+            resolve_concurrent(commit_record, slot_index, &windows[window_index])?;
+            slot_index += 1;
+            if slot_index >= TIMELINE_WINDOW_SIZE {
+                window_index += 1;
+                slot_index = 0;
+            }
+        }
+        debug_assert_eq!(
+            first_window_relative_index + (window_index * TIMELINE_WINDOW_SIZE + slot_index) as i64,
+            commit_relative_index
+        );
+        Ok(())
     }
 
     pub(crate) fn watermark(&self) -> SequenceNumber {
-        self.timeline.watermark()
+        let (window, slot_index) = self.timeline.try_get_window(self.timeline.watermark()).unwrap();
+        match window.get_status(slot_index) {
+            CommitStatus::Applied(seq, _) | CommitStatus::Closed(seq) => seq.clone(),
+            CommitStatus::Validated(_, _) | CommitStatus::Pending(_, _) | CommitStatus::Empty =>
+                unreachable!("The isolation manager must always have the watermark commit record in the window, and it must be either committed or aborted."),
+        }
     }
 
-    pub(crate) fn apply_to_commit_record<F, T>(&self, sequence_number: SequenceNumber, function: F) -> T
+    pub(crate) fn apply_to_commit_record<F, T>(&self, relative_index: i64, function: F) -> T
     where
         F: FnOnce(&CommitRecord) -> T,
     {
-        let shared_window = self.timeline.get_window(sequence_number);
-        let record = shared_window.get_record(sequence_number);
-        function(record)
+        let (window, index) = self.timeline.try_get_window(relative_index).unwrap();
+        let record = match window.get_status(index) {
+            CommitStatus::Validated(_, commit_record) | CommitStatus::Applied(_, commit_record) => commit_record,
+            _ => panic!("apply_to_commit_record called on uncommitted record"), // TODO: Do we want to be able to apply on pending?
+        };
+        // debug_assert_eq!(read_sequence_number, sequence_number);
+        function(&record)
+    }
+
+    pub(crate) fn iterate_commit_status_from_disk<'a, D>(
+        durability_service: &'a D,
+        start_sequence_number: SequenceNumber,
+    ) -> durability::Result<impl Iterator<Item = durability::Result<CommitStatus<'a>>>>
+    where
+        D: DurabilityService,
+    {
+        let mut statuses: HashMap<u128, bool> = HashMap::new();
+        for record in durability_service.iter_type_from::<StatusRecord>(start_sequence_number.clone()).unwrap() {
+            if let Ok((_, predecessor_record)) = record {
+                // We can't stop early because status records may be out-of-order
+                statuses.insert(
+                    predecessor_record.commit_record_sequence_number().number().number(),
+                    predecessor_record.was_committed(),
+                );
+            } else {
+                todo!()
+            }
+        }
+
+        let map_fn = move |result: durability::Result<(SequenceNumber, CommitRecord)>| match result {
+            Ok((commit_sequence_number, commit_record)) => {
+                Ok(match statuses.get(&commit_sequence_number.number().number()) {
+                    None => CommitStatus::Pending(commit_sequence_number, Cow::Owned(commit_record)),
+                    Some(true) => CommitStatus::Applied(commit_sequence_number, Cow::Owned(commit_record)),
+                    Some(false) => CommitStatus::Closed(commit_sequence_number),
+                })
+            }
+            Err(err) => Err(err),
+        };
+        Ok(durability_service.iter_type_from::<CommitRecord>(start_sequence_number.clone())?.map(map_fn))
     }
 }
 
 fn resolve_concurrent(
     commit_record: &CommitRecord,
-    predecessor_sequence_number: SequenceNumber,
+    predecessor_slot_index: usize,
     predecessor_window: &TimelineWindow<TIMELINE_WINDOW_SIZE>,
 ) -> Result<(), IsolationError> {
-    let commit_dependency = match predecessor_window.get_status(predecessor_sequence_number) {
+    let commit_dependency = match predecessor_window.get_status(predecessor_slot_index) {
         CommitStatus::Empty => unreachable!("A concurrent status should never be empty at commit time"),
-        CommitStatus::Pending(predecessor_record) => match commit_record.compute_dependency(predecessor_record) {
+        CommitStatus::Pending(_, predecessor_record) => match commit_record.compute_dependency(&predecessor_record) {
             CommitDependency::Independent => CommitDependency::Independent,
             result => {
-                if predecessor_window.await_pending_status_commits(predecessor_sequence_number) {
+                if predecessor_window.await_pending_status_commits(predecessor_slot_index) {
                     result
                 } else {
                     CommitDependency::Independent
                 }
             }
         },
-        CommitStatus::Committed(predecessor_record) => commit_record.compute_dependency(predecessor_record),
-        CommitStatus::Closed => CommitDependency::Independent,
+        CommitStatus::Validated(_, predecessor_record) | CommitStatus::Applied(_, predecessor_record) => commit_record.compute_dependency(&predecessor_record),
+        CommitStatus::Closed(_) => CommitDependency::Independent,
     };
+    handle_dependency(commit_dependency)
+}
 
+fn handle_dependency(commit_dependency: CommitDependency) -> Result<(), IsolationError> {
     match commit_dependency {
         CommitDependency::Independent => (),
         CommitDependency::DependentPuts { puts } => puts.into_iter().for_each(DependentPut::apply),
         CommitDependency::Conflict(conflict) => return Err(IsolationError::Conflict(conflict)),
     }
-
     Ok(())
 }
 
@@ -204,18 +348,6 @@ impl fmt::Display for IsolationError {
 
 impl Error for IsolationError {}
 
-//
-// We can adjust the Window size to amortise the cost of the read-write locks to maintain the timeline
-//
-const TIMELINE_WINDOW_SIZE: usize = 100;
-
-#[derive(Debug)]
-struct Timeline {
-    next_window_and_windows: RwLock<(SequenceNumber, VecDeque<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>)>,
-}
-
-///
-///
 /// Timeline concept:
 ///   Timeline is made of Windows.
 ///   Each Window stores a number of Slots.
@@ -230,143 +362,200 @@ struct Timeline {
 ///   Commit without close just records into its Slot for its commit sequence number the Closed state.
 ///
 ///
-///
-///
+
+// We can adjust the Window size to amortise the cost of the read-write locks to maintain the timeline
+pub const TIMELINE_WINDOW_SIZE: usize = 100;
+
+#[derive(Debug)]
+struct Timeline {
+    next_window_and_windows: RwLock<(i64, VecDeque<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>)>,
+    watermark: AtomicI64,
+}
 
 impl Timeline {
-    fn new(starting_sequence_number: SequenceNumber) -> Timeline {
-        debug_assert!(starting_sequence_number.number() > 0);
-        let last_sequence_number_value = starting_sequence_number.number() - U80::new(1);
-        let initial_window = Arc::new(TimelineWindow::new(SequenceNumber::new(last_sequence_number_value)));
-        let next_window_start = initial_window.end();
+    fn new(next_relative_index: i64) -> Timeline {
         let mut windows = VecDeque::new();
-        windows.push_back(initial_window);
-
-        let timeline = Timeline { next_window_and_windows: RwLock::new((next_window_start, windows)) };
-
-        // initialise the one virtual 'predecessor' so snapshots have a sequence number to open against
-        let sequence_number = SequenceNumber::new(last_sequence_number_value);
-        let window = timeline.get_window(sequence_number);
-        window.set_closed(sequence_number);
-        timeline
+        Timeline {
+            next_window_and_windows: RwLock::new((next_relative_index, windows)),
+            watermark: AtomicI64::new(next_relative_index - 1),
+        }
     }
 
-    fn watermark(&self) -> SequenceNumber {
-        //
-        // TODO: we would like to not be a non-locking and constant time operation (probably an Atomic) since every snapshot queries for the watermark.
-        //       Issues:
-        //         1) Rust does not support an AtomicU128 which could hold a SequenceNumber.
-        //             --> Perhaps we want to combine a logically 'unsafe' structure that uses a raw pointer/atomic int & unsafe writes to a pair of slots that are pointed into?
-        //             --> Alternative: keep an atomic u64 and keep a 'origin' which is increases over time so we never have to use the entire u128 range.
-        //         2) If we just keep a reference to the window containing the current watermark, we still need a lock to update it...
-        //             --> The IsolationManager should be able to guarantee that the watermark moves up atomically when the N+1's snapshot closes/commits
-        //             --> However this would definitely require a lock over both
-        //             --> It should be good enough to order it such that commit/close does: 1) update timeline, then 2) update watermark if possible 3) return control. This will guarantee new snapshots will see this commit in the watermark if it moves up.
-        //             --> There is a complexity in updating the watermark - we need to scan commit statuses from the current watermark upwards, then update it. What if two commits do this concurrently and race? Is it possible to not make progress?
-        //
-        //     We should just re-think what the watermark guarantees actually are...?
-        //     1) Because we commit optimistically/at the end of a snapshot only, commit slots are only filled once a transaction goes to commit. This means we can at worst be as behind as the current set of 'processing' commits, which is not many.
-        //     2) We do allow pending commits to proceed out of order sometimes - if they have non-intersecting commit records. This means we can't guarantee the watermark is raised after a commit.
-        //        --> first hint: maybe we can just bump the watermark when a commit happens that did not skip any commit records/intersected with all concurrent commits? Seems like most cases will not suit this...
-        //     3) Side note: If we want to preserve causality between transactions by the same user, a new transaction by the same user must wait for the watermark to rise past the recently committed snapshot.
-        //         --> simplest way to do this without retaining causality information on the client is: when a client asks for a snapshot, immediately get _latest_ (possibly pending) commit sequence number. Then wait until watermark rises to meet that and use it.
-        //
-        let (next_sequence_number, windows) = &*self.next_window_and_windows.read().unwrap_or_log();
-        windows
-            .iter()
-            .find_map(|w| {
-                if w.is_finished() {
-                    None
-                } else {
-                    debug_assert!(w.watermark().is_some());
-                    w.watermark()
+    fn may_free_windows(&self) {
+        let watermark = self.watermark();
+        let can_free_some: bool = {
+            let (next_relative_index, windows) = &*self.next_window_and_windows.read().unwrap_or_log();
+            let start_of_second_window = *next_relative_index - ((windows.len() - 1) * TIMELINE_WINDOW_SIZE) as i64;
+            match windows.front() {
+                None => false,
+                Some(front) => front.get_readers() == 0 && watermark >= start_of_second_window,
+            }
+        };
+        if can_free_some {
+            let (next_relative_index, windows) = &mut *self.next_window_and_windows.write().unwrap_or_log();
+            let mut start_of_next_window = *next_relative_index - ((windows.len() - 1) * TIMELINE_WINDOW_SIZE) as i64;
+            while watermark >= start_of_next_window && windows.front().is_some() && windows.front().unwrap().get_readers() == 0
+            {
+                windows.pop_front();
+                start_of_next_window += TIMELINE_WINDOW_SIZE as i64;
+            }
+        }
+    }
+
+    fn may_increment_watermark(&self, relative_index: i64) {
+        let mut watermark = self.watermark.load(Ordering::SeqCst);
+        if relative_index != watermark + 1 {
+            return ();
+        }
+
+        let (mut window, mut slot_index) = self.try_get_window(relative_index).unwrap();
+        let first_window_end: i64 = relative_index + (TIMELINE_WINDOW_SIZE - slot_index) as i64;
+        loop {
+            let should_update: bool = match window.get_status(slot_index) {
+                CommitStatus::Empty | CommitStatus::Pending(_, _) | CommitStatus::Validated(_, _) => false,
+                CommitStatus::Applied(_, _) => true,
+                CommitStatus::Closed(_) => true,
+            };
+            if should_update
+                && self.watermark.compare_exchange(watermark, watermark + 1, Ordering::SeqCst, Ordering::SeqCst).is_ok()
+            {
+                watermark += 1;
+                slot_index += 1;
+                if slot_index >= TIMELINE_WINDOW_SIZE {
+                    if let Some(res) = self.try_get_window(watermark + 1) {
+                        (window, slot_index) = res;
+                        assert_eq!(0, slot_index);
+                    } else {
+                        break;
+                    }
                 }
-            })
-            .unwrap_or_else(|| SequenceNumber::new(next_sequence_number.number() - U80::new(1)))
+            } else {
+                break;
+            }
+        }
+        if watermark >= first_window_end {
+            self.may_free_windows();
+        }
+    }
+
+    fn watermark(&self) -> i64 {
+        // TODO: Verify we address all concerns here & remove these comments
+        // // TODO: we would like to not be a non-locking and constant time operation (probably an Atomic) since every snapshot queries for the watermark.
+        // //       Issues:
+        // //         1) Rust does not support an AtomicU128 which could hold a SequenceNumber.
+        // //             --> Perhaps we want to combine a logically 'unsafe' structure that uses a raw pointer/atomic int & unsafe writes to a pair of slots that are pointed into?
+        // //             --> Alternative: keep an atomic u64 and keep a 'origin' which is increases over time so we never have to use the entire u128 range.
+        // //         2) If we just keep a reference to the window containing the current watermark, we still need a lock to update it...
+        // //             --> The IsolationManager should be able to guarantee that the watermark moves up atomically when the N+1's snapshot closes/commits
+        // //             --> However this would definitely require a lock over both
+        // //             --> It should be good enough to order it such that commit/close does: 1) update timeline, then 2) update watermark if possible 3) return control. This will guarantee new snapshots will see this commit in the watermark if it moves up.
+        // //             --> There is a complexity in updating the watermark - we need to scan commit statuses from the current watermark upwards, then update it. What if two commits do this concurrently and race? Is it possible to not make progress?
+        // //
+        // //     We should just re-think what the watermark guarantees actually are...?
+        // //     1) Because we commit optimistically/at the end of a snapshot only, commit slots are only filled once a transaction goes to commit. This means we can at worst be as behind as the current set of 'processing' commits, which is not many.
+        // //     2) We do allow pending commits to proceed out of order sometimes - if they have non-intersecting commit records. This means we can't guarantee the watermark is raised after a commit.
+        // //        --> first hint: maybe we can just bump the watermark when a commit happens that did not skip any commit records/intersected with all concurrent commits? Seems like most cases will not suit this...
+        // //     3) Side note: If we want to preserve causality between transactions by the same user, a new transaction by the same user must wait for the watermark to rise past the recently committed snapshot.
+        // //         --> simplest way to do this without retaining causality information on the client is: when a client asks for a snapshot, immediately get _latest_ (possibly pending) commit sequence number. Then wait until watermark rises to meet that and use it.
+        // //
+        self.watermark.load(Ordering::SeqCst)
     }
 
     fn record_reader(&self, sequence_number: SequenceNumber) {
-        let window = self.get_or_create_window(sequence_number);
-        window.increment_readers();
-    }
-
-    fn record_pending(
-        &self,
-        sequence_number: SequenceNumber,
-        commit_record: CommitRecord,
-    ) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
-        let window = self.get_or_create_window(sequence_number);
-        window.set_pending(sequence_number, commit_record);
-        window
-    }
-
-    fn record_committed(&self, sequence_number: SequenceNumber) {
-        let window = self.get_or_create_window(sequence_number);
-        window.set_committed(sequence_number);
-        self.remove_window_reader(sequence_number, &window);
+        if let Some(window) = self.find_window_for_reader(sequence_number) {
+            window.increment_readers();
+        };
     }
 
     fn remove_reader(&self, reader_sequence_number: SequenceNumber) {
-        let read_window = self.get_window(reader_sequence_number);
-        self.remove_window_reader(reader_sequence_number, &read_window);
+        if let Some(window) = self.find_window_for_reader(reader_sequence_number) {
+            debug_assert!(window.get_readers() >= 0);
+            let _readers_remaining = window.decrement_readers();
+            if _readers_remaining == 0 {
+                self.may_free_windows();
+            }
+        };
     }
 
-    fn remove_window_reader(
+    fn find_window_for_reader(
         &self,
-        reader_sequence_number: SequenceNumber,
-        reader_window: &TimelineWindow<TIMELINE_WINDOW_SIZE>,
-    ) {
-        debug_assert!(reader_window.contains(reader_sequence_number));
-        let _readers_remaining = reader_window.decrement_readers();
-
-        // TODO: clean up windows that no longer need to be retained in memory.
-        //      --> see task
-    }
-
-    fn last_window(
-        windows: &VecDeque<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>,
-    ) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
-        debug_assert!(!windows.is_empty());
-        windows[windows.len() - 1].clone()
-    }
-
-    fn get_or_create_window(&self, sequence_number: SequenceNumber) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
-        self.try_get_window(sequence_number).clone().unwrap_or_else(|| self.create_windows_to(sequence_number))
-    }
-
-    fn get_window(&self, sequence_number: SequenceNumber) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
-        self.try_get_window(sequence_number).unwrap()
-    }
-
-    fn try_get_window(&self, sequence_number: SequenceNumber) -> Option<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>> {
-        let (_, windows) = &*self.next_window_and_windows.read().unwrap_or_log();
-        Self::find_window(sequence_number, windows)
-    }
-
-    fn find_window(
         sequence_number: SequenceNumber,
-        windows: &VecDeque<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>,
     ) -> Option<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>> {
-        windows.iter().rev().find(|window| window.contains(sequence_number)).cloned()
+        let (_, windows) = &*self.next_window_and_windows.read().unwrap_or_log();
+        windows
+            .iter()
+            .rev()
+            .find(|window| {
+                let start_seq = window.starting_sequence_number();
+                start_seq.is_some() && start_seq.unwrap().number() <= sequence_number.number()
+            })
+            .cloned()
     }
 
-    fn create_windows_to(&self, sequence_number: SequenceNumber) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
-        let (next_window, windows) = &mut *self.next_window_and_windows.write().unwrap_or_log();
+    fn collect_concurrent_windows(
+        &self,
+        start_sequence_number: SequenceNumber,
+        end_relative_index: i64,
+    ) -> (Vec<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>, i64) {
+        let (next_window, windows) = &*self.next_window_and_windows.read().unwrap_or_log();
+        let relative_index_of_window_0 = *next_window - (windows.len() * TIMELINE_WINDOW_SIZE) as i64;
+        assert!(end_relative_index >= relative_index_of_window_0);
+        let end_lies_in_window = (end_relative_index - relative_index_of_window_0) as usize / TIMELINE_WINDOW_SIZE;
+        let mut concurrent_windows: Vec<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>> = Vec::new();
 
-        // re-check if another thread created required window before we acquired lock
-        let window = Self::find_window(sequence_number, windows);
-        if let Some(window) = window {
-            window.clone()
-        } else {
-            loop {
-                let new_window = TimelineWindow::new(*next_window);
-                *next_window = new_window.end_sequence_number;
-                let shared_new_window = Arc::new(new_window);
-                windows.push_back(shared_new_window.clone());
-                if shared_new_window.contains(sequence_number) {
-                    break shared_new_window;
+        let window_after = (0..windows.len()).find(|i| {
+            let window_start_seq = windows.get(*i).unwrap().starting_sequence_number().unwrap().number();
+            window_start_seq > start_sequence_number.number()
+        });
+        let first_concurrent_window = match window_after {
+            None => windows.len() - 1,
+            Some(i) => {
+                if i == 0 {
+                    i
+                } else {
+                    i - 1
                 }
             }
+        };
+        for i in first_concurrent_window..(end_lies_in_window + 1) {
+            concurrent_windows.push(windows.get(i).unwrap().clone());
+        }
+        let start_index_of_first_concurrent =
+            relative_index_of_window_0 + (first_concurrent_window * TIMELINE_WINDOW_SIZE) as i64;
+        (concurrent_windows, start_index_of_first_concurrent)
+    }
+
+    fn try_get_window(&self, relative_index: i64) -> Option<(Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>, usize)> {
+        let (next_window, windows) = &*self.next_window_and_windows.read().unwrap_or_log();
+        let start_index: i64 = next_window - (windows.len() * TIMELINE_WINDOW_SIZE) as i64;
+        let must_be_in_window = (relative_index - start_index) as usize / TIMELINE_WINDOW_SIZE;
+
+        if must_be_in_window >= 0 && must_be_in_window < windows.len() {
+            let in_window = windows.get(must_be_in_window)?;
+            let slot_index: usize = (relative_index - start_index) as usize % TIMELINE_WINDOW_SIZE;
+            Some((in_window.clone(), slot_index))
+        } else {
+            None
+        }
+    }
+
+    fn get_or_create_window(&self, relative_index: i64) -> (Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>, usize) {
+        let create: bool = {
+            let (next_window, _) = &*self.next_window_and_windows.read().unwrap_or_log();
+            relative_index >= *next_window
+        };
+        if create {
+            self.create_windows_to(relative_index);
+        }
+        self.try_get_window(relative_index).unwrap()
+    }
+
+    fn create_windows_to(&self, relative_index: i64) {
+        let (next_window, windows) = &mut *self.next_window_and_windows.write().unwrap_or_log();
+        while relative_index >= *next_window {
+            let shared_new_window = Arc::new(TimelineWindow::new());
+            *next_window += TIMELINE_WINDOW_SIZE as i64;
+            windows.push_back(shared_new_window.clone());
         }
     }
 
@@ -374,153 +563,112 @@ impl Timeline {
         let (_, windows) = &*self.next_window_and_windows.read().unwrap_or_log();
         windows.len()
     }
-
-    fn next_window_sequence_number(&self) -> SequenceNumber {
-        let (next_window_sequence_number, _) = *self.next_window_and_windows.read().unwrap_or_log();
-        next_window_sequence_number
-    }
 }
 
 #[derive(Debug)]
 struct TimelineWindow<const SIZE: usize> {
-    starting_sequence_number: SequenceNumber,
-    end_sequence_number: SequenceNumber,
-    slots: [AtomicU8; SIZE],
-    commit_records: [OnceLock<CommitRecord>; SIZE],
+    slot_status: [AtomicU8; SIZE],
+    commit_records: [OnceLock<(SequenceNumber, CommitRecord)>; SIZE],
     readers: AtomicU64,
-    available_slots: AtomicUsize,
 }
 
 impl<const SIZE: usize> TimelineWindow<SIZE> {
-    fn new(starting_sequence_number: SequenceNumber) -> TimelineWindow<SIZE> {
-        const EMPTY: OnceLock<CommitRecord> = OnceLock::new();
-        let commit_data = [EMPTY; SIZE];
-        let slots: [AtomicU8; SIZE] = core::array::from_fn(|_| AtomicU8::new(0));
-        debug_assert_eq!(slots[0].load(Ordering::SeqCst), SlotMarker::Empty.as_u8());
+    fn new() -> TimelineWindow<SIZE> {
+        const EMPTY: OnceLock<(SequenceNumber, CommitRecord)> = OnceLock::new();
+        let commit_records = [EMPTY; SIZE];
+        let slot_status: [AtomicU8; SIZE] = core::array::from_fn(|_| AtomicU8::new(0));
+        debug_assert_eq!(slot_status[0].load(Ordering::SeqCst), SlotMarker::Empty.as_u8());
 
-        TimelineWindow {
-            starting_sequence_number,
-            end_sequence_number: SequenceNumber::new(starting_sequence_number.number() + U80::new(SIZE as u128)),
-            slots,
-            commit_records: commit_data,
-            readers: AtomicU64::new(0),
-            available_slots: AtomicUsize::new(SIZE),
-        }
+        TimelineWindow { slot_status, commit_records, readers: AtomicU64::new(0) }
     }
 
     /// Sequence number start of window (inclusive)
-    fn start(&self) -> SequenceNumber {
-        self.starting_sequence_number
+    fn starting_sequence_number(&self) -> Option<&SequenceNumber> {
+        Some(&self.commit_records[0].get()?.0)
     }
 
-    /// Sequence number end of window (exclusive)
-    fn end(&self) -> SequenceNumber {
-        self.end_sequence_number
+    fn insert_pending(&self, index: usize, sequence_number: SequenceNumber, commit_record: CommitRecord) {
+        self.commit_records[index].set((sequence_number, commit_record)).unwrap_or_log();
+        self.slot_status[index].store(SlotMarker::Pending.as_u8(), Ordering::SeqCst);
     }
 
-    fn contains(&self, sequence_number: SequenceNumber) -> bool {
-        self.starting_sequence_number <= sequence_number && sequence_number < self.end_sequence_number
+    fn set_validated(&self, index: usize) {
+        self.slot_status[index].store(SlotMarker::Validated.as_u8(), Ordering::SeqCst);
     }
 
-    fn is_finished(&self) -> bool {
-        self.available_slots.load(Ordering::SeqCst) == 0
+    fn set_closed(&self, index: usize) {
+        self.slot_status[index].store(SlotMarker::Closed.as_u8(), Ordering::SeqCst);
     }
 
-    fn watermark(&self) -> Option<SequenceNumber> {
-        self.slots.iter().enumerate().find_map(|(index, status)| {
-            let marker = SlotMarker::from(status.load(Ordering::SeqCst));
-            match marker {
-                SlotMarker::Empty | SlotMarker::Pending => {
-                    Some(SequenceNumber::new(self.start().number() + U80::new(index as u128 - 1)))
-                }
-                SlotMarker::Committed | SlotMarker::Closed => None,
+    fn set_applied(&self, index: usize) {
+        self.slot_status[index].store(SlotMarker::Applied.as_u8(), Ordering::SeqCst);
+    }
+
+    fn get_status(&self, index: usize) -> CommitStatus<'_> {
+        let status = SlotMarker::from(self.slot_status[index].load(Ordering::SeqCst));
+        if let SlotMarker::Empty = status {
+            CommitStatus::Empty
+        } else {
+            let (seq, record) = self.commit_records[index].get().unwrap();
+            match status {
+                SlotMarker::Empty => unreachable!(),
+                SlotMarker::Pending => CommitStatus::Pending(seq.clone(), Cow::Borrowed(record)),
+                SlotMarker::Validated => CommitStatus::Validated(seq.clone(), Cow::Borrowed(record)),
+                SlotMarker::Applied => CommitStatus::Applied(seq.clone(), Cow::Borrowed(record)),
+                SlotMarker::Closed => CommitStatus::Closed(seq.clone()),
             }
-        })
+        }
     }
 
-    fn await_pending_status_commits(&self, at: SequenceNumber) -> bool {
-        debug_assert!(!matches!(self.get_status(at), CommitStatus::Empty));
+    fn await_pending_status_commits(
+        &self,
+        index: usize
+    ) -> bool {
+        debug_assert!(!matches!(self.get_status(index), CommitStatus::Empty));
         loop {
-            match self.get_status(at) {
+            match self.get_status(index) {
                 CommitStatus::Empty => unreachable!("Illegal state - commit status cannot move from pending to empty"),
-                CommitStatus::Pending(_) => {
+                CommitStatus::Pending(_, _) => {
                     // TODO: we can improve the spin lock with async/await
                     // Note we only expect to have long waits in long chains of overlapping transactions that would conflict
                     // could also do a little sleep in the spin lock, for example if the validating is still far away
                     std::hint::spin_loop();
                 }
-                CommitStatus::Committed(_) => return true,
-                CommitStatus::Closed => return false,
+                // By returning true on validation, we ignore the possibility that the predecessor commit may be aborted due to a conflict on another partition.
+                CommitStatus::Validated(_, _) | CommitStatus::Applied(_, _) => return true,
+                CommitStatus::Closed(_) => return false,
             }
         }
     }
 
-    fn set_pending(&self, sequence_number: SequenceNumber, commit_record: CommitRecord) {
-        debug_assert!(self.contains(sequence_number));
-        let index = self.index_of(sequence_number);
-        self.commit_records[index].set(commit_record).unwrap_or_log();
-        self.slots[index].store(SlotMarker::Pending.as_u8(), Ordering::SeqCst);
-    }
-
-    fn set_committed(&self, sequence_number: SequenceNumber) {
-        debug_assert!(self.contains(sequence_number));
-        let index = self.index_of(sequence_number);
-        self.slots[index].store(SlotMarker::Committed.as_u8(), Ordering::SeqCst);
-        self.available_slots.fetch_sub(1, Ordering::SeqCst);
-    }
-
-    fn set_closed(&self, sequence_number: SequenceNumber) {
-        debug_assert!(self.contains(sequence_number));
-        let index = self.index_of(sequence_number);
-        self.slots[index].store(SlotMarker::Closed.as_u8(), Ordering::SeqCst);
-        self.available_slots.fetch_sub(1, Ordering::SeqCst);
-    }
-
-    fn get_record(&self, sequence_number: SequenceNumber) -> &CommitRecord {
-        debug_assert!(self.contains(sequence_number));
-        let index = self.index_of(sequence_number);
-        self.commit_records[index].get().unwrap()
-    }
-
-    fn get_status(&self, sequence_number: SequenceNumber) -> CommitStatus<'_> {
-        debug_assert!(self.contains(sequence_number));
-        let index = self.index_of(sequence_number);
-        let status = SlotMarker::from(self.slots[index].load(Ordering::SeqCst));
-        match status {
-            SlotMarker::Empty => CommitStatus::Empty,
-            SlotMarker::Pending => CommitStatus::Pending(self.commit_records[index].get().unwrap()),
-            SlotMarker::Committed => CommitStatus::Committed(self.commit_records[index].get().unwrap()),
-            SlotMarker::Closed => CommitStatus::Closed,
-        }
+    fn get_readers(&self) -> u64 {
+        self.readers.load(Ordering::Relaxed)
     }
 
     fn increment_readers(&self) {
-        self.readers.fetch_add(1, Ordering::SeqCst);
+        self.readers.fetch_add(1, Ordering::Relaxed);
     }
 
     fn decrement_readers(&self) -> u64 {
-        self.readers.fetch_sub(1, Ordering::SeqCst)
-    }
-
-    fn index_of(&self, sequence_number: SequenceNumber) -> usize {
-        debug_assert!(sequence_number.number() - self.starting_sequence_number.number() < usize::MAX as u128);
-        (sequence_number.number() - self.starting_sequence_number.number()).number() as usize
+        self.readers.fetch_sub(1, Ordering::Relaxed) - 1 // Return the resulting number of readers
     }
 }
 
 #[derive(Debug)]
 pub(crate) enum CommitStatus<'a> {
     Empty,
-    Pending(&'a CommitRecord),
-    Committed(&'a CommitRecord),
-    Closed,
+    Pending(SequenceNumber, Cow<'a, CommitRecord>),
+    Validated(SequenceNumber, Cow<'a, CommitRecord>),
+    Applied(SequenceNumber, Cow<'a, CommitRecord>),
+    Closed(SequenceNumber),
 }
 
 #[derive(Debug)]
 enum SlotMarker {
     Empty,
     Pending,
-    Committed,
+    Validated,
+    Applied,
     Closed,
 }
 
@@ -529,8 +677,9 @@ impl SlotMarker {
         match self {
             SlotMarker::Empty => 0,
             SlotMarker::Pending => 1,
-            SlotMarker::Committed => 2,
-            SlotMarker::Closed => 3,
+            SlotMarker::Validated => 2,
+            SlotMarker::Applied => 3,
+            SlotMarker::Closed => 4,
         }
     }
 
@@ -538,8 +687,9 @@ impl SlotMarker {
         match value {
             0 => SlotMarker::Empty,
             1 => SlotMarker::Pending,
-            2 => SlotMarker::Committed,
-            3 => SlotMarker::Closed,
+            2 => SlotMarker::Validated,
+            3 => SlotMarker::Applied,
+            4 => SlotMarker::Closed,
             _ => unreachable!(),
         }
     }
@@ -550,6 +700,18 @@ pub(crate) struct CommitRecord {
     // TODO: this could read-through to the WAL if we have to save memory?
     buffers: KeyspaceBuffers,
     open_sequence_number: SequenceNumber,
+}
+
+impl Clone for CommitRecord {
+    fn clone(&self) -> Self {
+        todo!()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct StatusRecord {
+    commit_record_sequence_number: SequenceNumber,
+    was_committed: bool,
 }
 
 impl CommitRecord {
@@ -644,5 +806,242 @@ impl DurabilityRecord for CommitRecord {
         let mut buf = Vec::new();
         reader.read_to_end(&mut buf).unwrap();
         bincode::deserialize(&buf)
+    }
+}
+
+impl StatusRecord {
+    pub(crate) fn new(sequence_number: SequenceNumber, committed: bool) -> StatusRecord {
+        StatusRecord { commit_record_sequence_number: sequence_number, was_committed: committed }
+    }
+
+    pub(crate) fn was_committed(&self) -> bool {
+        self.was_committed
+    }
+
+    pub(crate) fn commit_record_sequence_number(&self) -> SequenceNumber {
+        self.commit_record_sequence_number
+    }
+
+    fn deserialise_from(record_type: DurabilityRecordType, reader: impl Read)
+    where
+        Self: Sized,
+    {
+        assert_eq!(Self::RECORD_TYPE, record_type);
+        // TODO: handle error with a better message
+        bincode::deserialize_from(reader).unwrap_or_log()
+    }
+}
+
+impl DurabilityRecord for StatusRecord {
+    const RECORD_TYPE: DurabilityRecordType = 1;
+
+    const RECORD_NAME: &'static str = "status_record";
+
+    fn serialise_into(&self, writer: &mut impl std::io::Write) -> bincode::Result<()> {
+        debug_assert_eq!(
+            bincode::serialize(
+                &bincode::deserialize::<StatusRecord>(bincode::serialize(&self).as_ref().unwrap()).unwrap()
+            )
+            .unwrap(),
+            bincode::serialize(self).unwrap()
+        );
+        bincode::serialize_into(writer, &self)
+    }
+
+    fn deserialise_from(reader: &mut impl Read) -> bincode::Result<Self> {
+        // https://github.com/bincode-org/bincode/issues/633
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf).unwrap();
+        bincode::deserialize(&buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::KeyspaceSet;
+
+    macro_rules! test_keyspace_set {
+        {$($variant:ident => $id:literal : $name: literal),* $(,)?} => {
+            #[derive(Clone, Copy)]
+            enum TestKeyspaceSet { $($variant),* }
+            impl KeyspaceSet for TestKeyspaceSet {
+                fn iter() -> impl Iterator<Item = Self> { [$(Self::$variant),*].into_iter() }
+                fn id(&self) -> u8 {
+                    match *self { $(Self::$variant => $id),* }
+                }
+                fn name(&self) -> &'static str {
+                    match *self { $(Self::$variant => $name),* }
+                }
+            }
+        };
+    }
+
+    test_keyspace_set! {
+        Keyspace => 0: "keyspace",
+    }
+    use durability::SequenceNumber;
+
+    use crate::{
+        isolation_manager::{CommitRecord, CommitStatus, Timeline, TIMELINE_WINDOW_SIZE},
+        snapshot::buffer::KeyspaceBuffers,
+        MVCCStorage,
+    };
+
+    struct MockTransaction {
+        read_sequence_number: SequenceNumber,
+        relative_index: i64,
+        commit_sequence_number: SequenceNumber,
+    }
+
+    impl MockTransaction {
+        fn new(
+            read_sequence_number: SequenceNumber,
+            relative_index: i64,
+            commit_sequence_number: SequenceNumber,
+        ) -> MockTransaction {
+            MockTransaction { read_sequence_number, relative_index, commit_sequence_number }
+        }
+    }
+
+    fn create_timeline() -> Timeline {
+        let timeline = Timeline::new(0);
+        let (window, slot_index) = timeline.get_or_create_window(0);
+        window.insert_pending(
+            slot_index,
+            SequenceNumber::MIN,
+            CommitRecord::new(KeyspaceBuffers::new(), SequenceNumber::MIN),
+        );
+        window.set_closed(slot_index);
+        timeline.may_increment_watermark(0);
+        timeline
+    }
+
+    fn tx_open(timeline: &Timeline, read_sequence_number: SequenceNumber) {
+        timeline.record_reader(read_sequence_number);
+    }
+
+    fn tx_close(timeline: &Timeline, read_sequence_number: SequenceNumber) {
+        timeline.remove_reader(read_sequence_number);
+    }
+
+    fn tx_start_commit(timeline: &Timeline, tx: &MockTransaction) {
+        let (window, slot_index) = timeline.get_or_create_window(tx.relative_index);
+        window.insert_pending(slot_index, tx.commit_sequence_number.clone(), _record(tx.read_sequence_number));
+    }
+
+    fn tx_finalise_commit_status(timeline: &Timeline, tx: &MockTransaction, validation_result: bool) {
+        let (window, slot_index) = timeline.try_get_window(tx.relative_index).unwrap();
+        if let CommitStatus::Pending(_, commit_record) = window.get_status(slot_index) {
+            if validation_result {
+                window.set_validated(slot_index);
+                window.set_applied(slot_index);
+            } else {
+                window.set_closed(slot_index);
+            }
+            timeline.remove_reader(commit_record.open_sequence_number);
+            timeline.may_increment_watermark(tx.relative_index);
+        } else {
+            unreachable!()
+        }
+    }
+
+    fn tx_complete_commit(timeline: &Timeline, tx: &MockTransaction) {
+        tx_finalise_commit_status(timeline, tx, true);
+    }
+
+    fn tx_abort_commit(timeline: &Timeline, tx: &MockTransaction) {
+        tx_finalise_commit_status(timeline, tx, false);
+    }
+
+    fn _seq(from: u128) -> SequenceNumber {
+        SequenceNumber::from(from)
+    }
+
+    fn _record(read_sequence_number: SequenceNumber) -> CommitRecord {
+        CommitRecord::new(KeyspaceBuffers::new(), read_sequence_number)
+    }
+
+    #[test]
+    fn watermark_is_updated() {
+        let timeline = &create_timeline();
+        let tx1 = &MockTransaction::new(_seq(0), 1, _seq(1));
+        tx_open(timeline, tx1.read_sequence_number);
+        tx_start_commit(timeline, tx1);
+        tx_finalise_commit_status(timeline, tx1, true);
+        assert_eq!(tx1.relative_index, timeline.watermark());
+
+        let tx2 = &MockTransaction::new(_seq(0), 2, _seq(2));
+
+        tx_open(timeline, tx2.read_sequence_number);
+        tx_start_commit(timeline, tx2);
+        tx_finalise_commit_status(timeline, tx2, false);
+        assert_eq!(tx2.relative_index, timeline.watermark());
+
+        let tx3 = &MockTransaction::new(_seq(0), 3, _seq(3));
+        let tx4 = &MockTransaction::new(_seq(0), 4, _seq(4));
+        tx_open(timeline, tx3.read_sequence_number);
+        tx_open(timeline, tx4.read_sequence_number);
+        tx_start_commit(timeline, tx3);
+        tx_start_commit(timeline, tx4);
+        tx_finalise_commit_status(timeline, tx4, true);
+        assert_eq!(tx2.relative_index, timeline.watermark()); // tx3 is not yet committed, watermark does not move.
+        tx_finalise_commit_status(timeline, tx3, true);
+        assert_eq!(tx4.relative_index, timeline.watermark()); // Watermark goes up all the way to 4.
+    }
+
+    #[test]
+    fn unused_windows_are_cleaned_up() {
+        let timeline = &create_timeline();
+
+        let tx_count = TIMELINE_WINDOW_SIZE + 2;
+        for i in 1..tx_count {
+            //
+            let tx = &MockTransaction::new(_seq(0), i as i64, _seq(i as u128));
+            tx_open(timeline, tx.read_sequence_number);
+            tx_start_commit(timeline, tx);
+        }
+
+        let stop_at = tx_count - 2;
+        for i in 1..stop_at {
+            let tx = &MockTransaction::new(_seq(0), i as i64, _seq(i as u128));
+            tx_finalise_commit_status(timeline, tx, true);
+        }
+        assert!(timeline.try_get_window(1).is_some());
+        for i in stop_at..tx_count {
+            let tx = &MockTransaction::new(_seq(0), i as i64, _seq(i as u128));
+            tx_finalise_commit_status(timeline, tx, true);
+        }
+        assert!(timeline.try_get_window(1).is_none());
+    }
+
+    #[test]
+    fn watermark_keeps_window_pinned() {
+        let timeline = &create_timeline();
+        let tx1 = &MockTransaction::new(_seq(0), 1, _seq(1));
+        tx_open(timeline, tx1.read_sequence_number);
+        tx_start_commit(timeline, tx1);
+        tx_finalise_commit_status(timeline, tx1, true);
+
+        let got_window = timeline.try_get_window(tx1.relative_index);
+        assert!(got_window.is_some());
+
+        let mut i = tx1.relative_index + 1;
+        while timeline.try_get_window(i).is_some() {
+            let tx = &MockTransaction::new(_seq(0), i, _seq(i as u128));
+            tx_open(timeline, tx.read_sequence_number);
+            tx_start_commit(timeline, tx);
+            tx_finalise_commit_status(timeline, tx, true);
+            i += 1;
+        }
+
+        match timeline.try_get_window(timeline.watermark()) {
+            Some((window, slot_index)) => {
+                debug_assert_eq!(TIMELINE_WINDOW_SIZE - 1, slot_index); // If this fails, the test is wrong.
+                assert_eq!(0, window.get_readers());
+            }
+            None => {
+                assert!(false);
+            }
+        }
     }
 }

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -181,7 +181,7 @@ pub struct WriteSnapshot<'storage, D> {
 
 impl<'storage, D> WriteSnapshot<'storage, D> {
     pub(crate) fn new(storage: &'storage MVCCStorage<D>, open_sequence_number: SequenceNumber) -> Self {
-        storage.isolation_manager.opened(open_sequence_number);
+        storage.isolation_manager.opened_for_read(open_sequence_number);
         WriteSnapshot { storage, buffers: KeyspaceBuffers::new(), open_sequence_number }
     }
 }

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -206,7 +206,7 @@ impl<D> MVCCStorage<D> {
     {
         use StorageRecoverError::DurabilityServiceRead;
         let records =
-            IsolationManager::iterate_commit_status_from_disk(&self.durability_service, SequenceNumber::MIN)
+            IsolationManager::iterate_commit_status_from_disk(&self.durability_service, SequenceNumber::MIN, SequenceNumber::MAX)
             .map_err(|error| DurabilityServiceRead { source: error })?;
         for record in records {
             match record {

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -219,7 +219,7 @@ impl<D> MVCCStorage<D> {
                                 commit_record.into_owned(),
                             );
                         }
-                        CommitStatus::Closed(commit_sequence_number) => {
+                        CommitStatus::Aborted(commit_sequence_number) => {
                             self.isolation_manager.load_aborted(
                                 Self::todo_relative_index_from_sequence_number(commit_sequence_number),
                                 commit_sequence_number,

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -226,7 +226,7 @@ impl<D> MVCCStorage<D> {
                             );
                         }
                         CommitStatus::Pending(commit_sequence_number, commit_record) => {
-                            self.isolation_manager.opened(commit_record.open_sequence_number()); // try_commit currently decrements reader count.
+                            self.isolation_manager.opened_for_read(commit_record.open_sequence_number()); // try_commit currently decrements reader count.
                             let try_commit_result = self.try_write_commit_record(
                                 Self::todo_relative_index_from_sequence_number(commit_sequence_number),
                                 commit_sequence_number,
@@ -430,7 +430,7 @@ impl<D> MVCCStorage<D> {
     }
 
     pub fn closed_snapshot_write(&self, open_sequence_number: SequenceNumber) {
-        self.isolation_manager.closed(open_sequence_number)
+        self.isolation_manager.closed_for_read(open_sequence_number)
     }
 
     fn get_keyspace(&self, keyspace_id: KeyspaceId) -> &Keyspace {

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -183,7 +183,7 @@ impl<D> MVCCStorage<D> {
         let name = name.as_ref();
         let (keyspaces, keyspaces_index) = recover_keyspaces::<KS>(&storage_dir)?;
 
-        let isolation_manager = if durability_service.previous() == SequenceNumber::MIN {
+        let isolation_manager = if durability_service.is_empty() {
             let im = IsolationManager::new(Self::todo_relative_index_from_sequence_number(SequenceNumber::MIN));
             im.load_aborted(0, SequenceNumber::MIN); // Initialise the watermark to zero
             im

--- a/storage/tests/test_isolation.rs
+++ b/storage/tests/test_isolation.rs
@@ -152,7 +152,7 @@ fn isolation_manager_reads_evicted_from_disk() {
     snapshot1.delete(key_1.clone().into_owned_array());
     snapshot1.commit().unwrap();
 
-    for _i in 0..storage::isolation_manager::TIMELINE_WINDOW_SIZE {
+    for _i in 0..resource::constants::storage::TIMELINE_WINDOW_SIZE {
         let snapshot_i = storage.open_snapshot_write();
         snapshot_i.put_val(key_2.clone().into_owned_array(), value_1.clone());
         snapshot_i.commit().unwrap();

--- a/storage/tests/test_isolation.rs
+++ b/storage/tests/test_isolation.rs
@@ -133,3 +133,63 @@ fn g0_update_conflicts_fail() {
         result_2
     );
 }
+
+#[test]
+fn isolation_manager_reads_evicted_from_disk() {
+    init_logging();
+    let storage_path = create_tmp_dir();
+    let storage = setup_storage(&storage_path);
+    let key_1 = StorageKey::new_owned(Keyspace, ByteArray::copy(&KEY_1));
+    let key_2 = StorageKey::new_owned(Keyspace, ByteArray::copy(&KEY_2));
+    let value_1 = ByteArray::copy(&VALUE_1);
+
+    let snapshot0 = storage.open_snapshot_write();
+    snapshot0.put_val(key_1.clone().into_owned_array(), value_1.clone());
+    snapshot0.commit().unwrap();
+    let watermark_after_0 = storage.read_watermark();
+
+    let snapshot1 = storage.open_snapshot_write();
+    snapshot1.delete(key_1.clone().into_owned_array());
+    snapshot1.commit().unwrap();
+
+    for _i in 0..storage::isolation_manager::TIMELINE_WINDOW_SIZE {
+        let snapshot_i = storage.open_snapshot_write();
+        snapshot_i.put_val(key_2.clone().into_owned_array(), value_1.clone());
+        snapshot_i.commit().unwrap();
+    }
+
+    {
+        let snapshot_passes = storage.open_snapshot_write_at(watermark_after_0).unwrap();
+        snapshot_passes.put_val(key_2.clone().into_owned_array(), value_1.clone());
+        let snapshot_passes_result = snapshot_passes.commit();
+
+        assert!(snapshot_passes_result.is_ok());
+    }
+    {
+        let snapshot_conflicts = storage.open_snapshot_write_at(watermark_after_0).unwrap();
+        snapshot_conflicts.get_required(key_1.clone()).unwrap();
+        snapshot_conflicts.put_val(key_2.clone().into_owned_array(), value_1.clone());
+        let snapshot_conflicts_result = snapshot_conflicts.commit();
+
+        assert!(
+            matches!(
+                snapshot_conflicts_result,
+                Err(
+                    SnapshotError::Commit {
+                    source: MVCCStorageError {
+                        kind: MVCCStorageErrorKind::IsolationError {
+                            source: IsolationError::Conflict(IsolationConflict::DeleteRequired),
+                            ..
+                        },
+                        ..
+                    },
+                    ..
+                },
+                    ..
+                )
+            ),
+            "{}",
+            snapshot_conflicts_result.unwrap_err()
+        );
+    }
+}

--- a/storage/tests/test_mvcc.rs
+++ b/storage/tests/test_mvcc.rs
@@ -90,8 +90,7 @@ fn test_reading_snapshots() {
     let storage_path = create_tmp_dir();
     let storage = setup_storage(&storage_path);
 
-    let key_1: &StorageKey<'_, 48> =
-        &StorageKey::Reference(StorageKeyReference::new(Keyspace, ByteReference::new(&KEY_1)));
+    let key_1: &StorageKey<'_, 48> = &StorageKey::Reference(StorageKeyReference::new(Keyspace, ByteReference::new(&KEY_1)));
 
     let snapshot_write_0 = storage.open_snapshot_write();
     snapshot_write_0.put_val(StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_1)), ByteArray::copy(&VALUE_0));

--- a/storage/tests/test_mvcc.rs
+++ b/storage/tests/test_mvcc.rs
@@ -90,7 +90,8 @@ fn test_reading_snapshots() {
     let storage_path = create_tmp_dir();
     let storage = setup_storage(&storage_path);
 
-    let key_1: &StorageKey<'_, 48> = &StorageKey::Reference(StorageKeyReference::new(Keyspace, ByteReference::new(&KEY_1)));
+    let key_1: &StorageKey<'_, 48> =
+        &StorageKey::Reference(StorageKeyReference::new(Keyspace, ByteReference::new(&KEY_1)));
 
     let snapshot_write_0 = storage.open_snapshot_write();
     snapshot_write_0.put_val(StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_1)), ByteArray::copy(&VALUE_0));


### PR DESCRIPTION
## Usage and product changes
Refactors how the isolation manager tracks transactions & implements cleanup of transactions which are no longer needed. 

## Implementation
* Re-implements the isolation manager timeline to work on relative_indices (which are guaranteed to be contiguous) instead of sequence numbers (which will be discontiguous at least in the distributed case)
* Implements cleaning up of commits which are no longer needed to validate active transactions.
* Add path for reading commit data straight from storage. 
* Add tests when reading from storage.