### PR TITLE
Sentry transaction

### DIFF
--- a/common/diagnostics/Diagnostics.java
+++ b/common/diagnostics/Diagnostics.java
@@ -10,7 +10,6 @@ import com.vaticle.typedb.core.common.exception.ErrorMessage;
 import com.vaticle.typedb.core.common.exception.TypeDBException;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.ssl.SslContext;
-import io.sentry.ITransaction;
 import io.sentry.Sentry;
 import io.sentry.SpanStatus;
 import io.sentry.TransactionContext;
@@ -119,9 +118,7 @@ public abstract class Diagnostics {
 
             // FIXME temporary heartbeat every 24 hours
             if (errorReportingEnable) scheduled.scheduleAtFixedRate(() -> {
-                ITransaction transaction = Sentry.startTransaction(new TransactionContext("server", "heartbeat"));
-                transaction.setStatus(SpanStatus.OK);
-                transaction.finish();
+                Sentry.startTransaction(new TransactionContext("server", "heartbeat")).finish(SpanStatus.OK);
             }, 0, 1, TimeUnit.DAYS);
         }
 

--- a/common/diagnostics/Diagnostics.java
+++ b/common/diagnostics/Diagnostics.java
@@ -119,7 +119,7 @@ public abstract class Diagnostics {
             // FIXME temporary heartbeat every 24 hours
             if (errorReportingEnable) scheduled.scheduleAtFixedRate(() -> {
                 Sentry.startTransaction(new TransactionContext("server", "heartbeat")).finish(SpanStatus.OK);
-            }, 0, 1, TimeUnit.DAYS);
+            }, 1, 24, TimeUnit.HOURS);
         }
 
         @Override

--- a/common/diagnostics/Diagnostics.java
+++ b/common/diagnostics/Diagnostics.java
@@ -117,9 +117,14 @@ public abstract class Diagnostics {
             Sentry.setUser(user);
 
             // FIXME temporary heartbeat every 24 hours
-            if (errorReportingEnable) scheduled.scheduleAtFixedRate(() -> {
-                Sentry.startTransaction(new TransactionContext("server", "heartbeat")).finish(SpanStatus.OK);
-            }, 1, 24, TimeUnit.HOURS);
+            if (errorReportingEnable) {
+                scheduled.schedule(() -> {
+                    Sentry.startTransaction(new TransactionContext("server", "bootup")).finish(SpanStatus.OK);
+                }, 1, TimeUnit.HOURS);
+                scheduled.scheduleAtFixedRate(() -> {
+                    Sentry.startTransaction(new TransactionContext("server", "heartbeat")).finish(SpanStatus.OK);
+                }, 25, 24, TimeUnit.HOURS);
+            }
         }
 
         @Override

--- a/database/CoreDatabaseManager.java
+++ b/database/CoreDatabaseManager.java
@@ -104,31 +104,6 @@ public class CoreDatabaseManager implements TypeDB.DatabaseManager {
         }
     }
 
-    private void submitDiagnostics(TransactionContext context) {
-        for (CoreDatabase database : all()) {
-            ITransaction transaction = Sentry.startTransaction(context);
-            try {
-                transaction.setData("db_name_hash", database.name().hashCode());
-                transaction.setMeasurement("concept_type_count", database.typeCount());
-                transaction.setMeasurement("concept_thing_count", database.thingCount());
-                transaction.setMeasurement("concept_thing_connection_count", database.roleCount() + database.hasCount());
-                transaction.setMeasurement("concept_thing_entity_count", database.entityCount());
-                transaction.setMeasurement("concept_thing_relation_count", database.relationCount());
-                transaction.setMeasurement("concept_thing_attribute_count", database.attributeCount());
-                transaction.setMeasurement("concept_thing_role_count", database.roleCount());
-                transaction.setMeasurement("concept_thing_has_count", database.hasCount());
-                transaction.setMeasurement("storage_data_keys_count", database.storageDataKeysEstimate());
-                transaction.setMeasurement("storage_data_bytes", database.storageDataBytesEstimate());
-                transaction.setStatus(SpanStatus.OK);
-            } catch (Exception e) {
-                transaction.setThrowable(e);
-                transaction.setStatus(SpanStatus.UNKNOWN);
-            } finally {
-                transaction.finish();
-            }
-        }
-    }
-
     @Override
     public boolean contains(String name) {
         if (!isOpen.get()) throw TypeDBException.of(DATABASE_MANAGER_CLOSED);


### PR DESCRIPTION
## Usage and product changes

We reintroduce a simple notification task, when diagnostics is enabled, which notifies the diagnostics server of the server ID.