### PR TITLE
Fix application of query bounds through match-fetch queries

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -36,5 +36,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "2e067a01ebd4984d931ab0119bb28ea6be231c93",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "3cd409cf6699d3616c5b5c80849f9210833135a2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -142,6 +142,7 @@ public class Conjunction implements Pattern, Cloneable {
                 } else throw TypeDBException.of(ILLEGAL_STATE);
             }
         });
+        negations.forEach(negation -> negation.disjunction().conjunctions().forEach(conjunction -> conjunction.bound(bounds)));
     }
 
     public Variable variable(Identifier.Variable identifier) {

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -112,7 +112,7 @@ public class Inserter {
 
     private static void validate(TypeVariable var, @Nullable Getter getter) {
         if (var.id().isName() &&
-                (getter == null || !getter.disjunction().sharedVariables().contains(var.id().asName()))) {
+                (getter == null || !getter.disjunction().returnedVariables().contains(var.id().asName()))) {
             throw TypeDBException.of(ILLEGAL_UNBOUND_TYPE_VAR_IN_INSERT, var.id());
         }
     }

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -95,7 +95,7 @@ public class Reasoner {
             boundDisjunction = new Disjunction(iterate(disjunction.conjunctions()).map(c -> bound(c, bindings)).toList());
         } else boundDisjunction = disjunction;
         inferAndValidateTypes(boundDisjunction);
-        Filter filter = filterVars.isEmpty() ? Filter.create(boundDisjunction.sharedVariables()) : Filter.create(filterVars);
+        Filter filter = filterVars.isEmpty() ? Filter.create(boundDisjunction.returnedVariables()) : Filter.create(filterVars);
         Optional<Sorting> sorting = modifiers.sort().map(Sorting::create);
         sorting.ifPresent(value -> validateSorting(boundDisjunction, value));
         Disjunction answerableDisjunction = filterUnanswerable(boundDisjunction);

--- a/reasoner/controller/ConclusionController.java
+++ b/reasoner/controller/ConclusionController.java
@@ -217,7 +217,7 @@ public abstract class ConclusionController<
         public void setUp() {
             setHubReactive(fanOut(this));
             InputPort<Either<ConceptMap, Materialisation>> conditionInput = createInputPort();
-            ConceptMap filteredBounds = bounds().filter(rule.when().sharedVariables());
+            ConceptMap filteredBounds = bounds().filter(rule.when().returnedVariables());
             mayRequestCondition(new ConditionRequest(conditionInput.identifier(), driver(), rule.condition(), filteredBounds));
             Stream<Either<ConceptMap, Map<Variable, Concept>>, OUTPUT> conclusionReactive = createStream();
             conditionInput.map(Processor::convertConclusionInput).registerSubscriber(conclusionReactive);
@@ -296,7 +296,7 @@ public abstract class ConclusionController<
                 if (packet.isFirst()) {
                     assert packet.first().concepts().keySet().containsAll(Collections.intersection(
                             conclusionProcessor().rule().conclusion().pattern().retrieves(),
-                            iterate(conclusionProcessor().rule().condition().disjunction().pattern().sharedVariables())
+                            iterate(conclusionProcessor().rule().condition().disjunction().pattern().returnedVariables())
                                     .map(Variable.Retrievable::asRetrievable).toSet()
                     ));
                     InputPort<Either<ConceptMap, Materialisation>> materialisationInput = conclusionProcessor().createInputPort();


### PR DESCRIPTION
## Usage and product changes

We fix a bug that was revealed when using `match-fetch` queries with subqueries that had nested patterns. This change now correctly applies 1) filtering to a parent match query so that the right outputs are generated 2) passes the bounds received from a preceding query correctly into all child patterns of subsequent query clauses.

## Implementation

- Add test in BDD for bounds-passing and filtering from match to fetch clauses that contain nested patterns
- Split `Disjunction.sharedVariables` (which only returns non-recursive variables that are common across all branches of a disjunction) and `namedVariables` (which contains _all_ named variables in any branch, read recursively.)