### PR TITLE
Check supertypes of relation when inferring player role types during insert

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -36,5 +36,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "6bd4b47bdb6c4464bdab0d5a547f10f3c2a46f2c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "2e067a01ebd4984d931ab0119bb28ea6be231c93",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/query/common/Util.java
+++ b/query/common/Util.java
@@ -32,7 +32,7 @@ public class Util {
                 throw TypeDBException.of(TYPE_NOT_FOUND, Label.of(var.label().get().label(), relationType.getLabel().name()));
             }
         } else if ((inferred = player.getType().getPlays()
-                .filter(rt -> rt.getRelationType().equals(relation.getType()))
+                .filter(rt -> relation.getType().getSupertypes().anyMatch(supertype -> supertype.equals(rt.getRelationType())))
                 .toSet()).size() == 1) {
             roleType = inferred.iterator().next();
         } else if (inferred.size() > 1) {

--- a/query/common/Util.java
+++ b/query/common/Util.java
@@ -31,8 +31,8 @@ public class Util {
             if ((roleType = relationType.getRelates(var.label().get().label())) == null) {
                 throw TypeDBException.of(TYPE_NOT_FOUND, Label.of(var.label().get().label(), relationType.getLabel().name()));
             }
-        } else if ((inferred = player.getType().getPlays()
-                .filter(rt -> relation.getType().getSupertypes().anyMatch(supertype -> supertype.equals(rt.getRelationType())))
+        } else if ((inferred = relation.getType().getRelates()
+                .filter(relatesRole -> player.getType().plays(relatesRole))
                 .toSet()).size() == 1) {
             roleType = inferred.iterator().next();
         } else if (inferred.size() > 1) {


### PR DESCRIPTION
## Usage and product changes

Given the following minimal schema:
```
define
player sub entity, plays super-relation:super-role;
super-relation sub relation, relates super-role;
sub-relation sub super-relation;
```

It was impossible to insert an instance of `sub-relation` relating a `player` without explicitly specifying its role:
```
> match $player isa player; 
  insert ($player) isa sub-relation; 
[THW27] Invalid Thing Write: Unable to add role player '$player' to the relation, 
        as there is no provided or inferrable role type.
```

The reason for this was that during the handling of the `insert` query, we check if it can play a role defined directly on the requested relation type, without considering any role types it may have inherited. This PR resolves that issue.

## Implementation

Instead of iterating through the player's possible role types and checking that it's defined on the target relation, we iterate through the role types the relation relates, and check if the player's type can play those.