### PR TITLE
Move put validation to commit time, update put state during validation

### DIFF
--- a/common/primitive/u80.rs
+++ b/common/primitive/u80.rs
@@ -38,7 +38,7 @@ impl U80 {
     pub const BYTES: usize = 10;
 
     pub fn new(number: u128) -> U80 {
-        assert!(number < U80::MAX.number);
+        assert!(number <= U80::MAX.number);
         U80 { number }
     }
 
@@ -66,14 +66,14 @@ impl U80 {
 impl Add for U80 {
     type Output = U80;
     fn add(self, rhs: Self) -> Self::Output {
-        U80 { number: self.number + rhs.number }
+        Self::new(self.number + rhs.number)
     }
 }
 
 impl Add<u128> for U80 {
     type Output = U80;
     fn add(self, rhs: u128) -> Self::Output {
-        U80 { number: self.number + rhs }
+        Self::new(self.number + rhs)
     }
 }
 
@@ -86,14 +86,14 @@ impl AddAssign<u128> for U80 {
 impl Sub for U80 {
     type Output = U80;
     fn sub(self, rhs: Self) -> Self::Output {
-        U80 { number: self.number - rhs.number }
+        Self::new(self.number - rhs.number)
     }
 }
 
 impl Sub<u128> for U80 {
     type Output = U80;
     fn sub(self, rhs: u128) -> Self::Output {
-        U80 { number: self.number - rhs }
+        Self::new(self.number - rhs)
     }
 }
 

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -139,15 +139,15 @@ impl IsolationManager {
 
 fn resolve_concurrent(
     commit_record: &CommitRecord,
-    at: SequenceNumber,
+    predecessor_sequence_number: SequenceNumber,
     predecessor_window: &TimelineWindow<TIMELINE_WINDOW_SIZE>,
 ) -> Result<(), IsolationError> {
-    let commit_dependency = match predecessor_window.get_status(at) {
+    let commit_dependency = match predecessor_window.get_status(predecessor_sequence_number) {
         CommitStatus::Empty => unreachable!("A concurrent status should never be empty at commit time"),
         CommitStatus::Pending(predecessor_record) => match commit_record.compute_dependency(predecessor_record) {
             CommitDependency::Independent => CommitDependency::Independent,
             result => {
-                if predecessor_window.await_pending_status_commits(at) {
+                if predecessor_window.await_pending_status_commits(predecessor_sequence_number) {
                     result
                 } else {
                     CommitDependency::Independent

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -21,7 +21,7 @@ use std::{
     fmt,
     io::Read,
     sync::{
-        atomic::{AtomicU64, AtomicU8, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering},
         Arc, OnceLock, RwLock,
     },
 };
@@ -79,14 +79,14 @@ impl IsolationManager {
             self.commit_failed(commit_sequence_number, open_sequence_number);
         }
 
-        validation_result
+        validation_result.map_err(IsolationError::Conflict)
     }
 
     fn validate_all_concurrent(
         &self,
         commit_sequence_number: SequenceNumber,
         commit_record: &CommitRecord,
-    ) -> Result<(), IsolationError> {
+    ) -> Result<(), IsolationConflict> {
         debug_assert!(commit_record.open_sequence_number() < commit_sequence_number);
         // TODO: decide if we should block until all predecessors finish, allow out of order (non-Calvin model/traditional model)
         //       We could also validate against all predecessors even if they are validating and fail eagerly.
@@ -99,32 +99,45 @@ impl IsolationManager {
             if !predecessor_window.contains(at) {
                 predecessor_window = self.timeline.get_window(at);
             }
-            self.validate_concurrent(commit_record, at, &predecessor_window)?;
+            if let Some(conflict) = self.resolve_concurrent(commit_record, at, &predecessor_window) {
+                return Err(conflict);
+            }
             at = SequenceNumber::new(at.number() + 1);
         }
         Ok(())
     }
 
-    fn validate_concurrent(
+    fn resolve_concurrent(
         &self,
         commit_record: &CommitRecord,
         predecessor_sequence_number: SequenceNumber,
         predecessor_window: &TimelineWindow<TIMELINE_WINDOW_SIZE>,
-    ) -> Result<(), IsolationError> {
+    ) -> Option<IsolationConflict> {
         let predecessor_status = predecessor_window.get_status(predecessor_sequence_number);
-        match predecessor_status {
+        let isolation_dependency = match predecessor_status {
             CommitStatus::Empty => unreachable!("A concurrent status should never be empty at commit time"),
             CommitStatus::Pending(predecessor_record) => {
-                let result = self.validate_isolation(commit_record, predecessor_record);
-                if result.is_err() && self.await_pending_status_commits(predecessor_sequence_number, predecessor_window)
-                {
-                    result
-                } else {
-                    Ok(())
+                match self.compute_dependency(commit_record, predecessor_record) {
+                    IsolationDependency::Independent => IsolationDependency::Independent,
+                    result => {
+                        if self.await_pending_status_commits(predecessor_sequence_number, predecessor_window) {
+                            result
+                        } else {
+                            IsolationDependency::Independent
+                        }
+                    }
                 }
             }
-            CommitStatus::Committed(predecessor_record) => self.validate_isolation(commit_record, predecessor_record),
-            CommitStatus::Closed => Ok(()),
+            CommitStatus::Committed(predecessor_record) => self.compute_dependency(commit_record, predecessor_record),
+            CommitStatus::Closed => IsolationDependency::Independent,
+        };
+        match isolation_dependency {
+            IsolationDependency::Independent => None,
+            IsolationDependency::DependentPuts { puts } => {
+                puts.into_iter().for_each(|DependentPut { flag, value }| flag.store(value, Ordering::Release));
+                None
+            }
+            IsolationDependency::Conflict(conflict) => Some(conflict),
         }
     }
 
@@ -149,10 +162,12 @@ impl IsolationManager {
         }
     }
 
-    fn validate_isolation(&self, record: &CommitRecord, predecessor: &CommitRecord) -> Result<(), IsolationError> {
+    fn compute_dependency(&self, record: &CommitRecord, predecessor: &CommitRecord) -> IsolationDependency {
         // TODO: this can be optimised by some kind of bit-wise NAND of two bloom filter-like data
         // structures first, since we assume few clashes this should mostly succeed
         // TODO: can be optimised with an intersection of two sorted iterators instead of iterate + gets
+
+        let mut puts_to_update = Vec::new();
 
         for (buffer, predecessor_buffer) in record.buffers().iter().zip(predecessor.buffers()) {
             let map = buffer.map().read().unwrap();
@@ -168,17 +183,31 @@ impl IsolationManager {
             for (key, write) in map.iter() {
                 if let Some(predecessor_write) = predecessor_map.get(key.bytes()) {
                     match (predecessor_write, write) {
-                        (Write::Delete, Write::InsertPreexisting { reinsert, .. }) => {
-                            reinsert.store(true, Ordering::Release)
+                        (Write::Delete, Write::RequireExists { .. }) => {
+                            return IsolationDependency::Conflict(IsolationConflict::DeleteRequired);
                         }
-                        (Write::Delete, Write::RequireExists { .. }) => return Err(IsolationError::DeleteRequired),
-                        (Write::RequireExists { .. }, Write::Delete)=> return Err(IsolationError::RequiredDelete),
-                        (_, _) => (),
+                        (Write::RequireExists { .. }, Write::Delete) => {
+                            // we escalate required-delete to failure, since requires implies dependencies that may be broken
+                            // TODO: maybe RequireExists should be RequireDependency to capture this?
+                            return IsolationDependency::Conflict(IsolationConflict::RequiredDelete);
+                        }
+                        (Write::Insert { .. } | Write::Put { .. }, Write::Put { reinsert, .. }) => {
+                            puts_to_update.push(DependentPut { flag: reinsert.clone(), value: false });
+                        }
+                        (Write::Delete, Write::Put { reinsert, .. }) => {
+                            puts_to_update.push(DependentPut { flag: reinsert.clone(), value: true });
+                        }
+                        _ => (),
                     }
                 }
             }
         }
-        Ok(())
+
+        if puts_to_update.is_empty() {
+            IsolationDependency::Independent
+        } else {
+            IsolationDependency::DependentPuts { puts: puts_to_update }
+        }
     }
 
     fn pending(
@@ -213,17 +242,32 @@ impl IsolationManager {
 }
 
 #[derive(Debug)]
-pub enum IsolationError {
+struct DependentPut {
+    flag: Arc<AtomicBool>,
+    value: bool,
+}
+
+#[derive(Debug)]
+enum IsolationDependency {
+    Independent,
+    DependentPuts { puts: Vec<DependentPut> },
+    Conflict(IsolationConflict),
+}
+
+#[derive(Debug)]
+pub enum IsolationConflict {
     DeleteRequired,
     RequiredDelete,
 }
 
+#[derive(Debug)]
+pub enum IsolationError {
+    Conflict(IsolationConflict),
+}
+
 impl fmt::Display for IsolationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::DeleteRequired => write!(f, "Isolation violation: Delete-Require conflict. A preceding concurrent commit has deleted a key required by this transaction. Please retry."),
-            Self::RequiredDelete => write!(f, "Isolation violation: Require-Delete conflict. This commit has deleted a key required by a preceding concurrent transaction. Please retry."),
-        }
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
     }
 }
 

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -79,9 +79,9 @@ impl IsolationManager {
                 Ok(())
             }
             Some(conflict) => {
-                    self.commit_failed(commit_sequence_number, open_sequence_number);
-                    Err(IsolationError::Conflict(conflict))
-                }
+                self.commit_failed(commit_sequence_number, open_sequence_number);
+                Err(IsolationError::Conflict(conflict))
+            }
         }
     }
 
@@ -215,8 +215,15 @@ pub enum IsolationError {
 }
 
 impl fmt::Display for IsolationError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Conflict(IsolationConflict::DeleteRequired) => {
+                write!(f, "Isolation violation: Delete-Require conflict. A preceding concurrent commit has deleted a key required by this transaction. Please retry.")
+            }
+            Self::Conflict(IsolationConflict::RequiredDelete) => {
+                write!(f, "Isolation violation: Require-Delete conflict. This commit has deleted a key required by a preceding concurrent transaction. Please retry.")
+            }
+        }
     }
 }
 

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -73,72 +73,63 @@ impl IsolationManager {
         let validation_result =
             self.validate_all_concurrent(commit_sequence_number, commit_window.get_record(commit_sequence_number));
 
-        if validation_result.is_ok() {
-            self.committed(commit_sequence_number);
-        } else {
-            self.commit_failed(commit_sequence_number, open_sequence_number);
+        match validation_result {
+            None => {
+                self.committed(commit_sequence_number);
+                Ok(())
+            }
+            Some(conflict) => {
+                    self.commit_failed(commit_sequence_number, open_sequence_number);
+                    Err(IsolationError::Conflict(conflict))
+                }
         }
-
-        validation_result.map_err(IsolationError::Conflict)
     }
 
     fn validate_all_concurrent(
         &self,
         commit_sequence_number: SequenceNumber,
         commit_record: &CommitRecord,
-    ) -> Result<(), IsolationConflict> {
+    ) -> Option<IsolationConflict> {
         debug_assert!(commit_record.open_sequence_number() < commit_sequence_number);
         // TODO: decide if we should block until all predecessors finish, allow out of order (non-Calvin model/traditional model)
         //       We could also validate against all predecessors even if they are validating and fail eagerly.
 
         let mut at = SequenceNumber::new(commit_record.open_sequence_number.number() + 1);
         let Some(mut predecessor_window) = self.timeline.try_get_window(at) else {
-            return Ok(()); // nothing to validate
+            return None; // nothing to validate
         };
         while at < commit_sequence_number {
             if !predecessor_window.contains(at) {
                 predecessor_window = self.timeline.get_window(at);
             }
-            if let Some(conflict) = self.resolve_concurrent(commit_record, at, &predecessor_window) {
-                return Err(conflict);
-            }
-            at = SequenceNumber::new(at.number() + 1);
-        }
-        Ok(())
-    }
 
-    fn resolve_concurrent(
-        &self,
-        commit_record: &CommitRecord,
-        predecessor_sequence_number: SequenceNumber,
-        predecessor_window: &TimelineWindow<TIMELINE_WINDOW_SIZE>,
-    ) -> Option<IsolationConflict> {
-        let predecessor_status = predecessor_window.get_status(predecessor_sequence_number);
-        let isolation_dependency = match predecessor_status {
-            CommitStatus::Empty => unreachable!("A concurrent status should never be empty at commit time"),
-            CommitStatus::Pending(predecessor_record) => {
-                match self.compute_dependency(commit_record, predecessor_record) {
-                    IsolationDependency::Independent => IsolationDependency::Independent,
-                    result => {
-                        if self.await_pending_status_commits(predecessor_sequence_number, predecessor_window) {
-                            result
-                        } else {
-                            IsolationDependency::Independent
+            let isolation_dependency = match predecessor_window.get_status(at) {
+                CommitStatus::Empty => unreachable!("A concurrent status should never be empty at commit time"),
+                CommitStatus::Pending(predecessor_record) => {
+                    match commit_record.compute_dependency(predecessor_record) {
+                        IsolationDependency::Independent => IsolationDependency::Independent,
+                        result => {
+                            if self.await_pending_status_commits(at, &predecessor_window) {
+                                result
+                            } else {
+                                IsolationDependency::Independent
+                            }
                         }
                     }
                 }
+                CommitStatus::Committed(predecessor_record) => commit_record.compute_dependency(predecessor_record),
+                CommitStatus::Closed => IsolationDependency::Independent,
+            };
+
+            match isolation_dependency {
+                IsolationDependency::Independent => (),
+                IsolationDependency::DependentPuts { puts } => puts.into_iter().for_each(DependentPut::apply),
+                IsolationDependency::Conflict(conflict) => return Some(conflict),
             }
-            CommitStatus::Committed(predecessor_record) => self.compute_dependency(commit_record, predecessor_record),
-            CommitStatus::Closed => IsolationDependency::Independent,
-        };
-        match isolation_dependency {
-            IsolationDependency::Independent => None,
-            IsolationDependency::DependentPuts { puts } => {
-                puts.into_iter().for_each(|DependentPut { flag, value }| flag.store(value, Ordering::Release));
-                None
-            }
-            IsolationDependency::Conflict(conflict) => Some(conflict),
+
+            at = SequenceNumber::new(at.number() + 1);
         }
+        None
     }
 
     fn await_pending_status_commits(
@@ -159,54 +150,6 @@ impl IsolationManager {
                 CommitStatus::Committed(_) => return true,
                 CommitStatus::Closed => return false,
             }
-        }
-    }
-
-    fn compute_dependency(&self, record: &CommitRecord, predecessor: &CommitRecord) -> IsolationDependency {
-        // TODO: this can be optimised by some kind of bit-wise NAND of two bloom filter-like data
-        // structures first, since we assume few clashes this should mostly succeed
-        // TODO: can be optimised with an intersection of two sorted iterators instead of iterate + gets
-
-        let mut puts_to_update = Vec::new();
-
-        for (buffer, predecessor_buffer) in record.buffers().iter().zip(predecessor.buffers()) {
-            let map = buffer.map().read().unwrap();
-            if map.is_empty() {
-                continue;
-            }
-
-            let predecessor_map = predecessor_buffer.map().read().unwrap();
-            if predecessor_map.is_empty() {
-                continue;
-            }
-
-            for (key, write) in map.iter() {
-                if let Some(predecessor_write) = predecessor_map.get(key.bytes()) {
-                    match (predecessor_write, write) {
-                        (Write::Delete, Write::RequireExists { .. }) => {
-                            return IsolationDependency::Conflict(IsolationConflict::DeleteRequired);
-                        }
-                        (Write::RequireExists { .. }, Write::Delete) => {
-                            // we escalate required-delete to failure, since requires implies dependencies that may be broken
-                            // TODO: maybe RequireExists should be RequireDependency to capture this?
-                            return IsolationDependency::Conflict(IsolationConflict::RequiredDelete);
-                        }
-                        (Write::Insert { .. } | Write::Put { .. }, Write::Put { reinsert, .. }) => {
-                            puts_to_update.push(DependentPut { flag: reinsert.clone(), value: false });
-                        }
-                        (Write::Delete, Write::Put { reinsert, .. }) => {
-                            puts_to_update.push(DependentPut { flag: reinsert.clone(), value: true });
-                        }
-                        _ => (),
-                    }
-                }
-            }
-        }
-
-        if puts_to_update.is_empty() {
-            IsolationDependency::Independent
-        } else {
-            IsolationDependency::DependentPuts { puts: puts_to_update }
         }
     }
 
@@ -245,6 +188,12 @@ impl IsolationManager {
 struct DependentPut {
     flag: Arc<AtomicBool>,
     value: bool,
+}
+
+impl DependentPut {
+    fn apply(self) {
+        self.flag.store(self.value, Ordering::Release);
+    }
 }
 
 #[derive(Debug)]
@@ -624,6 +573,54 @@ impl CommitRecord {
         assert_eq!(Self::RECORD_TYPE, record_type);
         // TODO: handle error with a better message
         bincode::deserialize_from(reader).unwrap_or_log()
+    }
+
+    fn compute_dependency(&self, predecessor: &CommitRecord) -> IsolationDependency {
+        // TODO: this can be optimised by some kind of bit-wise NAND of two bloom filter-like data
+        // structures first, since we assume few clashes this should mostly succeed
+        // TODO: can be optimised with an intersection of two sorted iterators instead of iterate + gets
+
+        let mut puts_to_update = Vec::new();
+
+        for (buffer, predecessor_buffer) in self.buffers().iter().zip(predecessor.buffers()) {
+            let map = buffer.map().read().unwrap();
+            if map.is_empty() {
+                continue;
+            }
+
+            let predecessor_map = predecessor_buffer.map().read().unwrap();
+            if predecessor_map.is_empty() {
+                continue;
+            }
+
+            for (key, write) in map.iter() {
+                if let Some(predecessor_write) = predecessor_map.get(key.bytes()) {
+                    match (predecessor_write, write) {
+                        (Write::Delete, Write::RequireExists { .. }) => {
+                            return IsolationDependency::Conflict(IsolationConflict::DeleteRequired);
+                        }
+                        (Write::RequireExists { .. }, Write::Delete) => {
+                            // we escalate required-delete to failure, since requires implies dependencies that may be broken
+                            // TODO: maybe RequireExists should be RequireDependency to capture this?
+                            return IsolationDependency::Conflict(IsolationConflict::RequiredDelete);
+                        }
+                        (Write::Insert { .. } | Write::Put { .. }, Write::Put { reinsert, .. }) => {
+                            puts_to_update.push(DependentPut { flag: reinsert.clone(), value: false });
+                        }
+                        (Write::Delete, Write::Put { reinsert, .. }) => {
+                            puts_to_update.push(DependentPut { flag: reinsert.clone(), value: true });
+                        }
+                        _ => (),
+                    }
+                }
+            }
+        }
+
+        if puts_to_update.is_empty() {
+            IsolationDependency::Independent
+        } else {
+            IsolationDependency::DependentPuts { puts: puts_to_update }
+        }
     }
 }
 

--- a/storage/snapshot/buffer.rs
+++ b/storage/snapshot/buffer.rs
@@ -100,13 +100,13 @@ impl KeyspaceBuffer {
         self.buffer.write().unwrap().insert(key, Write::Insert { value });
     }
 
-    pub(crate) fn insert_preexisting(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
-        self.buffer.write().unwrap().insert(key, Write::InsertPreexisting { value, reinsert: Arc::default() });
+    pub(crate) fn put(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
+        self.buffer.write().unwrap().insert(key, Write::Put { value, reinsert: Arc::default() });
     }
 
     pub(crate) fn require_exists(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
         let mut map = self.buffer.write().unwrap();
-        // TODO: what if it already has been inserted? Ie. InsertPreexisting?
+        // TODO: what if it already has been inserted? Ie. Put?
         map.insert(key, Write::RequireExists { value });
     }
 
@@ -125,9 +125,9 @@ impl KeyspaceBuffer {
     pub(crate) fn get<const INLINE_BYTES: usize>(&self, key: &[u8]) -> Option<ByteArray<INLINE_BYTES>> {
         let map = self.buffer.read().unwrap();
         match map.get(key) {
-            Some(Write::Insert { value })
-            | Some(Write::InsertPreexisting { value, .. })
-            | Some(Write::RequireExists { value }) => Some(ByteArray::copy(value.bytes())),
+            Some(Write::Insert { value }) | Some(Write::Put { value, .. }) | Some(Write::RequireExists { value }) => {
+                Some(ByteArray::copy(value.bytes()))
+            }
             Some(Write::Delete) | None => None,
         }
     }

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -158,25 +158,9 @@ impl<'storage, D> WriteSnapshot<'storage, D> {
     }
 
     pub fn put_val(&self, key: StorageKeyArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
-        let buffer = self.buffers.get(key.keyspace_id());
-        if buffer.contains(key.byte_array()) {
-            // TODO: replace existing buffered write. If it contains a preexisting, we can continue to use it
-            todo!()
-        } else {
-            let wrapped = StorageKeyReference::from(&key);
-            let existing_stored = self
-                .storage
-                .get(wrapped, self.open_sequence_number, |reference| {
-                    // Only copy if the value is the same
-                    (reference.bytes() == value.bytes()).then(|| ByteArray::from(reference))
-                })
-                .unwrap();
-            if let Some(Some(existing_stored)) = existing_stored {
-                buffer.insert_preexisting(key.into_byte_array(), existing_stored);
-            } else {
-                buffer.insert(key.into_byte_array(), value);
-            }
-        }
+        let keyspace_id = key.keyspace_id();
+        let byte_array = key.into_byte_array();
+        self.buffers.get(keyspace_id).put(byte_array, value);
     }
 
     /// Insert a delete marker for the key with a new version

--- a/storage/snapshot/write.rs
+++ b/storage/snapshot/write.rs
@@ -31,7 +31,7 @@ pub(crate) enum Write {
     // Insert KeyValue with a new version. Never conflicts.
     Insert { value: ByteArray<BUFFER_VALUE_INLINE> },
     // Insert KeyValue with new version if a concurrent Txn deletes Key. Boolean indicates requires re-insertion. Never conflicts.
-    InsertPreexisting { value: ByteArray<BUFFER_VALUE_INLINE>, reinsert: Arc<AtomicBool> },
+    Put { value: ByteArray<BUFFER_VALUE_INLINE>, reinsert: Arc<AtomicBool> },
     // Delete with a new version. Conflicts with Require.
     Delete,
 }
@@ -41,10 +41,9 @@ impl PartialEq for Write {
         match (self, other) {
             (Self::RequireExists { value }, Self::RequireExists { value: other_value }) => value == other_value,
             (Self::Insert { value }, Self::Insert { value: other_value }) => value == other_value,
-            (
-                Self::InsertPreexisting { value, reinsert },
-                Self::InsertPreexisting { value: other_value, reinsert: other_reinsert },
-            ) => other_value == value && reinsert.load(Ordering::Acquire) == other_reinsert.load(Ordering::Acquire),
+            (Self::Put { value, reinsert }, Self::Put { value: other_value, reinsert: other_reinsert }) => {
+                other_value == value && reinsert.load(Ordering::Acquire) == other_reinsert.load(Ordering::Acquire)
+            }
             (Self::Delete, Self::Delete) => true,
             _ => false,
         }
@@ -58,8 +57,8 @@ impl Write {
         matches!(self, Write::Insert { .. })
     }
 
-    pub(crate) fn is_insert_preexisting(&self) -> bool {
-        matches!(self, Write::InsertPreexisting { .. })
+    pub(crate) fn is_put(&self) -> bool {
+        matches!(self, Write::Put { .. })
     }
 
     pub(crate) fn is_delete(&self) -> bool {
@@ -68,7 +67,7 @@ impl Write {
 
     pub(crate) fn get_value(&self) -> &ByteArray<BUFFER_VALUE_INLINE> {
         match self {
-            Write::Insert { value } | Write::InsertPreexisting { value, .. } | Write::RequireExists { value } => value,
+            Write::Insert { value } | Write::Put { value, .. } | Write::RequireExists { value } => value,
             Write::Delete => panic!("Buffered delete does not have a value."),
         }
     }

--- a/storage/tests/test_isolation.rs
+++ b/storage/tests/test_isolation.rs
@@ -23,7 +23,7 @@ use primitive::prefix_range::PrefixRange;
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
 use storage::{
     error::{MVCCStorageError, MVCCStorageErrorKind},
-    isolation_manager::IsolationError,
+    isolation_manager::{IsolationError, IsolationConflict},
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
     snapshot::SnapshotError,
     KeyspaceSet, MVCCStorage,
@@ -128,7 +128,10 @@ fn g0_update_conflicts_fail() {
             Err(
                 SnapshotError::Commit {
                     source: MVCCStorageError {
-                        kind: MVCCStorageErrorKind::IsolationError { source: IsolationError::RequiredDelete, .. },
+                        kind: MVCCStorageErrorKind::IsolationError {
+                            source: IsolationError::Conflict(IsolationConflict::RequiredDelete),
+                            ..
+                        },
                         ..
                     },
                     ..


### PR DESCRIPTION
## Usage and product changes

We now avoid reading storage during put operations in a write snapshot. Instead, all put operations are initialized during commit into storage, and the state of whether the insertion of the put data needs to be performed is updated during commit validation.