### PR TITLE
Single writer transactions

### DIFF
--- a/concept/benches/bench_thing_write.rs
+++ b/concept/benches/bench_thing_write.rs
@@ -96,7 +96,6 @@ fn criterion_benchmark(c: &mut Criterion) {
     let w1 = storage.read_watermark();
     create_schema(&storage, &type_vertex_generator);
     let w2 = storage.read_watermark();
-    dbg!("before schema commit watermark: {}, after: {}", w1, w2);
     let schema_cache = Arc::new(TypeCache::new(storage.clone(), storage.read_watermark()).unwrap());
 
     let mut group = c.benchmark_group("test writes");

--- a/concept/tests/test_thing.rs
+++ b/concept/tests/test_thing.rs
@@ -36,33 +36,31 @@ fn thing_create_iterate() {
     let mut storage = Arc::new(MVCCStorage::<WAL>::open::<EncodingKeyspace>("storage", &storage_path).unwrap());
     let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
     TypeManager::<WriteSnapshot<WAL>>::initialise_types(storage.clone(), type_vertex_generator.clone()).unwrap();
-    let snapshot: Arc<WriteSnapshot<WAL>> = Arc::new(storage.clone().open_snapshot_write());
+    let mut snapshot: WriteSnapshot<WAL> = storage.clone().open_snapshot_write();
     {
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        let type_manager = Arc::new(TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), None));
+        let type_manager = Arc::new(TypeManager::new(type_vertex_generator.clone(), None));
 
-        let thing_manager = ThingManager::new(snapshot.clone(), thing_vertex_generator.clone(), type_manager.clone());
+        let thing_manager = ThingManager::new(thing_vertex_generator.clone(), type_manager.clone());
         let person_label = Label::build("person");
-        let person_type = type_manager.create_entity_type(&person_label, false).unwrap();
+        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label, false).unwrap();
 
-        let _person_1 = thing_manager.create_entity(person_type.clone()).unwrap();
-        let _person_2 = thing_manager.create_entity(person_type.clone()).unwrap();
-        let _person_3 = thing_manager.create_entity(person_type.clone()).unwrap();
-        let _person_4 = thing_manager.create_entity(person_type.clone()).unwrap();
+        let _person_1 = thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap();
+        let _person_2 = thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap();
+        let _person_3 = thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap();
+        let _person_4 = thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap();
 
-        let finalise_result = thing_manager.finalise();
+        let finalise_result = thing_manager.finalise(&mut snapshot);
         assert!(finalise_result.is_ok());
     }
-    if let write_snapshot = Arc::try_unwrap(snapshot).ok().unwrap() {
-        write_snapshot.commit().unwrap();
-    }
+    snapshot.commit().unwrap();
 
     {
-        let snapshot: Arc<ReadSnapshot<WAL>> = Arc::new(storage.clone().open_snapshot_read());
-        let type_manager = Arc::new(TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), None));
+        let snapshot: ReadSnapshot<WAL> = storage.clone().open_snapshot_read();
+        let type_manager = Arc::new(TypeManager::new(type_vertex_generator.clone(), None));
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        let thing_manager = ThingManager::new(snapshot.clone(), thing_vertex_generator.clone(), type_manager);
-        let entities = thing_manager.get_entities().collect_cloned();
+        let thing_manager = ThingManager::new(thing_vertex_generator.clone(), type_manager);
+        let entities = thing_manager.get_entities(&snapshot).collect_cloned();
         assert_eq!(entities.len(), 4);
     }
 }
@@ -81,45 +79,44 @@ fn attribute_create() {
     let age_value: i64 = 10;
     let name_value: &str = "TypeDB Fan";
 
-    let snapshot: Arc<WriteSnapshot<WAL>> = Arc::new(storage.clone().open_snapshot_write());
+    let mut snapshot: WriteSnapshot<WAL> = storage.clone().open_snapshot_write();
     {
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        let type_manager = Arc::new(TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), None));
-        let thing_manager = ThingManager::new(snapshot.clone(), thing_vertex_generator.clone(), type_manager.clone());
+        let type_manager = Arc::new(TypeManager::new(type_vertex_generator.clone(), None));
+        let thing_manager = ThingManager::new(thing_vertex_generator.clone(), type_manager.clone());
 
-        let age_type = type_manager.create_attribute_type(&age_label, false).unwrap();
-        age_type.set_value_type(&type_manager, ValueType::Long);
-        age_type.set_annotation(&type_manager, AttributeTypeAnnotation::Independent(AnnotationIndependent::new())).unwrap();
-        let name_type = type_manager.create_attribute_type(&name_label, false).unwrap();
-        name_type.set_value_type(&type_manager, ValueType::String);
-        name_type.set_annotation(&type_manager, AttributeTypeAnnotation::Independent(AnnotationIndependent::new())).unwrap();
+        let age_type = type_manager.create_attribute_type(&mut snapshot, &age_label, false).unwrap();
+        age_type.set_value_type(&mut snapshot, &type_manager, ValueType::Long);
+        age_type.set_annotation(&mut snapshot, &type_manager, AttributeTypeAnnotation::Independent(AnnotationIndependent::new())).unwrap();
+        let name_type = type_manager.create_attribute_type(&mut snapshot, &name_label, false).unwrap();
+        name_type.set_value_type(&mut snapshot, &type_manager, ValueType::String);
+        name_type.set_annotation(&mut snapshot, &type_manager, AttributeTypeAnnotation::Independent(AnnotationIndependent::new())).unwrap();
 
-        let mut age_1 = thing_manager.create_attribute(age_type.clone(), Value::Long(age_value)).unwrap();
-        assert_eq!(age_1.get_value(&thing_manager).unwrap(), Value::Long(age_value));
+        let mut age_1 = thing_manager.create_attribute(&mut snapshot, age_type.clone(), Value::Long(age_value)).unwrap();
+        assert_eq!(age_1.get_value(&mut snapshot, &thing_manager).unwrap(), Value::Long(age_value));
 
         let mut name_1 = thing_manager
-            .create_attribute(name_type.clone(), Value::String(Cow::Borrowed(name_value)))
+            .create_attribute(&mut snapshot, name_type.clone(), Value::String(Cow::Borrowed(name_value)))
             .unwrap();
-        assert_eq!(name_1.get_value(&thing_manager).unwrap(), Value::String(Cow::Borrowed(name_value)));
+        assert_eq!(name_1.get_value(&mut snapshot, &thing_manager).unwrap(), Value::String(Cow::Borrowed(name_value)));
 
-        let finalise_result = thing_manager.finalise();
+        let finalise_result = thing_manager.finalise(&mut snapshot);
         assert!(finalise_result.is_ok());
     }
-    let write_snapshot = Arc::try_unwrap(snapshot).ok().unwrap();
-    write_snapshot.commit().unwrap();
+    snapshot.commit().unwrap();
 
     {
-        let snapshot: Arc<ReadSnapshot<WAL>> = Arc::new(storage.open_snapshot_read());
-        let type_manager = Arc::new(TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), None));
+        let snapshot: ReadSnapshot<WAL> = storage.open_snapshot_read();
+        let type_manager = Arc::new(TypeManager::new(type_vertex_generator.clone(), None));
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        let thing_manager = ThingManager::new(snapshot.clone(), thing_vertex_generator.clone(), type_manager.clone());
-        let attributes = thing_manager.get_attributes().collect_cloned();
+        let thing_manager = ThingManager::new(thing_vertex_generator.clone(), type_manager.clone());
+        let attributes = thing_manager.get_attributes(&snapshot).collect_cloned();
         assert_eq!(attributes.len(), 2);
 
-        let age_type = type_manager.get_attribute_type(&age_label).unwrap().unwrap();
-        let mut ages = thing_manager.get_attributes_in(age_type).unwrap().collect_cloned();
+        let age_type = type_manager.get_attribute_type(&snapshot, &age_label).unwrap().unwrap();
+        let mut ages = thing_manager.get_attributes_in(&snapshot, age_type).unwrap().collect_cloned();
         assert_eq!(ages.len(), 1);
-        assert_eq!(ages.first_mut().unwrap().get_value(&thing_manager).unwrap(), Value::Long(age_value));
+        assert_eq!(ages.first_mut().unwrap().get_value(&snapshot, &thing_manager).unwrap(), Value::Long(age_value));
     }
 }
 
@@ -138,51 +135,49 @@ fn has() {
     let age_value: i64 = 10;
     let name_value: &str = "TypeDB Fan";
 
-    let snapshot: Arc<WriteSnapshot<WAL>> = Arc::new(storage.clone().open_snapshot_write());
+    let mut snapshot: WriteSnapshot<WAL> = storage.clone().open_snapshot_write();
     {
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        let type_manager = Arc::new(TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), None));
-        let thing_manager = ThingManager::new(snapshot.clone(), thing_vertex_generator.clone(), type_manager.clone());
+        let type_manager = Arc::new(TypeManager::new(type_vertex_generator.clone(), None));
+        let thing_manager = ThingManager::new(thing_vertex_generator.clone(), type_manager.clone());
 
-        let age_type = type_manager.create_attribute_type(&age_label, false).unwrap();
-        age_type.set_value_type(&type_manager, ValueType::Long);
-        let name_type = type_manager.create_attribute_type(&name_label, false).unwrap();
-        name_type.set_value_type(&type_manager, ValueType::String);
+        let age_type = type_manager.create_attribute_type(&mut snapshot, &age_label, false).unwrap();
+        age_type.set_value_type(&mut snapshot, &type_manager, ValueType::Long);
+        let name_type = type_manager.create_attribute_type(&mut snapshot, &name_label, false).unwrap();
+        name_type.set_value_type(&mut snapshot, &type_manager, ValueType::String);
 
-        let person_type = type_manager.create_entity_type(&person_label, false).unwrap();
-        person_type.set_owns(&type_manager, age_type.clone(), Ordering::Unordered);
-        person_type.set_owns(&type_manager, name_type.clone(), Ordering::Unordered);
+        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label, false).unwrap();
+        person_type.set_owns(&mut snapshot, &type_manager, age_type.clone(), Ordering::Unordered);
+        person_type.set_owns(&mut snapshot, &type_manager, name_type.clone(), Ordering::Unordered);
 
-        let person_1 = thing_manager.create_entity(person_type.clone()).unwrap();
-        let age_1 = thing_manager.create_attribute(age_type.clone(), Value::Long(age_value)).unwrap();
+        let person_1 = thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap();
+        let age_1 = thing_manager.create_attribute(&mut snapshot, age_type.clone(), Value::Long(age_value)).unwrap();
         let name_1 = thing_manager
-            .create_attribute(name_type.clone(), Value::String(Cow::Owned(String::from(name_value))))
+            .create_attribute(&mut snapshot, name_type.clone(), Value::String(Cow::Owned(String::from(name_value))))
             .unwrap();
 
-        person_1.set_has_unordered(&thing_manager, age_1).unwrap();
-        person_1.set_has_unordered(&thing_manager, name_1).unwrap();
+        person_1.set_has_unordered(&mut snapshot, &thing_manager, age_1).unwrap();
+        person_1.set_has_unordered(&mut snapshot, &thing_manager, name_1).unwrap();
 
-        let retrieved_attributes_count = person_1.get_has(&thing_manager).count();
+        let retrieved_attributes_count = person_1.get_has(&snapshot, &thing_manager).count();
         assert_eq!(retrieved_attributes_count, 2);
 
-        let finalise_result = thing_manager.finalise();
+        let finalise_result = thing_manager.finalise(&mut snapshot);
         assert!(finalise_result.is_ok());
     }
-
-    let write_snapshot = Arc::try_unwrap(snapshot).ok().unwrap();
-    write_snapshot.commit().unwrap();
+    snapshot.commit().unwrap();
 
     {
-        let snapshot: Arc<ReadSnapshot<WAL>> = Arc::new(storage.clone().open_snapshot_read());
-        let type_manager = Arc::new(TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), None));
+        let snapshot: ReadSnapshot<WAL> = storage.clone().open_snapshot_read();
+        let type_manager = Arc::new(TypeManager::new(type_vertex_generator.clone(), None));
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        let thing_manager = ThingManager::new(snapshot.clone(), thing_vertex_generator.clone(), type_manager.clone());
-        let attributes = thing_manager.get_attributes().collect_cloned();
+        let thing_manager = ThingManager::new(thing_vertex_generator.clone(), type_manager.clone());
+        let attributes = thing_manager.get_attributes(&snapshot).collect_cloned();
         assert_eq!(attributes.len(), 2);
 
-        let people = thing_manager.get_entities().collect_cloned();
+        let people = thing_manager.get_entities(&snapshot).collect_cloned();
         let person_1 = people.first().unwrap();
-        let retrieved_attributes_count = person_1.get_has(&thing_manager).count();
+        let retrieved_attributes_count = person_1.get_has(&snapshot, &thing_manager).count();
         assert_eq!(retrieved_attributes_count, 2);
     }
 }
@@ -203,115 +198,111 @@ fn attribute_cleanup_on_concurrent_detach() {
     let name_alice_value: &str = "Alice";
     let name_bob_value: &str = "Bob";
 
-    let snapshot: Arc<WriteSnapshot<WAL>> = Arc::new(storage.clone().open_snapshot_write());
+    let mut snapshot: WriteSnapshot<WAL> = storage.clone().open_snapshot_write();
     {
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        let type_manager = Arc::new(TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), None));
-        let thing_manager = ThingManager::new(snapshot.clone(), thing_vertex_generator.clone(), type_manager.clone());
+        let type_manager = Arc::new(TypeManager::new(type_vertex_generator.clone(), None));
+        let thing_manager = ThingManager::new(thing_vertex_generator.clone(), type_manager.clone());
 
-        let age_type = type_manager.create_attribute_type(&age_label, false).unwrap();
-        age_type.set_value_type(&type_manager, ValueType::Long);
-        let name_type = type_manager.create_attribute_type(&name_label, false).unwrap();
-        name_type.set_value_type(&type_manager, ValueType::String);
+        let age_type = type_manager.create_attribute_type(&mut snapshot, &age_label, false).unwrap();
+        age_type.set_value_type(&mut snapshot, &type_manager, ValueType::Long);
+        let name_type = type_manager.create_attribute_type(&mut snapshot, &name_label, false).unwrap();
+        name_type.set_value_type(&mut snapshot, &type_manager, ValueType::String);
 
-        let person_type = type_manager.create_entity_type(&person_label, false).unwrap();
-        let owns_age = person_type.set_owns(&type_manager, age_type.clone(), Ordering::Unordered);
-        owns_age.set_annotation(&type_manager, OwnsAnnotation::Distinct(AnnotationDistinct::new()));
-        let _ = person_type.set_owns(&type_manager, name_type.clone(), Ordering::Unordered);
+        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label, false).unwrap();
+        let owns_age = person_type.set_owns(&mut snapshot, &type_manager, age_type.clone(), Ordering::Unordered);
+        owns_age.set_annotation(&mut snapshot, &type_manager, OwnsAnnotation::Distinct(AnnotationDistinct::new()));
+        let _ = person_type.set_owns(&mut snapshot, &type_manager, name_type.clone(), Ordering::Unordered);
 
-        let person_1 = thing_manager.create_entity(person_type.clone()).unwrap();
-        let person_2 = thing_manager.create_entity(person_type.clone()).unwrap();
-        let age_1 = thing_manager.create_attribute(age_type.clone(), Value::Long(age_value)).unwrap();
-        let name_alice = thing_manager.create_attribute(
-            name_type.clone(),
-            Value::String(Cow::Borrowed(name_alice_value)),
+        let person_1 = thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap();
+        let person_2 = thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap();
+        let age_1 = thing_manager.create_attribute(&mut snapshot, age_type.clone(), Value::Long(age_value)).unwrap();
+        let name_alice = thing_manager.create_attribute(&mut snapshot,
+                                                        name_type.clone(),
+                                                        Value::String(Cow::Borrowed(name_alice_value)),
         ).unwrap();
-        let name_bob = thing_manager.create_attribute(
-            name_type.clone(),
-            Value::String(Cow::Owned(String::from(name_bob_value))),
+        let name_bob = thing_manager.create_attribute(&mut snapshot,
+                                                      name_type.clone(),
+                                                      Value::String(Cow::Owned(String::from(name_bob_value))),
         ).unwrap();
 
-        person_1.set_has_unordered(&thing_manager, age_1.as_reference()).unwrap();
-        person_1.set_has_unordered(&thing_manager, name_alice.as_reference()).unwrap();
-        person_2.set_has_unordered(&thing_manager, age_1).unwrap();
-        person_2.set_has_unordered(&thing_manager, name_bob.as_reference()).unwrap();
-        let finalise_result = thing_manager.finalise();
+        person_1.set_has_unordered(&mut snapshot, &thing_manager, age_1.as_reference()).unwrap();
+        person_1.set_has_unordered(&mut snapshot, &thing_manager, name_alice.as_reference()).unwrap();
+        person_2.set_has_unordered(&mut snapshot, &thing_manager, age_1).unwrap();
+        person_2.set_has_unordered(&mut snapshot, &thing_manager, name_bob.as_reference()).unwrap();
+        let finalise_result = thing_manager.finalise(&mut snapshot);
         assert!(finalise_result.is_ok());
     }
-
-    let write_snapshot = Arc::try_unwrap(snapshot).ok().unwrap();
-    write_snapshot.commit().unwrap();
+    snapshot.commit().unwrap();
 
     // two concurrent snapshots delete the independent ownerships
-    let snapshot_1: Arc<WriteSnapshot<WAL>> = Arc::new(storage.clone().open_snapshot_write());
-    let snapshot_2: Arc<WriteSnapshot<WAL>> = Arc::new(storage.clone().open_snapshot_write());
+    let mut snapshot_1: WriteSnapshot<WAL> = storage.clone().open_snapshot_write();
+    let mut snapshot_2: WriteSnapshot<WAL> = storage.clone().open_snapshot_write();
 
     {
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        let type_manager = Arc::new(TypeManager::new(snapshot_1.clone(), type_vertex_generator.clone(), None));
-        let thing_manager = ThingManager::new(snapshot_1.clone(), thing_vertex_generator.clone(), type_manager.clone());
-        let name_type = type_manager.get_attribute_type(&name_label).unwrap().unwrap();
-        let age_type = type_manager.get_attribute_type(&age_label).unwrap().unwrap();
+        let type_manager = Arc::new(TypeManager::new(type_vertex_generator.clone(), None));
+        let thing_manager = ThingManager::new(thing_vertex_generator.clone(), type_manager.clone());
+        let name_type = type_manager.get_attribute_type(&snapshot_1, &name_label).unwrap().unwrap();
+        let age_type = type_manager.get_attribute_type(&snapshot_1, &age_label).unwrap().unwrap();
 
-        let entities = thing_manager.get_entities().collect_cloned();
+        let entities = thing_manager.get_entities(&snapshot_1).collect_cloned();
         let bob = entities.iter().filter(|entity| {
-            entity.has_attribute(&thing_manager, name_type.clone(), Value::String(Cow::Borrowed(name_bob_value)))
+            entity.has_attribute(&snapshot_1, &thing_manager, name_type.clone(), Value::String(Cow::Borrowed(name_bob_value)))
                 .unwrap()
         }).next().unwrap();
 
-        let mut ages = thing_manager.get_attributes_in(age_type.clone()).unwrap().collect_cloned();
+        let mut ages = thing_manager.get_attributes_in(&snapshot_1, age_type.clone()).unwrap().collect_cloned();
         let age = ages.iter_mut().filter_map(|mut attr| {
-            if attr.get_value(&thing_manager).unwrap().unwrap_long() == age_value {
+            if attr.get_value(&snapshot_1, &thing_manager).unwrap().unwrap_long() == age_value {
                 Some(attr.as_reference())
             } else {
                 None
             }
         }).next().unwrap();
-        bob.delete_has_unordered(&thing_manager, age).unwrap();
+        bob.delete_has_unordered(&mut snapshot_1, &thing_manager, age).unwrap();
 
-        let finalise_result = thing_manager.finalise();
+        let finalise_result = thing_manager.finalise(&mut snapshot_1);
         assert!(finalise_result.is_ok());
     }
 
     {
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        let type_manager = Arc::new(TypeManager::new(snapshot_2.clone(), type_vertex_generator.clone(), None));
-        let thing_manager = ThingManager::new(snapshot_2.clone(), thing_vertex_generator.clone(), type_manager.clone());
-        let name_type = type_manager.get_attribute_type(&name_label).unwrap().unwrap();
-        let age_type = type_manager.get_attribute_type(&age_label).unwrap().unwrap();
+        let type_manager = Arc::new(TypeManager::new(type_vertex_generator.clone(), None));
+        let thing_manager = ThingManager::new(thing_vertex_generator.clone(), type_manager.clone());
+        let name_type = type_manager.get_attribute_type(&snapshot_2, &name_label).unwrap().unwrap();
+        let age_type = type_manager.get_attribute_type(&snapshot_2, &age_label).unwrap().unwrap();
 
-        let entities = thing_manager.get_entities().collect_cloned();
+        let entities = thing_manager.get_entities(&snapshot_2).collect_cloned();
         let alice = entities.iter().filter(|entity|
-            entity.has_attribute(&thing_manager, name_type.clone(), Value::String(Cow::Borrowed(name_bob_value)))
+            entity.has_attribute(&snapshot_2, &thing_manager, name_type.clone(), Value::String(Cow::Borrowed(name_bob_value)))
                 .unwrap()
         ).next().unwrap();
 
-        let mut ages = thing_manager.get_attributes_in(age_type.clone()).unwrap().collect_cloned();
+        let mut ages = thing_manager.get_attributes_in(&snapshot_2, age_type.clone()).unwrap().collect_cloned();
         let age = ages.iter_mut().filter_map(|mut attr| {
-            if attr.get_value(&thing_manager).unwrap().unwrap_long() == age_value {
+            if attr.get_value(&snapshot_2, &thing_manager).unwrap().unwrap_long() == age_value {
                 Some(attr.as_reference())
             } else {
                 None
             }
         }).next().unwrap();
-        alice.delete_has_unordered(&thing_manager, age).unwrap();
+        alice.delete_has_unordered(&mut snapshot_2, &thing_manager, age).unwrap();
 
-        let finalise_result = thing_manager.finalise();
+        let finalise_result = thing_manager.finalise(&mut snapshot_2);
         assert!(finalise_result.is_ok());
     }
 
-    let write_snapshot_1 = Arc::try_unwrap(snapshot_1).ok().unwrap();
-    write_snapshot_1.commit().unwrap();
-    let write_snapshot_2 = Arc::try_unwrap(snapshot_2).ok().unwrap();
-    write_snapshot_2.commit().unwrap();
+    snapshot_1.commit().unwrap();
+    snapshot_2.commit().unwrap();
     {
-        let snapshot: Arc<ReadSnapshot<WAL>> = Arc::new(storage.clone().open_snapshot_read());
-        let type_manager = Arc::new(TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), None));
+        let snapshot: ReadSnapshot<WAL> = storage.clone().open_snapshot_read();
+        let type_manager = Arc::new(TypeManager::new(type_vertex_generator.clone(), None));
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        let thing_manager = ThingManager::new(snapshot.clone(), thing_vertex_generator.clone(), type_manager.clone());
-        let age_type = type_manager.get_attribute_type(&age_label).unwrap().unwrap();
+        let thing_manager = ThingManager::new(thing_vertex_generator.clone(), type_manager.clone());
+        let age_type = type_manager.get_attribute_type(&snapshot, &age_label).unwrap().unwrap();
 
-        let attributes = thing_manager.get_attributes_in(age_type).unwrap().collect_cloned();
+        let attributes = thing_manager.get_attributes_in(&snapshot, age_type).unwrap().collect_cloned();
         assert_eq!(attributes.len(), 0);
     }
 }
@@ -331,81 +322,79 @@ fn role_player_distinct() {
     let person_label = Label::build("person");
     let company_label = Label::build("company");
 
-    let snapshot: Arc<WriteSnapshot<WAL>> = Arc::new(storage.clone().open_snapshot_write());
+    let mut snapshot: WriteSnapshot<WAL> = storage.clone().open_snapshot_write();
     {
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        let type_manager = Arc::new(TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), None));
-        let thing_manager = ThingManager::new(snapshot.clone(), thing_vertex_generator.clone(), type_manager.clone());
+        let type_manager = Arc::new(TypeManager::new(type_vertex_generator.clone(), None));
+        let thing_manager = ThingManager::new(thing_vertex_generator.clone(), type_manager.clone());
 
-        let employment_type = type_manager.create_relation_type(&employment_label, false).unwrap();
-        employment_type.create_relates(&type_manager, employee_role, Ordering::Unordered).unwrap();
-        let employee_type = employment_type.get_relates_role(&type_manager, employee_role).unwrap().unwrap().role();
-        employee_type.set_annotation(&type_manager, RoleTypeAnnotation::Distinct(AnnotationDistinct::new())).unwrap();
-        employment_type.create_relates(&type_manager, employer_role, Ordering::Unordered).unwrap();
-        let employer_type = employment_type.get_relates_role(&type_manager, employer_role).unwrap().unwrap().role();
-        employer_type.set_annotation(&type_manager, RoleTypeAnnotation::Distinct(AnnotationDistinct::new())).unwrap();
+        let employment_type = type_manager.create_relation_type(&mut snapshot, &employment_label, false).unwrap();
+        employment_type.create_relates(&mut snapshot, &type_manager, employee_role, Ordering::Unordered).unwrap();
+        let employee_type = employment_type.get_relates_role(&snapshot, &type_manager, employee_role).unwrap().unwrap().role();
+        employee_type.set_annotation(&mut snapshot, &type_manager, RoleTypeAnnotation::Distinct(AnnotationDistinct::new())).unwrap();
+        employment_type.create_relates(&mut snapshot, &type_manager, employer_role, Ordering::Unordered).unwrap();
+        let employer_type = employment_type.get_relates_role(&snapshot, &type_manager, employer_role).unwrap().unwrap().role();
+        employer_type.set_annotation(&mut snapshot, &type_manager, RoleTypeAnnotation::Distinct(AnnotationDistinct::new())).unwrap();
         employer_type.set_annotation(
-            &type_manager, RoleTypeAnnotation::Cardinality(AnnotationCardinality::new(1, Some(2))),
+            &mut snapshot, &type_manager, RoleTypeAnnotation::Cardinality(AnnotationCardinality::new(1, Some(2))),
         ).unwrap();
 
-        let person_type = type_manager.create_entity_type(&person_label, false).unwrap();
-        let company_type = type_manager.create_entity_type(&company_label, false).unwrap();
-        person_type.set_plays(&type_manager, employee_type.clone());
-        company_type.set_plays(&type_manager, employee_type.clone());
+        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label, false).unwrap();
+        let company_type = type_manager.create_entity_type(&mut snapshot, &company_label, false).unwrap();
+        person_type.set_plays(&mut snapshot, &type_manager, employee_type.clone());
+        company_type.set_plays(&mut snapshot, &type_manager, employee_type.clone());
 
-        let person_1 = thing_manager.create_entity(person_type.clone()).unwrap();
-        let company_1 = thing_manager.create_entity(company_type.clone()).unwrap();
-        let company_2 = thing_manager.create_entity(company_type.clone()).unwrap();
-        let company_3 = thing_manager.create_entity(company_type.clone()).unwrap();
+        let person_1 = thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap();
+        let company_1 = thing_manager.create_entity(&mut snapshot, company_type.clone()).unwrap();
+        let company_2 = thing_manager.create_entity(&mut snapshot, company_type.clone()).unwrap();
+        let company_3 = thing_manager.create_entity(&mut snapshot, company_type.clone()).unwrap();
 
-        let employment_1 = thing_manager.create_relation(employment_type.clone()).unwrap();
-        employment_1.add_player(&thing_manager, employee_type.clone(), Object::Entity(person_1.as_reference())).unwrap();
-        employment_1.add_player(&thing_manager, employer_type.clone(), Object::Entity(company_1.as_reference())).unwrap();
+        let employment_1 = thing_manager.create_relation(&mut snapshot, employment_type.clone()).unwrap();
+        employment_1.add_player(&mut snapshot, &thing_manager, employee_type.clone(), Object::Entity(person_1.as_reference())).unwrap();
+        employment_1.add_player(&mut snapshot, &thing_manager, employer_type.clone(), Object::Entity(company_1.as_reference())).unwrap();
 
-        let employment_2 = thing_manager.create_relation(employment_type.clone()).unwrap();
-        employment_2.add_player(&thing_manager, employee_type.clone(), Object::Entity(person_1.as_reference())).unwrap();
-        employment_2.add_player(&thing_manager, employer_type.clone(), Object::Entity(company_2.as_reference())).unwrap();
-        employment_2.add_player(&thing_manager, employer_type.clone(), Object::Entity(company_3.as_reference())).unwrap();
+        let employment_2 = thing_manager.create_relation(&mut snapshot, employment_type.clone()).unwrap();
+        employment_2.add_player(&mut snapshot, &thing_manager, employee_type.clone(), Object::Entity(person_1.as_reference())).unwrap();
+        employment_2.add_player(&mut snapshot, &thing_manager, employer_type.clone(), Object::Entity(company_2.as_reference())).unwrap();
+        employment_2.add_player(&mut snapshot, &thing_manager, employer_type.clone(), Object::Entity(company_3.as_reference())).unwrap();
 
-        assert_eq!(employment_1.get_players(&thing_manager).count(), 2);
-        assert_eq!(employment_2.get_players(&thing_manager).count(), 3);
+        assert_eq!(employment_1.get_players(&snapshot, &thing_manager).count(), 2);
+        assert_eq!(employment_2.get_players(&snapshot, &thing_manager).count(), 3);
 
-        assert_eq!(person_1.get_relations(&thing_manager).count(), 2);
-        assert_eq!(company_1.get_relations(&thing_manager).count(), 1);
-        assert_eq!(company_2.get_relations(&thing_manager).count(), 1);
-        assert_eq!(company_3.get_relations(&thing_manager).count(), 1);
+        assert_eq!(person_1.get_relations(&snapshot, &thing_manager).count(), 2);
+        assert_eq!(company_1.get_relations(&snapshot, &thing_manager).count(), 1);
+        assert_eq!(company_2.get_relations(&snapshot, &thing_manager).count(), 1);
+        assert_eq!(company_3.get_relations(&snapshot, &thing_manager).count(), 1);
 
-        assert_eq!(person_1.get_indexed_players(&thing_manager).count(), 3);
+        assert_eq!(person_1.get_indexed_players(&snapshot, &thing_manager).count(), 3);
 
-        let finalise_result = thing_manager.finalise();
+        let finalise_result = thing_manager.finalise(&mut snapshot);
         assert!(finalise_result.is_ok());
     }
-
-    let write_snapshot = Arc::try_unwrap(snapshot).ok().unwrap();
-    write_snapshot.commit().unwrap();
+    snapshot.commit().unwrap();
     {
-        let snapshot: Arc<ReadSnapshot<WAL>> = Arc::new(storage.clone().open_snapshot_read());
-        let type_manager = Arc::new(TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), None));
+        let snapshot: ReadSnapshot<WAL> = storage.clone().open_snapshot_read();
+        let type_manager = Arc::new(TypeManager::new(type_vertex_generator.clone(), None));
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        let thing_manager = ThingManager::new(snapshot.clone(), thing_vertex_generator.clone(), type_manager.clone());
-        let entities = thing_manager.get_entities().collect_cloned();
+        let thing_manager = ThingManager::new(thing_vertex_generator.clone(), type_manager.clone());
+        let entities = thing_manager.get_entities(&snapshot).collect_cloned();
         assert_eq!(entities.len(), 4);
-        let relations = thing_manager.get_relations().collect_cloned();
+        let relations = thing_manager.get_relations(&snapshot).collect_cloned();
         assert_eq!(relations.len(), 2);
 
-        let players_0 = relations[0].get_players(&thing_manager).count();
+        let players_0 = relations[0].get_players(&snapshot, &thing_manager).count();
         if players_0 == 2 {
-            assert_eq!(relations[1].get_players(&thing_manager).count(), 3);
+            assert_eq!(relations[1].get_players(&snapshot, &thing_manager).count(), 3);
         } else {
-            assert_eq!(relations[1].get_players(&thing_manager).count(), 2);
+            assert_eq!(relations[1].get_players(&snapshot, &thing_manager).count(), 2);
         }
 
         let person_1 = entities.iter()
-            .find(|entity| entity.type_() == type_manager.get_entity_type(&person_label).unwrap().unwrap())
+            .find(|entity| entity.type_() == type_manager.get_entity_type(&snapshot, &person_label).unwrap().unwrap())
             .unwrap();
 
-        assert_eq!(person_1.get_relations(&thing_manager).count(), 2);
-        assert_eq!(person_1.get_indexed_players(&thing_manager).count(), 3);
+        assert_eq!(person_1.get_relations(&snapshot, &thing_manager).count(), 2);
+        assert_eq!(person_1.get_indexed_players(&snapshot, &thing_manager).count(), 3);
     }
 }
 
@@ -423,99 +412,97 @@ fn role_player_duplicates() {
     let resource_label = Label::build("resource");
     let group_label = Label::build("group");
 
-    let snapshot: Arc<WriteSnapshot<WAL>> = Arc::new(storage.clone().open_snapshot_write());
+    let mut snapshot: WriteSnapshot<WAL> = storage.clone().open_snapshot_write();
     {
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        let type_manager = Arc::new(TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), None));
-        let thing_manager = ThingManager::new(snapshot.clone(), thing_vertex_generator.clone(), type_manager.clone());
+        let type_manager = Arc::new(TypeManager::new(type_vertex_generator.clone(), None));
+        let thing_manager = ThingManager::new(thing_vertex_generator.clone(), type_manager.clone());
 
-        let list_type = type_manager.create_relation_type(&list_label, false).unwrap();
-        list_type.create_relates(&type_manager, entry_role_label, Ordering::Unordered).unwrap();
-        let entry_type = list_type.get_relates_role(&type_manager, entry_role_label).unwrap().unwrap().role();
-        entry_type.set_annotation(
-            &type_manager,
-            RoleTypeAnnotation::Cardinality(AnnotationCardinality::new(0, Some(4))), // must be small to allow index to kick in
+        let list_type = type_manager.create_relation_type(&mut snapshot, &list_label, false).unwrap();
+        list_type.create_relates(&mut snapshot, &type_manager, entry_role_label, Ordering::Unordered).unwrap();
+        let entry_type = list_type.get_relates_role(&snapshot, &type_manager, entry_role_label).unwrap().unwrap().role();
+        entry_type.set_annotation(&mut snapshot,
+                                  &type_manager,
+                                  RoleTypeAnnotation::Cardinality(AnnotationCardinality::new(0, Some(4))), // must be small to allow index to kick in
         ).unwrap();
-        list_type.create_relates(&type_manager, owner_role_label, Ordering::Unordered).unwrap();
-        let owner_type = list_type.get_relates_role(&type_manager, owner_role_label).unwrap().unwrap().role();
+        list_type.create_relates(&mut snapshot, &type_manager, owner_role_label, Ordering::Unordered).unwrap();
+        let owner_type = list_type.get_relates_role(&snapshot, &type_manager, owner_role_label).unwrap().unwrap().role();
 
-        let resource_type = type_manager.create_entity_type(&resource_label, false).unwrap();
-        let group_type = type_manager.create_entity_type(&group_label, false).unwrap();
-        resource_type.set_plays(&type_manager, entry_type.clone());
-        group_type.set_plays(&type_manager, owner_type.clone());
+        let resource_type = type_manager.create_entity_type(&mut snapshot, &resource_label, false).unwrap();
+        let group_type = type_manager.create_entity_type(&mut snapshot, &group_label, false).unwrap();
+        resource_type.set_plays(&mut snapshot, &type_manager, entry_type.clone());
+        group_type.set_plays(&mut snapshot, &type_manager, owner_type.clone());
 
-        let group_1 = thing_manager.create_entity(group_type.clone()).unwrap();
-        let resource_1 = thing_manager.create_entity(resource_type.clone()).unwrap();
+        let group_1 = thing_manager.create_entity(&mut snapshot, group_type.clone()).unwrap();
+        let resource_1 = thing_manager.create_entity(&mut snapshot, resource_type.clone()).unwrap();
 
-        let list_1 = thing_manager.create_relation(list_type.clone()).unwrap();
-        list_1.add_player(&thing_manager, owner_type.clone(), Object::Entity(group_1.as_reference())).unwrap();
-        list_1.add_player(&thing_manager, entry_type.clone(), Object::Entity(resource_1.as_reference())).unwrap();
-        list_1.add_player(&thing_manager, entry_type.clone(), Object::Entity(resource_1.as_reference())).unwrap();
+        let list_1 = thing_manager.create_relation(&mut snapshot, list_type.clone()).unwrap();
+        list_1.add_player(&mut snapshot, &thing_manager, owner_type.clone(), Object::Entity(group_1.as_reference())).unwrap();
+        list_1.add_player(&mut snapshot, &thing_manager, entry_type.clone(), Object::Entity(resource_1.as_reference())).unwrap();
+        list_1.add_player(&mut snapshot, &thing_manager, entry_type.clone(), Object::Entity(resource_1.as_reference())).unwrap();
 
-        let player_counts: u64 = list_1.get_players(&thing_manager)
+        let player_counts: u64 = list_1.get_players(&snapshot, &thing_manager)
             .collect_cloned_vec(|(_, count)| count).unwrap().into_iter().sum();
         assert_eq!(player_counts, 3);
 
-        let group_relations_count: u64 = group_1.get_relations(&thing_manager)
+        let group_relations_count: u64 = group_1.get_relations(&snapshot, &thing_manager)
             .collect_cloned_vec(|(_, _, count)| count).unwrap().into_iter().sum();
         assert_eq!(group_relations_count, 1);
-        let resource_relations_count: u64 = resource_1.get_relations(&thing_manager)
+        let resource_relations_count: u64 = resource_1.get_relations(&snapshot, &thing_manager)
             .collect_cloned_vec(|(_, _, count)| count).unwrap().into_iter().sum();
         assert_eq!(resource_relations_count, 2);
 
-        let group_1_indexed_count: u64 = group_1.get_indexed_players(&thing_manager)
+        let group_1_indexed_count: u64 = group_1.get_indexed_players(&snapshot, &thing_manager)
             .collect_cloned_vec(|(_, _, _, count)| count).unwrap().into_iter().sum();
         assert_eq!(group_1_indexed_count, 2);
-        let resource_1_indexed_count: u64 = resource_1.get_indexed_players(&thing_manager)
+        let resource_1_indexed_count: u64 = resource_1.get_indexed_players(&snapshot, &thing_manager)
             .collect_cloned_vec(|(_, _, _, count)| count).unwrap().into_iter().sum();
         assert_eq!(resource_1_indexed_count, 2);
 
-        let group_relations_count: u64 = group_1.get_relations(&thing_manager)
+        let group_relations_count: u64 = group_1.get_relations(&snapshot, &thing_manager)
             .collect_cloned_vec(|(rel, rol, count)| count)
             .unwrap().into_iter().sum();
         assert_eq!(group_relations_count, 1);
 
-        let finalise_result = thing_manager.finalise();
+        let finalise_result = thing_manager.finalise(&mut snapshot);
         assert!(finalise_result.is_ok());
     }
-
-    let write_snapshot = Arc::try_unwrap(snapshot).ok().unwrap();
-    write_snapshot.commit().unwrap();
+    snapshot.commit().unwrap();
     {
-        let snapshot: Arc<ReadSnapshot<WAL>> = Arc::new(storage.open_snapshot_read());
-        let type_manager = Arc::new(TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), None));
+        let snapshot: ReadSnapshot<WAL> = storage.open_snapshot_read();
+        let type_manager = Arc::new(TypeManager::new(type_vertex_generator.clone(), None));
         let thing_vertex_generator = ThingVertexGenerator::new();
-        let thing_manager = ThingManager::new(snapshot.clone(), Arc::new(thing_vertex_generator), type_manager.clone());
-        let entities = thing_manager.get_entities().collect_cloned();
+        let thing_manager = ThingManager::new(Arc::new(thing_vertex_generator), type_manager.clone());
+        let entities = thing_manager.get_entities(&snapshot).collect_cloned();
         assert_eq!(entities.len(), 2);
-        let relations = thing_manager.get_relations().collect_cloned();
+        let relations = thing_manager.get_relations(&snapshot).collect_cloned();
         assert_eq!(relations.len(), 1);
 
         let list_1 = relations.get(0).unwrap();
-        let player_counts: u64 = list_1.get_players(&thing_manager)
+        let player_counts: u64 = list_1.get_players(&snapshot, &thing_manager)
             .collect_cloned_vec(|(_, count)| count).unwrap().into_iter().sum();
         assert_eq!(player_counts, 3);
 
         let group_1 = entities.iter()
-            .find(|entity| entity.type_() == type_manager.get_entity_type(&group_label).unwrap().unwrap())
+            .find(|entity| entity.type_() == type_manager.get_entity_type(&snapshot, &group_label).unwrap().unwrap())
             .unwrap();
 
         let resource_1 = entities.iter()
-            .find(|entity| entity.type_() == type_manager.get_entity_type(&resource_label).unwrap().unwrap())
+            .find(|entity| entity.type_() == type_manager.get_entity_type(&snapshot, &resource_label).unwrap().unwrap())
             .unwrap();
 
-        let group_relations_count: u64 = group_1.get_relations(&thing_manager)
+        let group_relations_count: u64 = group_1.get_relations(&snapshot, &thing_manager)
             .collect_cloned_vec(|(rel, rol, count)| count)
             .unwrap().into_iter().sum();
         assert_eq!(group_relations_count, 1);
-        let resource_relations_count: u64 = resource_1.get_relations(&thing_manager)
+        let resource_relations_count: u64 = resource_1.get_relations(&snapshot, &thing_manager)
             .collect_cloned_vec(|(_, _, count)| count).unwrap().into_iter().sum();
         assert_eq!(resource_relations_count, 2);
 
-        let group_1_indexed_count: u64 = group_1.get_indexed_players(&thing_manager)
+        let group_1_indexed_count: u64 = group_1.get_indexed_players(&snapshot, &thing_manager)
             .collect_cloned_vec(|(_, _, _, count)| count).unwrap().into_iter().sum();
         assert_eq!(group_1_indexed_count, 2);
-        let resource_1_indexed_count: u64 = resource_1.get_indexed_players(&thing_manager)
+        let resource_1_indexed_count: u64 = resource_1.get_indexed_players(&snapshot, &thing_manager)
             .collect_cloned_vec(|(_, _, _, count)| count).unwrap().into_iter().sum();
         assert_eq!(resource_1_indexed_count, 2);
     }

--- a/concept/tests/test_type.rs
+++ b/concept/tests/test_type.rs
@@ -174,12 +174,12 @@ fn role_usage() {
     let friend_name = "friend";
     let person_label = Label::build("person");
 
-    let snapshot: Arc<WriteSnapshot<_>> = Arc::new(storage.clone().open_snapshot_write());
+    let mut snapshot: WriteSnapshot<_> = storage.clone().open_snapshot_write();
     {
         // Without cache, uncommitted
-        let type_manager = TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), None);
-        let root_relation = type_manager.get_relation_type(&Kind::Relation.root_label()).unwrap().unwrap();
-        assert_eq!(*root_relation.get_label(&type_manager).unwrap(), Kind::Relation.root_label());
+        let type_manager = TypeManager::new(type_vertex_generator.clone(), None);
+        let root_relation = type_manager.get_relation_type(&snapshot, &Kind::Relation.root_label()).unwrap().unwrap();
+        assert_eq!(*root_relation.get_label(&snapshot, &type_manager).unwrap(), Kind::Relation.root_label());
         assert!(root_relation.is_root(&type_manager).unwrap());
         assert!(root_relation.get_supertype(&type_manager).unwrap().is_none());
         assert_eq!(root_relation.get_supertypes(&type_manager).unwrap().len(), 0);

--- a/concept/tests/test_type.rs
+++ b/concept/tests/test_type.rs
@@ -32,133 +32,131 @@ fn entity_usage() {
     let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
     TypeManager::<WriteSnapshot<WAL>>::initialise_types(storage.clone(), type_vertex_generator.clone()).unwrap();
 
-    let snapshot: Arc<WriteSnapshot<_>> = Arc::new(storage.clone().open_snapshot_write());
+    let mut snapshot: WriteSnapshot<_> = storage.clone().open_snapshot_write();
     {
         // Without cache, uncommitted
-        let type_manager = TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), None);
+        let type_manager = TypeManager::new(type_vertex_generator.clone(), None);
 
-        let root_entity = type_manager.get_entity_type(&Kind::Entity.root_label()).unwrap().unwrap();
-        assert_eq!(*root_entity.get_label(&type_manager).unwrap(), Kind::Entity.root_label());
-        assert!(root_entity.is_root(&type_manager).unwrap());
+        let root_entity = type_manager.get_entity_type(&snapshot, &Kind::Entity.root_label()).unwrap().unwrap();
+        assert_eq!(*root_entity.get_label(&snapshot, &type_manager).unwrap(), Kind::Entity.root_label());
+        assert!(root_entity.is_root(&snapshot, &type_manager).unwrap());
 
         // --- age sub attribute ---
         let age_label = Label::build("age");
-        let age_type = type_manager.create_attribute_type(&age_label, false).unwrap();
-        age_type.set_value_type(&type_manager, ValueType::Long);
+        let age_type = type_manager.create_attribute_type(&mut snapshot, &age_label, false).unwrap();
+        age_type.set_value_type(&mut snapshot, &type_manager, ValueType::Long);
 
-        assert!(!age_type.is_root(&type_manager).unwrap());
-        assert!(age_type.get_annotations(&type_manager).unwrap().is_empty());
-        assert_eq!(*age_type.get_label(&type_manager).unwrap(), age_label);
-        assert_eq!(age_type.get_value_type(&type_manager).unwrap(), Some(ValueType::Long));
+        assert!(!age_type.is_root(&snapshot, &type_manager).unwrap());
+        assert!(age_type.get_annotations(&snapshot, &type_manager).unwrap().is_empty());
+        assert_eq!(*age_type.get_label(&snapshot, &type_manager).unwrap(), age_label);
+        assert_eq!(age_type.get_value_type(&snapshot, &type_manager).unwrap(), Some(ValueType::Long));
 
         // --- person sub entity @abstract ---
         let person_label = Label::build("person");
-        let person_type = type_manager.create_entity_type(&person_label, false).unwrap();
-        person_type.set_annotation(&type_manager, EntityTypeAnnotation::Abstract(AnnotationAbstract::new())).unwrap();
+        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label, false).unwrap();
+        person_type.set_annotation(&mut snapshot, &type_manager, EntityTypeAnnotation::Abstract(AnnotationAbstract::new())).unwrap();
 
-        assert!(!person_type.is_root(&type_manager).unwrap());
+        assert!(!person_type.is_root(&snapshot, &type_manager).unwrap());
         assert!(person_type
-            .get_annotations(&type_manager)
+            .get_annotations(&snapshot, &type_manager)
             .unwrap()
             .contains(&EntityTypeAnnotation::Abstract(AnnotationAbstract::new())));
-        assert_eq!(*person_type.get_label(&type_manager).unwrap(), person_label);
+        assert_eq!(*person_type.get_label(&snapshot, &type_manager).unwrap(), person_label);
 
-        let supertype = person_type.get_supertype(&type_manager).unwrap().unwrap();
+        let supertype = person_type.get_supertype(&snapshot, &type_manager).unwrap().unwrap();
         assert_eq!(supertype, root_entity);
 
         // --- child sub person ---
         let child_label = Label::build("child");
-        let child_type = type_manager.create_entity_type(&child_label, false).unwrap();
-        child_type.set_supertype(&type_manager, person_type.clone()).unwrap();
+        let child_type = type_manager.create_entity_type(&mut snapshot, &child_label, false).unwrap();
+        child_type.set_supertype(&mut snapshot, &type_manager, person_type.clone()).unwrap();
 
-        assert!(!child_type.is_root(&type_manager).unwrap());
-        assert_eq!(*child_type.get_label(&type_manager).unwrap(), child_label);
+        assert!(!child_type.is_root(&snapshot, &type_manager).unwrap());
+        assert_eq!(*child_type.get_label(&snapshot, &type_manager).unwrap(), child_label);
 
-        let supertype = child_type.get_supertype(&type_manager).unwrap().unwrap();
+        let supertype = child_type.get_supertype(&snapshot, &type_manager).unwrap().unwrap();
         assert_eq!(supertype, person_type);
-        let supertypes = child_type.get_supertypes(&type_manager).unwrap();
+        let supertypes = child_type.get_supertypes(&snapshot, &type_manager).unwrap();
         assert_eq!(supertypes.len(), 2);
 
         // --- child owns age ---
-         child_type.set_owns(&type_manager, age_type.clone().into_owned(), Ordering::Unordered);
-        let owns = child_type.get_owns_attribute(&type_manager, age_type.clone().into_owned()).unwrap().unwrap();
+        child_type.set_owns(&mut snapshot, &type_manager, age_type.clone().into_owned(), Ordering::Unordered);
+        let owns = child_type.get_owns_attribute(&snapshot, &type_manager, age_type.clone().into_owned()).unwrap().unwrap();
         // TODO: test 'owns' structure directly
 
-        let all_owns = child_type.get_owns(&type_manager).unwrap();
+        let all_owns = child_type.get_owns(&snapshot, &type_manager).unwrap();
         assert_eq!(all_owns.len(), 1);
         assert!(all_owns.contains(&owns));
-        assert_eq!(child_type.get_owns_attribute(&type_manager, age_type.clone()).unwrap(), Some(owns));
-        assert!(child_type.has_owns_attribute(&type_manager, age_type.clone()).unwrap());
+        assert_eq!(child_type.get_owns_attribute(&snapshot, &type_manager, age_type.clone()).unwrap(), Some(owns));
+        assert!(child_type.has_owns_attribute(&snapshot, &type_manager, age_type.clone()).unwrap());
 
         // --- adult sub person ---
-        let adult = type_manager.create_entity_type(&Label::build("adult"), false).unwrap();
-        adult.set_supertype(&type_manager, person_type.clone()).unwrap();
-        assert_eq!(root_entity.get_subtypes(&type_manager).unwrap().len(), 1);
-        assert_eq!(root_entity.get_subtypes_transitive(&type_manager).unwrap().len(), 3);
-        assert_eq!(person_type.get_subtypes(&type_manager).unwrap().len(), 2);
-        assert_eq!(person_type.get_subtypes_transitive(&type_manager).unwrap().len(), 2);
+        let adult = type_manager.create_entity_type(&mut snapshot, &Label::build("adult"), false).unwrap();
+        adult.set_supertype(&mut snapshot, &type_manager, person_type.clone()).unwrap();
+        assert_eq!(root_entity.get_subtypes(&snapshot, &type_manager).unwrap().len(), 1);
+        assert_eq!(root_entity.get_subtypes_transitive(&snapshot, &type_manager).unwrap().len(), 3);
+        assert_eq!(person_type.get_subtypes(&snapshot, &type_manager).unwrap().len(), 2);
+        assert_eq!(person_type.get_subtypes_transitive(&snapshot, &type_manager).unwrap().len(), 2);
     }
-    if let write_snapshot = Arc::try_unwrap(snapshot).ok().unwrap() {
-        write_snapshot.commit().unwrap();
-    }
+    snapshot.commit().unwrap();
 
     {
         // With cache, committed
-        let snapshot: Arc<ReadSnapshot<_>> = Arc::new(storage.clone().open_snapshot_read());
+        let snapshot: ReadSnapshot<_> = storage.clone().open_snapshot_read();
         let type_cache = Arc::new(TypeCache::new(storage.clone(), snapshot.open_sequence_number()).unwrap());
-        let type_manager = TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), Some(type_cache));
+        let type_manager = TypeManager::new(type_vertex_generator.clone(), Some(type_cache));
 
-        let root_entity = type_manager.get_entity_type(&Kind::Entity.root_label()).unwrap().unwrap();
-        assert_eq!(*root_entity.get_label(&type_manager).unwrap(), Kind::Entity.root_label());
-        assert!(root_entity.is_root(&type_manager).unwrap());
+        let root_entity = type_manager.get_entity_type(&snapshot, &Kind::Entity.root_label()).unwrap().unwrap();
+        assert_eq!(*root_entity.get_label(&snapshot, &type_manager).unwrap(), Kind::Entity.root_label());
+        assert!(root_entity.is_root(&snapshot, &type_manager).unwrap());
 
         // --- age sub attribute ---
         let age_label = Label::build("age");
-        let age_type = type_manager.get_attribute_type(&age_label).unwrap().unwrap();
+        let age_type = type_manager.get_attribute_type(&snapshot, &age_label).unwrap().unwrap();
 
-        assert!(!age_type.is_root(&type_manager).unwrap());
-        assert!(age_type.get_annotations(&type_manager).unwrap().is_empty());
-        assert_eq!(*age_type.get_label(&type_manager).unwrap(), age_label);
-        assert_eq!(age_type.get_value_type(&type_manager).unwrap(), Some(ValueType::Long));
+        assert!(!age_type.is_root(&snapshot, &type_manager).unwrap());
+        assert!(age_type.get_annotations(&snapshot, &type_manager).unwrap().is_empty());
+        assert_eq!(*age_type.get_label(&snapshot, &type_manager).unwrap(), age_label);
+        assert_eq!(age_type.get_value_type(&snapshot, &type_manager).unwrap(), Some(ValueType::Long));
 
         // --- person sub entity ---
         let person_label = Label::build("person");
-        let person_type = type_manager.get_entity_type(&person_label).unwrap().unwrap();
-        assert!(!person_type.is_root(&type_manager).unwrap());
+        let person_type = type_manager.get_entity_type(&snapshot, &person_label).unwrap().unwrap();
+        assert!(!person_type.is_root(&snapshot, &type_manager).unwrap());
         assert!(person_type
-            .get_annotations(&type_manager)
+            .get_annotations(&snapshot, &type_manager)
             .unwrap()
             .contains(&EntityTypeAnnotation::Abstract(AnnotationAbstract::new())));
-        assert_eq!(*person_type.get_label(&type_manager).unwrap(), person_label);
+        assert_eq!(*person_type.get_label(&snapshot, &type_manager).unwrap(), person_label);
 
-        let supertype = person_type.get_supertype(&type_manager).unwrap().unwrap();
+        let supertype = person_type.get_supertype(&snapshot, &type_manager).unwrap().unwrap();
         assert_eq!(supertype, root_entity);
 
         // --- child sub person ---
         let child_label = Label::build("child");
-        let child_type = type_manager.get_entity_type(&child_label).unwrap().unwrap();
+        let child_type = type_manager.get_entity_type(&snapshot, &child_label).unwrap().unwrap();
 
-        assert!(!child_type.is_root(&type_manager).unwrap());
-        assert_eq!(*child_type.get_label(&type_manager).unwrap(), child_label);
+        assert!(!child_type.is_root(&snapshot, &type_manager).unwrap());
+        assert_eq!(*child_type.get_label(&snapshot, &type_manager).unwrap(), child_label);
 
-        let supertype = child_type.get_supertype(&type_manager).unwrap().unwrap();
+        let supertype = child_type.get_supertype(&snapshot, &type_manager).unwrap().unwrap();
         assert_eq!(supertype, person_type);
-        let supertypes = child_type.get_supertypes(&type_manager).unwrap();
+        let supertypes = child_type.get_supertypes(&snapshot, &type_manager).unwrap();
         assert_eq!(supertypes.len(), 2);
 
         // --- child owns age ---
-        let all_owns = child_type.get_owns(&type_manager).unwrap();
+        let all_owns = child_type.get_owns(&snapshot, &type_manager).unwrap();
         assert_eq!(all_owns.len(), 1);
         let expected_owns = Owns::new(ObjectType::Entity(child_type.clone()), age_type.clone());
         assert!(all_owns.contains(&expected_owns));
-        assert_eq!(child_type.get_owns_attribute(&type_manager, age_type.clone()).unwrap(), Some(expected_owns));
-        assert!(child_type.has_owns_attribute(&type_manager, age_type.clone()).unwrap());
+        assert_eq!(child_type.get_owns_attribute(&snapshot, &type_manager, age_type.clone()).unwrap(), Some(expected_owns));
+        assert!(child_type.has_owns_attribute(&snapshot, &type_manager, age_type.clone()).unwrap());
 
         // --- adult sub person ---
-        assert_eq!(root_entity.get_subtypes(&type_manager).unwrap().len(), 1);
-        assert_eq!(root_entity.get_subtypes_transitive(&type_manager).unwrap().len(), 3);
-        assert_eq!(person_type.get_subtypes(&type_manager).unwrap().len(), 2);
-        assert_eq!(person_type.get_subtypes_transitive(&type_manager).unwrap().len(), 2);
+        assert_eq!(root_entity.get_subtypes(&snapshot, &type_manager).unwrap().len(), 1);
+        assert_eq!(root_entity.get_subtypes_transitive(&snapshot, &type_manager).unwrap().len(), 3);
+        assert_eq!(person_type.get_subtypes(&snapshot, &type_manager).unwrap().len(), 2);
+        assert_eq!(person_type.get_subtypes_transitive(&snapshot, &type_manager).unwrap().len(), 2);
     }
 }
 
@@ -180,61 +178,59 @@ fn role_usage() {
         let type_manager = TypeManager::new(type_vertex_generator.clone(), None);
         let root_relation = type_manager.get_relation_type(&snapshot, &Kind::Relation.root_label()).unwrap().unwrap();
         assert_eq!(*root_relation.get_label(&snapshot, &type_manager).unwrap(), Kind::Relation.root_label());
-        assert!(root_relation.is_root(&type_manager).unwrap());
-        assert!(root_relation.get_supertype(&type_manager).unwrap().is_none());
-        assert_eq!(root_relation.get_supertypes(&type_manager).unwrap().len(), 0);
+        assert!(root_relation.is_root(&snapshot, &type_manager).unwrap());
+        assert!(root_relation.get_supertype(&snapshot, &type_manager).unwrap().is_none());
+        assert_eq!(root_relation.get_supertypes(&snapshot, &type_manager).unwrap().len(), 0);
         assert!(root_relation
-            .get_annotations(&type_manager)
+            .get_annotations(&snapshot, &type_manager)
             .unwrap()
             .contains(&RelationTypeAnnotation::Abstract(AnnotationAbstract::new())));
 
-        let root_role = type_manager.get_role_type(&Kind::Role.root_label()).unwrap().unwrap();
-        assert_eq!(*root_role.get_label(&type_manager).unwrap(), Kind::Role.root_label());
-        assert!(root_role.is_root(&type_manager).unwrap());
-        assert!(root_role.get_supertype(&type_manager).unwrap().is_none());
-        assert_eq!(root_role.get_supertypes(&type_manager).unwrap().len(), 0);
+        let root_role = type_manager.get_role_type(&snapshot, &Kind::Role.root_label()).unwrap().unwrap();
+        assert_eq!(*root_role.get_label(&snapshot, &type_manager).unwrap(), Kind::Role.root_label());
+        assert!(root_role.is_root(&snapshot, &type_manager).unwrap());
+        assert!(root_role.get_supertype(&snapshot, &type_manager).unwrap().is_none());
+        assert_eq!(root_role.get_supertypes(&snapshot, &type_manager).unwrap().len(), 0);
         assert!(root_role
-            .get_annotations(&type_manager)
+            .get_annotations(&snapshot, &type_manager)
             .unwrap()
             .contains(&RoleTypeAnnotation::Abstract(AnnotationAbstract::new())));
 
         // --- friendship sub relation, relates friend ---
-        let friendship_type = type_manager.create_relation_type(&friendship_label, false).unwrap();
-        friendship_type.create_relates(&type_manager, friend_name, Ordering::Unordered).unwrap();
-        let relates = friendship_type.get_relates_role(&type_manager, friend_name).unwrap().unwrap();
-        let role_type = friendship_type.get_role(&type_manager, friend_name).unwrap().unwrap();
+        let friendship_type = type_manager.create_relation_type(&mut snapshot, &friendship_label, false).unwrap();
+        friendship_type.create_relates(&mut snapshot, &type_manager, friend_name, Ordering::Unordered).unwrap();
+        let relates = friendship_type.get_relates_role(&snapshot, &type_manager, friend_name).unwrap().unwrap();
+        let role_type = friendship_type.get_role(&snapshot, &type_manager, friend_name).unwrap().unwrap();
         debug_assert_eq!(relates.relation(), friendship_type);
         debug_assert_eq!(relates.role(), role_type);
 
         // --- person plays friendship:friend ---
-        let person_type = type_manager.create_entity_type(&person_label, false).unwrap();
-        person_type.set_plays(&type_manager, role_type.clone().into_owned());
-        let plays = person_type.get_plays_role(&type_manager, role_type.clone().into_owned()).unwrap().unwrap();
+        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label, false).unwrap();
+        person_type.set_plays(&mut snapshot, &type_manager, role_type.clone().into_owned());
+        let plays = person_type.get_plays_role(&snapshot, &type_manager, role_type.clone().into_owned()).unwrap().unwrap();
         debug_assert_eq!(plays.player(), ObjectType::Entity(person_type.clone()));
         debug_assert_eq!(plays.role(), role_type);
     }
-    if let write_snapshot = Arc::try_unwrap(snapshot).ok().unwrap() {
-        write_snapshot.commit().unwrap();
-    }
+    snapshot.commit().unwrap();
 
     {
         // With cache, committed
-        let snapshot: Arc<ReadSnapshot<_>> = Arc::new(storage.clone().open_snapshot_read());
+        let snapshot: ReadSnapshot<_> = storage.clone().open_snapshot_read();
         let type_cache = Arc::new(TypeCache::new(storage.clone(), snapshot.open_sequence_number()).unwrap());
-        let type_manager = TypeManager::new(snapshot.clone(), type_vertex_generator.clone(), Some(type_cache));
+        let type_manager = TypeManager::new(type_vertex_generator.clone(), Some(type_cache));
 
         // --- friendship sub relation, relates friend ---
-        let friendship_type = type_manager.get_relation_type(&friendship_label).unwrap().unwrap();
-        let relates = friendship_type.get_relates_role(&type_manager, friend_name).unwrap();
+        let friendship_type = type_manager.get_relation_type(&snapshot, &friendship_label).unwrap().unwrap();
+        let relates = friendship_type.get_relates_role(&snapshot, &type_manager, friend_name).unwrap();
         debug_assert!(relates.is_some());
         let relates = relates.unwrap();
-        let role_type = friendship_type.get_role(&type_manager, friend_name).unwrap().unwrap();
+        let role_type = friendship_type.get_role(&snapshot, &type_manager, friend_name).unwrap().unwrap();
         debug_assert_eq!(relates.relation(), friendship_type);
         debug_assert_eq!(relates.role(), role_type);
 
         // --- person plays friendship:friend ---
-        let person_type = type_manager.get_entity_type(&person_label).unwrap().unwrap();
-        let plays = person_type.get_plays_role(&type_manager, role_type.clone().into_owned()).unwrap().unwrap();
+        let person_type = type_manager.get_entity_type(&snapshot, &person_label).unwrap().unwrap();
+        let plays = person_type.get_plays_role(&snapshot, &type_manager, role_type.clone().into_owned()).unwrap().unwrap();
         debug_assert_eq!(plays.player(), ObjectType::Entity(person_type.clone()));
         debug_assert_eq!(plays.role(), role_type);
     }

--- a/concept/thing/attribute.rs
+++ b/concept/thing/attribute.rs
@@ -156,6 +156,7 @@ impl<'a> Ord for Attribute<'a> {
 /// Attribute iterators handle hiding dependent attributes that were not deleted yet
 ///
 pub struct AttributeIterator<'a, Snapshot: ReadableSnapshot, const A_PS: usize, const H_PS: usize> {
+    snapshot: Option<&'a Snapshot>,
     type_manager: Option<&'a TypeManager<Snapshot>>,
     attributes_iterator: Option<SnapshotRangeIterator<'a, A_PS>>,
     has_reverse_iterator: Option<SnapshotRangeIterator<'a, H_PS>>,
@@ -166,9 +167,11 @@ impl<'a, Snapshot: ReadableSnapshot, const A_PS: usize, const H_PS: usize> Attri
     pub(crate) fn new(
         attributes_iterator: SnapshotRangeIterator<'a, A_PS>,
         has_reverse_iterator: SnapshotRangeIterator<'a, H_PS>,
+        snapshot: &'a Snapshot,
         type_manager: &'a TypeManager<Snapshot>,
     ) -> Self {
         Self {
+            snapshot: Some(snapshot),
             type_manager: Some(type_manager),
             attributes_iterator: Some(attributes_iterator),
             has_reverse_iterator: Some(has_reverse_iterator),
@@ -177,7 +180,7 @@ impl<'a, Snapshot: ReadableSnapshot, const A_PS: usize, const H_PS: usize> Attri
     }
 
     pub(crate) fn new_empty() -> Self {
-        Self { type_manager: None, attributes_iterator: None, has_reverse_iterator: None, state: State::Done }
+        Self { snapshot: None, type_manager: None, attributes_iterator: None, has_reverse_iterator: None, state: State::Done }
     }
 
     fn storage_key_to_attribute_vertex<'b>(storage_key_ref: StorageKeyReference<'b>) -> AttributeVertex<'b> {
@@ -254,7 +257,7 @@ impl<'a, Snapshot: ReadableSnapshot, const A_PS: usize, const H_PS: usize> Attri
                     let attribute_vertex = Self::storage_key_to_attribute_vertex(key);
                     let independent = Attribute::new(attribute_vertex.as_reference())
                         .type_()
-                        .is_independent(self.type_manager.as_ref().unwrap());
+                        .is_independent(self.snapshot.clone().unwrap(), self.type_manager.clone().unwrap());
                     match independent {
                         Ok(true) => self.state = State::ItemReady,
                         Ok(false) => {

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -69,26 +69,29 @@ impl<'a> Entity<'a> {
 
     pub fn has_attribute<Snapshot: ReadableSnapshot>(
         &self,
+        snapshot: &Snapshot,
         thing_manager: &ThingManager<Snapshot>,
         attribute_type: AttributeType<'static>,
         value: Value<'_>,
     ) -> Result<bool, ConceptReadError> {
-        thing_manager.has_attribute(self.as_reference(), attribute_type, value)
+        thing_manager.has_attribute(snapshot, self.as_reference(), attribute_type, value)
     }
 
-    pub fn get_has<'m,Snapshot: ReadableSnapshot>(
+    pub fn get_has<'m, Snapshot: ReadableSnapshot>(
         &self,
+        snapshot: &'m Snapshot,
         thing_manager: &'m ThingManager<Snapshot>,
     ) -> HasAttributeIterator<'m, { ThingEdgeHas::LENGTH_PREFIX_FROM_OBJECT }> {
-        thing_manager.get_has_unordered(self.as_reference())
+        thing_manager.get_has_unordered(snapshot, self.as_reference())
     }
 
-    pub fn get_has_type<'m,Snapshot: ReadableSnapshot>(
+    pub fn get_has_type<'m, Snapshot: ReadableSnapshot>(
         &self,
+        snapshot: &'m Snapshot,
         thing_manager: &'m ThingManager<Snapshot>,
         attribute_type: AttributeType<'static>,
     ) -> Result<HasAttributeIterator<'m, { ThingEdgeHas::LENGTH_PREFIX_FROM_OBJECT_TO_TYPE }>, ConceptReadError> {
-        thing_manager.get_has_type_unordered(self.as_reference(), attribute_type)
+        thing_manager.get_has_type_unordered(snapshot, self.as_reference(), attribute_type)
     }
 
     pub fn set_has_unordered<Snapshot: WritableSnapshot>(
@@ -98,13 +101,13 @@ impl<'a> Entity<'a> {
         attribute: Attribute<'_>,
     ) -> Result<(), ConceptWriteError> {
         // TODO: validate schema
-        let owns = self.get_type_owns(thing_manager.type_manager(), attribute.type_())
+        let owns = self.get_type_owns(snapshot, thing_manager.type_manager(), attribute.type_())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
-        let ordering = owns.get_ordering(thing_manager.type_manager())
+        let ordering = owns.get_ordering(snapshot, thing_manager.type_manager())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
         match ordering {
             Ordering::Unordered => {
-                thing_manager.set_has(self.as_reference(), attribute.as_reference());
+                thing_manager.set_has(snapshot, self.as_reference(), attribute.as_reference());
                 Ok(())
             }
             Ordering::Ordered => {
@@ -114,16 +117,17 @@ impl<'a> Entity<'a> {
     }
 
     pub fn delete_has_unordered<Snapshot: WritableSnapshot>(
-        &self, 
+        &self,
+        snapshot: &mut Snapshot,
         thing_manager: &ThingManager<Snapshot>, attribute: Attribute<'_>,
     ) -> Result<(), ConceptWriteError> {
-        let owns = self.get_type_owns(thing_manager.type_manager(), attribute.type_())
+        let owns = self.get_type_owns(snapshot, thing_manager.type_manager(), attribute.type_())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
-        let ordering = owns.get_ordering(thing_manager.type_manager())
+        let ordering = owns.get_ordering(snapshot, thing_manager.type_manager())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
         match ordering {
             Ordering::Unordered => {
-                thing_manager.delete_has(self.as_reference(), attribute);
+                thing_manager.delete_has(snapshot, self.as_reference(), attribute);
                 Ok(())
             }
             Ordering::Ordered => {
@@ -133,12 +137,15 @@ impl<'a> Entity<'a> {
     }
 
     pub fn set_has_ordered<Snapshot: ReadableSnapshot>(
-        &self, thing_manager: &ThingManager<Snapshot>, attribute_type: AttributeType<'static>,
+        &self,
+        snapshot: &mut Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
+        attribute_type: AttributeType<'static>,
         attributes: Vec<Attribute<'_>>,
     ) -> Result<(), ConceptWriteError> {
-        let owns = self.get_type_owns(thing_manager.type_manager(), attribute_type.clone())
+        let owns = self.get_type_owns(snapshot, thing_manager.type_manager(), attribute_type.clone())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
-        let ordering = owns.get_ordering(thing_manager.type_manager())
+        let ordering = owns.get_ordering(snapshot, thing_manager.type_manager())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
         match ordering {
             Ordering::Unordered => {
@@ -146,7 +153,7 @@ impl<'a> Entity<'a> {
             }
             Ordering::Ordered => {
                 // 1. get owned list
-                let attributes = thing_manager.get_has_type_ordered(self.as_reference(), attribute_type.clone())
+                let attributes = thing_manager.get_has_type_ordered(snapshot, self.as_reference(), attribute_type.clone())
                     .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
 
                 // 2. Delete existing but no-longer necessary has, and add new ones, with the correct counts (!)
@@ -160,11 +167,14 @@ impl<'a> Entity<'a> {
     }
 
     pub fn delete_has_ordered<Snapshot: WritableSnapshot>(
-        &self, thing_manager: &ThingManager<Snapshot>, attribute_type: AttributeType<'static>,
+        &self,
+        snapshot: &mut Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
+        attribute_type: AttributeType<'static>,
     ) -> Result<(), ConceptWriteError> {
-        let owns = self.get_type_owns(thing_manager.type_manager(), attribute_type)
+        let owns = self.get_type_owns(snapshot, thing_manager.type_manager(), attribute_type)
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
-        let ordering = owns.get_ordering(thing_manager.type_manager())
+        let ordering = owns.get_ordering(snapshot, thing_manager.type_manager())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
         match ordering {
             Ordering::Unordered => {
@@ -177,10 +187,13 @@ impl<'a> Entity<'a> {
         }
     }
 
-    fn get_type_owns<'m,Snapshot: ReadableSnapshot>(
-        &self, type_manager: &'m TypeManager<Snapshot>, attribute_type: AttributeType<'static>,
+    fn get_type_owns<'m, Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        type_manager: &'m TypeManager<Snapshot>,
+        attribute_type: AttributeType<'static>,
     ) -> Result<Owns<'m>, ConceptReadError> {
-        let owns = self.type_().get_owns_attribute(type_manager, attribute_type)?;
+        let owns = self.type_().get_owns_attribute(snapshot, type_manager, attribute_type)?;
         match owns {
             None => {
                 todo!("throw useful schema error")
@@ -191,18 +204,20 @@ impl<'a> Entity<'a> {
         }
     }
 
-    pub fn get_relations<'m,Snapshot: ReadableSnapshot>(
+    pub fn get_relations<'m, Snapshot: ReadableSnapshot>(
         &self,
+        snapshot: &'m Snapshot,
         thing_manager: &'m ThingManager<Snapshot>,
     ) -> RelationRoleIterator<'m, { ThingEdgeRolePlayer::LENGTH_PREFIX_FROM }> {
-        thing_manager.get_relations_roles(self.as_reference())
+        thing_manager.get_relations_roles(snapshot, self.as_reference())
     }
 
-    pub fn get_indexed_players<'m,Snapshot: ReadableSnapshot>(
-        &self,
+    pub fn get_indexed_players<'m, Snapshot: ReadableSnapshot>(
+        &'m self,
+        snapshot: &'m Snapshot,
         thing_manager: &'m ThingManager<Snapshot>,
     ) -> IndexedPlayersIterator<'m, { ThingEdgeRelationIndex::LENGTH_PREFIX_FROM }> {
-        thing_manager.get_indexed_players(Object::Entity(self.as_reference()))
+        thing_manager.get_indexed_players(snapshot, Object::Entity(self.as_reference()))
     }
 
     pub(crate) fn into_owned(self) -> Entity<'static> {
@@ -213,56 +228,63 @@ impl<'a> Entity<'a> {
 impl<'a> ConceptAPI<'a> for Entity<'a> {}
 
 impl<'a> ThingAPI<'a> for Entity<'a> {
-    fn set_modified<Snapshot: WritableSnapshot>(&self, thing_manager: &ThingManager<Snapshot>) {
-        if matches!(self.get_status(thing_manager), ConceptStatus::Persisted) {
-            thing_manager.lock_existing(self.as_reference());
+    fn set_modified<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &mut Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
+    ) {
+        if matches!(self.get_status(snapshot, thing_manager), ConceptStatus::Persisted) {
+            thing_manager.lock_existing(snapshot, self.as_reference());
         }
     }
 
     fn get_status<'m, Snapshot: ReadableSnapshot>(
         &self,
-        thing_manager: &'m ThingManager<Snapshot>
+        snapshot: &Snapshot,
+        thing_manager: &'m ThingManager<Snapshot>,
     ) -> ConceptStatus {
-        thing_manager.get_status(self.vertex().as_storage_key())
+        thing_manager.get_status(snapshot, self.vertex().as_storage_key())
     }
 
     fn errors<Snapshot: WritableSnapshot>(
-        &self, thing_manager: &ThingManager<Snapshot>) -> Result<Vec<ConceptWriteError>, ConceptReadError> {
+        &self,
+        snapshot: &Snapshot,
+        thing_manager: &ThingManager<Snapshot>) -> Result<Vec<ConceptWriteError>, ConceptReadError> {
         todo!()
     }
 
-    fn delete<'m>(self, thing_manager: &'m ThingManager<Snapshot>) -> Result<(), ConceptWriteError> {
-        let mut has_iter = self.get_has(thing_manager);
-        let mut has = has_iter.next().transpose()
+    fn delete<'m, Snapshot: WritableSnapshot>(
+        self,
+        snapshot: &mut Snapshot,
+        thing_manager: &'m ThingManager<Snapshot>
+    ) -> Result<(), ConceptWriteError> {
+        let has = self.get_has(snapshot, thing_manager)
+            .collect_cloned_vec(|(k, v)| k.into_owned())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
         let mut has_attr_type_deleted = HashSet::new();
-        while let Some((attr, count)) = has {
+        for attr in has {
             has_attr_type_deleted.add(attr.type_());
-            thing_manager.delete_has(self.as_reference(), attr);
-            has = has_iter.next().transpose()
-                .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
+            thing_manager.delete_has(snapshot, self.as_reference(), attr);
         }
 
-        for owns in self.type_().get_owns(thing_manager.type_manager())
+        for owns in self.type_().get_owns(snapshot, thing_manager.type_manager())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?
             .iter() {
-            let ordering = owns.get_ordering(thing_manager.type_manager())
+            let ordering = owns.get_ordering(snapshot, thing_manager.type_manager())
                 .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
             if matches!(ordering, Ordering::Ordered) {
-                thing_manager.delete_has_ordered(self.as_reference(), owns.attribute());
+                thing_manager.delete_has_ordered(snapshot, self.as_reference(), owns.attribute());
             }
         }
 
-        let mut relation_iter = self.get_relations(thing_manager);
-        let mut playing = relation_iter.next().transpose()
+        let relations_roles = self.get_relations(snapshot, thing_manager)
+            .collect_cloned_vec(|(relation, role, count)| (relation.into_owned(), role.into_owned()))
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
-        while let Some((relation, role, count)) = playing {
-            relation.delete_player_many(thing_manager, role, Object::Entity(self.as_reference()), count)?;
-            playing = relation_iter.next().transpose()
-                .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
+        for (relation, role) in relations_roles {
+            thing_manager.delete_role_player(snapshot, relation, self.as_reference(), role)?;
         }
 
-        thing_manager.delete_entity(self);
+        thing_manager.delete_entity(snapshot, self);
         Ok(())
     }
 }

--- a/concept/thing/mod.rs
+++ b/concept/thing/mod.rs
@@ -23,7 +23,7 @@ pub mod thing_manager;
 pub mod value;
 
 pub trait ThingAPI<'a> {
-    fn set_modified<Snapshot: WritableSnapshot>(&self, thing_manager: &ThingManager<Snapshot>);
+    fn set_modified<Snapshot: WritableSnapshot>(&self, snapshot: &mut Snapshot, thing_manager: &ThingManager<Snapshot>);
 
     // TODO: implementers could cache the status in a OnceCell if we do many operations on the same Thing at once
     fn get_status<'m, Snapshot: ReadableSnapshot>(
@@ -45,7 +45,7 @@ pub trait ThingAPI<'a> {
     ) -> Result<(), ConceptWriteError>;
 }
 
-pub trait ObjectAPI<'a>: ThingAPI<'a> {
+pub trait ObjectAPI<'a>: ThingAPI<'a> + Clone {
     fn vertex(&self) -> ObjectVertex<'_>;
 
     fn into_vertex(self) -> ObjectVertex<'a>;

--- a/concept/thing/mod.rs
+++ b/concept/thing/mod.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::io::Read;
 use bytes::byte_array::ByteArray;
 use encoding::graph::thing::vertex_attribute::AttributeID;
 use encoding::graph::thing::vertex_object::ObjectVertex;
@@ -22,14 +23,26 @@ pub mod thing_manager;
 pub mod value;
 
 pub trait ThingAPI<'a> {
-    fn set_modified(&self, thing_manager: &ThingManager<impl WritableSnapshot>);
+    fn set_modified<Snapshot: WritableSnapshot>(&self, thing_manager: &ThingManager<Snapshot>);
 
     // TODO: implementers could cache the status in a OnceCell if we do many operations on the same Thing at once
-    fn get_status<'m>(&self, thing_manager: &'m ThingManager<impl ReadableSnapshot>) -> ConceptStatus;
+    fn get_status<'m, Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        thing_manager: &'m ThingManager<Snapshot>
+    ) -> ConceptStatus;
 
-    fn errors(&self, thing_manager: &ThingManager<impl WritableSnapshot>)  -> Result<Vec<ConceptWriteError>, ConceptReadError>;
+    fn errors<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        thing_manager: &ThingManager<Snapshot>
+    )  -> Result<Vec<ConceptWriteError>, ConceptReadError>;
 
-    fn delete(self, thing_manager: &ThingManager<impl WritableSnapshot>) -> Result<(), ConceptWriteError>;
+    fn delete<Snapshot: WritableSnapshot>(
+        self,
+        snapshot: &mut Snapshot,
+        thing_manager: &ThingManager<Snapshot>
+    ) -> Result<(), ConceptWriteError>;
 }
 
 pub trait ObjectAPI<'a>: ThingAPI<'a> {

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -32,9 +32,9 @@ use crate::error::ConceptWriteError;
 use crate::thing::{ObjectAPI, ThingAPI};
 use crate::thing::object::HasAttributeIterator;
 use crate::thing::value::Value;
-use crate::type_::attribute_type::AttributeType;
 use crate::type_::{Ordering, OwnerAPI};
-use crate::type_::owns::{Owns};
+use crate::type_::attribute_type::AttributeType;
+use crate::type_::owns::Owns;
 use crate::type_::type_manager::TypeManager;
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
@@ -60,41 +60,47 @@ impl<'a> Relation<'a> {
         self.vertex.bytes()
     }
 
-    pub fn has_attribute(
+    pub fn has_attribute<Snapshot: ReadableSnapshot>(
         &self,
-        thing_manager: &ThingManager<impl ReadableSnapshot>,
+        snapshot: &Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
         attribute_type: AttributeType<'static>,
         value: Value<'_>,
     ) -> Result<bool, ConceptReadError> {
-        thing_manager.has_attribute(self.as_reference(), attribute_type, value)
+        thing_manager.has_attribute(snapshot, self.as_reference(), attribute_type, value)
     }
 
-    pub fn get_has<'m>(
+    pub fn get_has<'m, Snapshot: ReadableSnapshot>(
         &self,
-        thing_manager: &'m ThingManager<impl ReadableSnapshot>,
+        snapshot: &'m Snapshot,
+        thing_manager: &'m ThingManager<Snapshot>,
     ) -> HasAttributeIterator<'m, { ThingEdgeHas::LENGTH_PREFIX_FROM_OBJECT }> {
-        thing_manager.get_has_unordered(self.as_reference())
+        thing_manager.get_has_unordered(snapshot, self.as_reference())
     }
 
-    pub fn get_has_type<'m>(
+    pub fn get_has_type<'m, Snapshot: ReadableSnapshot>(
         &self,
-        thing_manager: &'m ThingManager<impl ReadableSnapshot>,
-        attribute_type: AttributeType<'static>
+        snapshot: &'m Snapshot,
+        thing_manager: &'m ThingManager<Snapshot>,
+        attribute_type: AttributeType<'static>,
     ) -> Result<HasAttributeIterator<'m, { ThingEdgeHas::LENGTH_PREFIX_FROM_OBJECT_TO_TYPE }>, ConceptReadError> {
-        thing_manager.get_has_type_unordered(self.as_reference(), attribute_type)
+        thing_manager.get_has_type_unordered(snapshot, self.as_reference(), attribute_type)
     }
 
-    pub fn set_has_unordered(
-        &self, thing_manager: &ThingManager<impl WritableSnapshot>, attribute: Attribute<'_>,
+    pub fn set_has_unordered<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &mut Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
+        attribute: Attribute<'_>,
     ) -> Result<(), ConceptWriteError> {
         // TODO: validate schema
-        let owns = self.get_type_owns(thing_manager.type_manager(), attribute.type_())
+        let owns = self.get_type_owns(snapshot, thing_manager.type_manager(), attribute.type_())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
-        let ordering = owns.get_ordering(thing_manager.type_manager())
+        let ordering = owns.get_ordering(snapshot, thing_manager.type_manager())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
         match ordering {
             Ordering::Unordered => {
-                thing_manager.set_has(self.as_reference(), attribute.as_reference());
+                thing_manager.set_has(snapshot, self.as_reference(), attribute.as_reference());
                 Ok(())
             }
             Ordering::Ordered => {
@@ -103,16 +109,19 @@ impl<'a> Relation<'a> {
         }
     }
 
-    pub fn delete_has_unordered(
-        &self, thing_manager: &ThingManager<impl WritableSnapshot>, attribute: Attribute<'static>,
+    pub fn delete_has_unordered<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &mut Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
+        attribute: Attribute<'static>,
     ) -> Result<(), ConceptWriteError> {
-        let owns = self.get_type_owns(thing_manager.type_manager(), attribute.type_())
+        let owns = self.get_type_owns(snapshot, thing_manager.type_manager(), attribute.type_())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
-        let ordering = owns.get_ordering(thing_manager.type_manager())
+        let ordering = owns.get_ordering(snapshot, thing_manager.type_manager())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
         match ordering {
             Ordering::Unordered => {
-                thing_manager.delete_has(self.as_reference(), attribute);
+                thing_manager.delete_has(snapshot, self.as_reference(), attribute);
                 Ok(())
             }
             Ordering::Ordered => {
@@ -122,10 +131,13 @@ impl<'a> Relation<'a> {
     }
 
 
-    fn get_type_owns<'m>(
-        &self, type_manager: &'m TypeManager<impl ReadableSnapshot>, attribute_type: AttributeType<'static>,
+    fn get_type_owns<'m, Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        type_manager: &'m TypeManager<Snapshot>,
+        attribute_type: AttributeType<'static>,
     ) -> Result<Owns<'m>, ConceptReadError> {
-        let owns = self.type_().get_owns_attribute(type_manager, attribute_type)?;
+        let owns = self.type_().get_owns_attribute(snapshot, type_manager, attribute_type)?;
         match owns {
             None => {
                 todo!("throw useful schema error")
@@ -138,13 +150,13 @@ impl<'a> Relation<'a> {
     //
     //
     // pub fn delete_has_single(
-    //     &self, thing_manager: &ThingManager<impl WritableSnapshot>, attribute: Attribute<'_>,
+    //     &self, thing_manager: &ThingManager<Snapshot>, attribute: Attribute<'_>,
     // ) -> Result<(), ConceptWriteError> {
     //     self.delete_has_many(thing_manager, attribute, 1)
     // }
     //
     // pub fn delete_has_many(
-    //     &self, thing_manager: &ThingManager<impl WritableSnapshot>, attribute: Attribute<'_>, count: u64,
+    //     &self, thing_manager: &ThingManager<Snapshot>, attribute: Attribute<'_>, count: u64,
     // ) -> Result<(), ConceptWriteError> {
     //     let owns = self.type_().get_owns_attribute(
     //         thing_manager.type_manager(),
@@ -167,41 +179,49 @@ impl<'a> Relation<'a> {
     //     Ok(())
     // }
 
-    pub fn get_relations<'m>(
+    pub fn get_relations<'m, Snapshot: ReadableSnapshot>(
         &self,
-        thing_manager: &'m ThingManager<impl ReadableSnapshot>,
+        snapshot: &'m Snapshot,
+        thing_manager: &'m ThingManager<Snapshot>,
     ) -> RelationRoleIterator<'m, { ThingEdgeRolePlayer::LENGTH_PREFIX_FROM }> {
-        thing_manager.get_relations_roles(self.as_reference())
+        thing_manager.get_relations_roles(snapshot, self.as_reference())
     }
 
-    pub fn get_indexed_players<'m>(
+    pub fn get_indexed_players<'m, Snapshot: ReadableSnapshot>(
         &self,
-        thing_manager: &'m ThingManager<impl ReadableSnapshot>,
+        snapshot: &'m Snapshot,
+        thing_manager: &'m ThingManager<Snapshot>,
     ) -> IndexedPlayersIterator<'m, { ThingEdgeRelationIndex::LENGTH_PREFIX_FROM }> {
-        thing_manager.get_indexed_players(Object::Relation(self.as_reference()))
+        thing_manager.get_indexed_players(snapshot, Object::Relation(self.as_reference()))
     }
 
-    pub fn has_players<'m>(&self, thing_manager: &'m ThingManager<impl ReadableSnapshot>) -> bool {
-        match self.get_status(thing_manager) {
-            ConceptStatus::Inserted => thing_manager.has_role_players(self.as_reference(), true),
-            ConceptStatus::Put | ConceptStatus::Persisted => thing_manager.has_role_players(self.as_reference(), false),
+    pub fn has_players<'m, Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        thing_manager: &'m ThingManager<Snapshot>,
+    ) -> bool {
+        match self.get_status(snapshot, thing_manager) {
+            ConceptStatus::Inserted => thing_manager.has_role_players(snapshot, self.as_reference(), true),
+            ConceptStatus::Put | ConceptStatus::Persisted => thing_manager.has_role_players(snapshot, self.as_reference(), false),
             ConceptStatus::Deleted => unreachable!("Cannot operate on a deleted concept."),
         }
     }
 
-    pub fn get_players<'m>(
-        &self,
-        thing_manager: &'m ThingManager<impl ReadableSnapshot>,
+    pub fn get_players<'m, Snapshot: ReadableSnapshot>(
+        &'m self,
+        snapshot: &'m Snapshot,
+        thing_manager: &'m ThingManager<Snapshot>,
     ) -> RolePlayerIterator<'m, { ThingEdgeHas::LENGTH_PREFIX_FROM_OBJECT }> {
-        thing_manager.get_role_players(self.as_reference())
+        thing_manager.get_role_players(snapshot, self.as_reference())
     }
 
-    fn get_player_counts(
+    fn get_player_counts<Snapshot: ReadableSnapshot>(
         &self,
-        thing_manager: &ThingManager<impl ReadableSnapshot>,
+        snapshot: &Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
     ) -> Result<HashMap<RoleType<'static>, u64>, ConceptReadError> {
         let mut map = HashMap::new();
-        let mut rp_iter = self.get_players(thing_manager);
+        let mut rp_iter = self.get_players(snapshot, thing_manager);
         let mut rp = rp_iter.next().transpose()?;
         while let Some((role_player, count)) = rp {
             let mut value = map.entry(role_player.role_type.clone()).or_insert(0);
@@ -219,129 +239,129 @@ impl<'a> Relation<'a> {
     /// TODO: to optimise the common case of creating a full relation, we could introduce a RelationBuilder, which can accumulate role players,
     ///   Then write all players + indexes in one go
     ///
-    pub fn add_player(
+    pub fn add_player<Snapshot: WritableSnapshot>(
         &self,
-        thing_manager: &ThingManager<impl WritableSnapshot>,
+        snapshot: &mut Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
         role_type: RoleType<'static>,
         player: Object<'_>,
     ) -> Result<(), ConceptWriteError> {
         // TODO: validate schema
-        let role_annotations = role_type.get_annotations(thing_manager.type_manager()).unwrap();
+        let role_annotations = role_type.get_annotations(snapshot, thing_manager.type_manager()).unwrap();
         let distinct = role_annotations.contains(&RoleTypeAnnotation::Distinct(AnnotationDistinct::new()));
         if distinct {
-            self.add_player_distinct(thing_manager, role_type, player)
+            self.add_player_distinct(snapshot, thing_manager, role_type, player)
         } else {
-            self.add_player_increment(thing_manager, role_type, player)
+            self.add_player_increment(snapshot, thing_manager, role_type, player)
         }
     }
 
-    fn add_player_distinct(
+    fn add_player_distinct<Snapshot: WritableSnapshot>(
         &self,
-        thing_manager: &ThingManager<impl WritableSnapshot>,
+        snapshot: &mut Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
         role_type: RoleType<'static>,
         player: Object<'_>,
     ) -> Result<(), ConceptWriteError> {
-        if thing_manager.type_manager().relation_index_available(self.type_())
+        if thing_manager.type_manager().relation_index_available(snapshot, self.type_())
             .map_err(|e| ConceptWriteError::ConceptRead { source: e })? {
             let compound_update_guard = thing_manager.relation_compound_update_mutex().lock().unwrap();
-            thing_manager.set_role_player(self.as_reference(), player.as_reference(), role_type.clone());
+            thing_manager.set_role_player(snapshot, self.as_reference(), player.as_reference(), role_type.clone());
             thing_manager.relation_index_player_regenerate(
-                self.as_reference(), player.as_reference(), role_type, 1,
+                snapshot, self.as_reference(), player.as_reference(), role_type, 1,
                 &compound_update_guard,
             );
         } else {
-            thing_manager.set_role_player(self.as_reference(), player.as_reference(), role_type.clone());
+            thing_manager.set_role_player(snapshot, self.as_reference(), player.as_reference(), role_type.clone());
         }
         Ok(())
     }
 
-    fn add_player_increment(
+    fn add_player_increment<Snapshot: WritableSnapshot>(
         &self,
-        thing_manager: &ThingManager<impl WritableSnapshot>,
+        snapshot: &mut Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
         role_type: RoleType<'static>,
         player: Object<'_>,
     ) -> Result<(), ConceptWriteError> {
         let compound_update_guard = thing_manager.relation_compound_update_mutex().lock().unwrap();
         let player_count = thing_manager.increment_role_player(
+            snapshot,
             self.as_reference(),
             player.as_reference(),
             role_type.clone(),
             &compound_update_guard,
         );
-        if thing_manager.type_manager().relation_index_available(self.type_())
+        if thing_manager.type_manager().relation_index_available(snapshot, self.type_())
             .map_err(|e| ConceptWriteError::ConceptRead { source: e })? {
             thing_manager.relation_index_player_regenerate(
-                self.as_reference(), player.as_reference(), role_type, player_count,
-                &compound_update_guard,
+                snapshot, self.as_reference(), player.as_reference(), role_type, player_count, &compound_update_guard,
             );
         }
         Ok(())
     }
 
-    pub fn delete_player_single(
+    pub fn delete_player_single<Snapshot: WritableSnapshot>(
         &self,
-        thing_manager: &ThingManager<impl WritableSnapshot>,
+        snapshot: &mut Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
         role_type: RoleType<'static>,
         player: Object<'_>,
     ) -> Result<(), ConceptWriteError> {
-        self.delete_player_many(thing_manager, role_type, player, 1)
+        self.delete_player_many(snapshot, thing_manager, role_type, player, 1)
     }
 
-    pub fn delete_player_many(
+    pub fn delete_player_many<Snapshot: WritableSnapshot>(
         &self,
-        thing_manager: &ThingManager<impl WritableSnapshot>,
+        snapshot: &mut Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
         role_type: RoleType<'static>,
         player: Object<'_>,
         delete_count: u64,
     ) -> Result<(), ConceptWriteError> {
-        let role_annotations = role_type.get_annotations(thing_manager.type_manager()).unwrap();
+        let role_annotations = role_type.get_annotations(snapshot, thing_manager.type_manager()).unwrap();
         let distinct = role_annotations.contains(&RoleTypeAnnotation::Distinct(AnnotationDistinct::new()));
         if distinct {
             debug_assert_eq!(delete_count, 1);
-            self.delete_player_distinct(thing_manager, role_type, player)
+            self.delete_player_distinct(snapshot, thing_manager, role_type, player)
         } else {
-            self.delete_player_decrement(thing_manager, role_type, player, delete_count)
+            self.delete_player_decrement(snapshot, thing_manager, role_type, player, delete_count)
         }
     }
 
-    fn delete_player_distinct(
+    fn delete_player_distinct<Snapshot: WritableSnapshot>(
         &self,
-        thing_manager: &ThingManager<impl WritableSnapshot>,
+        snapshot: &mut Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
         role_type: RoleType<'static>,
         player: Object<'_>,
     ) -> Result<(), ConceptWriteError> {
-        if thing_manager.type_manager().relation_index_available(self.type_())
-            .map_err(|e| ConceptWriteError::ConceptRead { source: e })? {
-            let compound_update_guard = thing_manager.relation_compound_update_mutex().lock().unwrap();
-            thing_manager.delete_role_player(self.as_reference(), player.as_reference(), role_type.clone());
-            thing_manager.relation_index_player_deleted(
-                self.as_reference(), player.as_reference(), role_type,
-                &compound_update_guard,
-            );
-        } else {
-            thing_manager.delete_role_player(self.as_reference(), player.as_reference(), role_type.clone());
-        }
+        thing_manager.delete_role_player(snapshot, self.as_reference(), player.as_reference(), role_type.clone())?;
         Ok(())
     }
 
-    fn delete_player_decrement(&self,
-                               thing_manager: &ThingManager<impl WritableSnapshot>,
-                               role_type: RoleType<'static>,
-                               player: Object<'_>,
-                               decrement_count: u64,
-    )  -> Result<(), ConceptWriteError> {
+    fn delete_player_decrement<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &mut Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
+        role_type: RoleType<'static>,
+        player: Object<'_>,
+        decrement_count: u64,
+    ) -> Result<(), ConceptWriteError> {
         let compound_update_guard = thing_manager.relation_compound_update_mutex().lock().unwrap();
         let remaining_player_count = thing_manager.decrement_role_player(
+            snapshot,
             self.as_reference(),
             player.as_reference(),
             role_type.clone(),
             decrement_count,
             &compound_update_guard,
         );
-        if thing_manager.type_manager().relation_index_available(self.type_())
+        if thing_manager.type_manager().relation_index_available(snapshot, self.type_())
             .map_err(|e| ConceptWriteError::ConceptRead { source: e })? {
             debug_assert_eq!(remaining_player_count, 0);
             thing_manager.relation_index_player_regenerate(
+                snapshot,
                 self.as_reference(), player.as_reference(), role_type, remaining_player_count,
                 &compound_update_guard,
             );
@@ -357,26 +377,38 @@ impl<'a> Relation<'a> {
 impl<'a> ConceptAPI<'a> for Relation<'a> {}
 
 impl<'a> ThingAPI<'a> for Relation<'a> {
-    fn set_modified(&self, thing_manager: &ThingManager<impl WritableSnapshot>) {
-        if matches!(self.get_status(thing_manager), ConceptStatus::Persisted) {
-            thing_manager.lock_existing(self.as_reference());
+    fn set_modified<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &mut Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
+    ) {
+        if matches!(self.get_status(snapshot, thing_manager), ConceptStatus::Persisted) {
+            thing_manager.lock_existing(snapshot, self.as_reference());
         }
     }
 
-    fn get_status<'m>(&self, thing_manager: &'m ThingManager<impl ReadableSnapshot>) -> ConceptStatus {
-        thing_manager.get_status(self.vertex().as_storage_key())
+    fn get_status<'m, Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        thing_manager: &'m ThingManager<Snapshot>,
+    ) -> ConceptStatus {
+        thing_manager.get_status(snapshot, self.vertex().as_storage_key())
     }
 
-    fn errors(&self, thing_manager: &ThingManager<impl WritableSnapshot>) -> Result<Vec<ConceptWriteError>, ConceptReadError> {
+    fn errors<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        thing_manager: &ThingManager<Snapshot>,
+    ) -> Result<Vec<ConceptWriteError>, ConceptReadError> {
         let mut errors = Vec::new();
 
         // validate cardinality
         let type_ = self.type_();
-        let relation_relates = type_.get_relates(thing_manager.type_manager())?;
-        let role_player_count = self.get_player_counts(thing_manager)?;
+        let relation_relates = type_.get_relates(snapshot, thing_manager.type_manager())?;
+        let role_player_count = self.get_player_counts(snapshot, thing_manager)?;
         for relates in relation_relates.iter() {
             let role_type = relates.role();
-            let cardinality = role_type.get_cardinality(thing_manager.type_manager())?;
+            let cardinality = role_type.get_cardinality(snapshot, thing_manager.type_manager())?;
             let player_count = role_player_count.get(&role_type).map_or(0, |c| *c);
             if !cardinality.is_valid(player_count) {
                 errors.push(ConceptWriteError::RelationRoleCardinality {
@@ -390,47 +422,49 @@ impl<'a> ThingAPI<'a> for Relation<'a> {
         Ok(errors)
     }
 
-    fn delete<'m>(self, thing_manager: &'m ThingManager<impl WritableSnapshot>) -> Result<(), ConceptWriteError> {
-        let mut has_iter = self.get_has(thing_manager);
-        let mut has = has_iter.next().transpose()
+    fn delete<'m, Snapshot: WritableSnapshot>(
+        self,
+        snapshot: &mut Snapshot,
+        thing_manager: &'m ThingManager<Snapshot>,
+    ) -> Result<(), ConceptWriteError> {
+        let mut has = self.get_has(snapshot, thing_manager)
+            .collect_cloned_vec(|(key, value)| key.into_owned())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
         let mut has_attr_type_deleted = HashSet::new();
-        while let Some((attr, count)) = has {
+        for attr in has {
             has_attr_type_deleted.add(attr.type_());
-            thing_manager.delete_has(self.as_reference(), attr);
-            has = has_iter.next().transpose()
-                .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
+            thing_manager.delete_has(snapshot, self.as_reference(), attr);
         }
 
-        for owns in self.type_().get_owns(thing_manager.type_manager())
+        for owns in self.type_().get_owns(snapshot, thing_manager.type_manager())
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?
             .iter() {
-            let ordering = owns.get_ordering(thing_manager.type_manager())
+            let ordering = owns.get_ordering(snapshot, thing_manager.type_manager())
                 .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
             if matches!(ordering, Ordering::Ordered) {
-                thing_manager.delete_has_ordered(self.as_reference(), owns.attribute());
+                thing_manager.delete_has_ordered(snapshot, self.as_reference(), owns.attribute());
             }
         }
 
-        let mut relation_iter = self.get_relations(thing_manager);
-        let mut playing = relation_iter.next().transpose()
+        let relations = self.get_relations(snapshot, thing_manager)
+            .collect_cloned_vec(|(relation, role, count)| (relation.into_owned(), role.into_owned()))
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
-        while let Some((relation, role, count)) = playing {
-            relation.delete_player_many(thing_manager, role, Object::Relation(self.as_reference()), count)?;
-            playing = relation_iter.next().transpose()
-                .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
+        for (relation, role) in relations {
+            thing_manager.delete_role_player(snapshot, relation, self.as_reference(), role)?;
         }
 
-        let mut player_iter = self.get_players(thing_manager);
-        let mut role_player = player_iter.next().transpose()
+        let players = self.get_players(snapshot, thing_manager)
+            .collect_cloned_vec(|(roleplayer, count)| (roleplayer.role_type, roleplayer.player.into_owned()))
             .map_err(|err| ConceptWriteError::ConceptRead { source: ConceptReadError::from(err) })?;
-        while let Some((rp, count)) = role_player {
-            self.delete_player_many(thing_manager, rp.role_type(), rp.player(), count)?;
-            role_player = player_iter.next().transpose()
-                .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
+        for (role, player) in players {
+            // TODO: Deleting one player at a time, each of which will delete parts of the relation index, isn't optimal
+            //       Instead, we could delete the players, then delete the entire index, if available.
+            thing_manager.delete_role_player(snapshot, self.as_reference(), player, role)?;
         }
 
-        thing_manager.delete_relation(self);
+        debug_assert_eq!(self.get_indexed_players(snapshot, thing_manager).count(), 0);
+
+        thing_manager.delete_relation(snapshot, self);
         Ok(())
     }
 }

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -270,7 +270,7 @@ impl<'a> Relation<'a> {
             thing_manager.relation_index_player_regenerate(
                 snapshot, self.as_reference(), player.as_reference(), role_type, 1,
                 &compound_update_guard,
-            );
+            )?;
         } else {
             thing_manager.set_role_player(snapshot, self.as_reference(), player.as_reference(), role_type.clone());
         }
@@ -296,7 +296,7 @@ impl<'a> Relation<'a> {
             .map_err(|e| ConceptWriteError::ConceptRead { source: e })? {
             thing_manager.relation_index_player_regenerate(
                 snapshot, self.as_reference(), player.as_reference(), role_type, player_count, &compound_update_guard,
-            );
+            )?;
         }
         Ok(())
     }
@@ -364,7 +364,7 @@ impl<'a> Relation<'a> {
                 snapshot,
                 self.as_reference(), player.as_reference(), role_type, remaining_player_count,
                 &compound_update_guard,
-            );
+            )?;
         }
         Ok(())
     }

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -55,78 +55,77 @@ use crate::{
 };
 
 pub struct ThingManager<Snapshot> {
-    snapshot: Arc<Snapshot>,
     vertex_generator: Arc<ThingVertexGenerator>,
     type_manager: Arc<TypeManager<Snapshot>>,
     relation_lock: Mutex<()>,
+    snapshot: PhantomData<Snapshot>,
 }
 
 impl<Snapshot: ReadableSnapshot> ThingManager<Snapshot> {
-    pub fn new(
-        snapshot: Arc<Snapshot>,
-        vertex_generator: Arc<ThingVertexGenerator>,
-        type_manager: Arc<TypeManager<Snapshot>>,
-    ) -> Self {
-        ThingManager { snapshot, vertex_generator, type_manager, relation_lock: Mutex::new(()) }
+    pub fn new(vertex_generator: Arc<ThingVertexGenerator>, type_manager: Arc<TypeManager<Snapshot>>) -> Self {
+        ThingManager { vertex_generator, type_manager, relation_lock: Mutex::new(()), snapshot: PhantomData::default() }
     }
 
     pub(crate) fn type_manager(&self) -> &TypeManager<Snapshot> {
         &self.type_manager
     }
 
-    pub fn get_entities(&self) -> EntityIterator<'_, 1> {
+    pub fn get_entities<'this>(&'this self, snapshot: &'this Snapshot) -> EntityIterator<'_, 1> {
         let prefix = ObjectVertex::build_prefix_prefix(Prefix::VertexEntity.prefix_id());
         let snapshot_iterator =
-            self.snapshot.iterate_range(KeyRange::new_within(prefix, Prefix::VertexEntity.fixed_width_keys()));
+            snapshot.iterate_range(KeyRange::new_within(prefix, Prefix::VertexEntity.fixed_width_keys()));
         EntityIterator::new(snapshot_iterator)
     }
 
-    pub fn get_relations(&self) -> RelationIterator<'_, 1> {
+    pub fn get_relations<'this>(&'this self, snapshot: &'this Snapshot) -> RelationIterator<'_, 1> {
         let prefix = ObjectVertex::build_prefix_prefix(Prefix::VertexRelation.prefix_id());
         let snapshot_iterator =
-            self.snapshot.iterate_range(KeyRange::new_within(prefix, Prefix::VertexRelation.fixed_width_keys()));
+            snapshot.iterate_range(KeyRange::new_within(prefix, Prefix::VertexRelation.fixed_width_keys()));
         RelationIterator::new(snapshot_iterator)
     }
 
-    pub fn get_attributes(&self) -> AttributeIterator<'_, Snapshot, 1, 2> {
+    pub fn get_attributes<'this>(&'this self, snapshot: &'this Snapshot) -> AttributeIterator<'_, Snapshot, 1, 2> {
         let start = AttributeVertex::build_prefix_prefix(Prefix::ATTRIBUTE_MIN);
         let end = AttributeVertex::build_prefix_prefix(Prefix::ATTRIBUTE_MAX);
-        let attribute_iterator = self.snapshot.iterate_range(KeyRange::new_inclusive(start, end));
+        let attribute_iterator = snapshot.iterate_range(KeyRange::new_inclusive(start, end));
 
         let has_reverse_start = ThingEdgeHasReverse::prefix_from_prefix(Prefix::ATTRIBUTE_MIN);
         let has_reverse_end = ThingEdgeHasReverse::prefix_from_prefix(Prefix::ATTRIBUTE_MAX);
         let has_reverse_iterator =
-            self.snapshot.iterate_range(KeyRange::new_inclusive(has_reverse_start, has_reverse_end));
-        AttributeIterator::new(attribute_iterator, has_reverse_iterator, self.type_manager())
+            snapshot.iterate_range(KeyRange::new_inclusive(has_reverse_start, has_reverse_end));
+        AttributeIterator::new(attribute_iterator, has_reverse_iterator, snapshot, self.type_manager())
     }
 
-    pub fn get_attributes_in(
-        &self,
+    pub fn get_attributes_in<'this>(
+        &'this self,
+        snapshot: &'this Snapshot,
         attribute_type: AttributeType<'_>,
     ) -> Result<AttributeIterator<'_, Snapshot, 3, 4>, ConceptReadError> {
         Ok(attribute_type
-            .get_value_type(self.type_manager.as_ref())?
+            .get_value_type(snapshot, self.type_manager.as_ref())?
             .map(|value_type| {
                 let attribute_value_type_prefix = AttributeVertex::value_type_to_prefix_type(value_type);
                 let prefix =
                     AttributeVertex::build_prefix_type(attribute_value_type_prefix, attribute_type.vertex().type_id_());
-                let attribute_iterator = self
-                    .snapshot
+                let attribute_iterator = snapshot
                     .iterate_range(KeyRange::new_within(prefix, attribute_value_type_prefix.fixed_width_keys()));
 
                 let has_reverse_prefix = ThingEdgeHasReverse::prefix_from_type(
                     attribute_value_type_prefix,
                     attribute_type.vertex().type_id_(),
                 );
-                let has_reverse_iterator = self
-                    .snapshot
+                let has_reverse_iterator = snapshot
                     .iterate_range(KeyRange::new_within(has_reverse_prefix, ThingEdgeHasReverse::FIXED_WIDTH_ENCODING));
-                AttributeIterator::new(attribute_iterator, has_reverse_iterator, self.type_manager())
+                AttributeIterator::new(attribute_iterator, has_reverse_iterator, snapshot, self.type_manager())
             })
             .unwrap_or_else(AttributeIterator::new_empty))
     }
 
-    pub(crate) fn get_attribute_value(&self, attribute: &Attribute<'_>) -> Result<Value<'static>, ConceptReadError> {
+    pub(crate) fn get_attribute_value(
+        &self,
+        snapshot: &Snapshot,
+        attribute: &Attribute<'_>,
+    ) -> Result<Value<'static>, ConceptReadError> {
         match attribute.value_type() {
             ValueType::Boolean => {
                 todo!()
@@ -143,8 +142,7 @@ impl<Snapshot: ReadableSnapshot> ThingManager<Snapshot> {
                 if attribute_id.is_inline() {
                     Ok(Value::String(Cow::Owned(String::from(attribute_id.get_inline_string_bytes().as_str()))))
                 } else {
-                    Ok(self
-                        .snapshot
+                    Ok(snapshot
                         .get_mapped(attribute.vertex().as_storage_key().as_reference(), |bytes| {
                             Value::String(Cow::Owned(String::from(
                                 StringBytes::new(Bytes::<1>::Reference(bytes)).as_str(),
@@ -159,6 +157,7 @@ impl<Snapshot: ReadableSnapshot> ThingManager<Snapshot> {
 
     pub(crate) fn get_attribute_with_value(
         &self,
+        snapshot: &Snapshot,
         attribute_type: AttributeType<'static>,
         value: Value<'_>,
     ) -> Result<Option<Attribute<'static>>, ConceptReadError> {
@@ -166,18 +165,18 @@ impl<Snapshot: ReadableSnapshot> ThingManager<Snapshot> {
             ValueType::Boolean => todo!(),
             ValueType::Long => {
                 debug_assert!(AttributeID::is_inlineable(value.as_reference()));
-                self.get_attribute_with_value_inline(attribute_type, value)
+                self.get_attribute_with_value_inline(snapshot, attribute_type, value)
             }
             ValueType::Double => todo!(),
             ValueType::String => {
                 if AttributeID::is_inlineable(value.as_reference()) {
-                    self.get_attribute_with_value_inline(attribute_type, value)
+                    self.get_attribute_with_value_inline(snapshot, attribute_type, value)
                 } else {
                     self.vertex_generator
                         .find_attribute_id_string_noinline(
                             attribute_type.vertex().type_id_(),
                             value.encode_string::<256>(),
-                            self.snapshot.as_ref(),
+                            snapshot,
                         )
                         .map_err(|err| ConceptReadError::SnapshotIterate { source: err })
                         .map(|id| {
@@ -192,6 +191,7 @@ impl<Snapshot: ReadableSnapshot> ThingManager<Snapshot> {
 
     fn get_attribute_with_value_inline(
         &self,
+        snapshot: &Snapshot,
         attribute_type: AttributeType<'static>,
         value: Value<'_>,
     ) -> Result<Option<Attribute<'static>>, ConceptReadError> {
@@ -201,13 +201,14 @@ impl<Snapshot: ReadableSnapshot> ThingManager<Snapshot> {
             attribute_type.vertex().type_id_(),
             AttributeID::build_inline(value),
         );
-        self.snapshot
+        snapshot
             .get_mapped(vertex.as_storage_key().as_reference(), |_| Attribute::new(vertex.clone()))
             .map_err(|err| ConceptReadError::SnapshotGet { source: err })
     }
 
     pub(crate) fn has_attribute<'a>(
         &self,
+        snapshot: &Snapshot,
         owner: impl ObjectAPI<'a>,
         attribute_type: AttributeType<'static>,
         value: Value<'_>,
@@ -218,7 +219,7 @@ impl<Snapshot: ReadableSnapshot> ThingManager<Snapshot> {
             AttributeVertex::build(value_type, attribute_type.vertex().type_id_(), AttributeID::build_inline(value))
         } else {
             // non-inline attributes require an extra lookup before checking for the has edge existence
-            let attribute = self.get_attribute_with_value(attribute_type, value)?;
+            let attribute = self.get_attribute_with_value(snapshot, attribute_type, value)?;
             match attribute {
                 Some(attribute) => attribute.into_vertex(),
                 None => return Ok(false),
@@ -226,8 +227,7 @@ impl<Snapshot: ReadableSnapshot> ThingManager<Snapshot> {
         };
 
         let has = ThingEdgeHas::build(owner.vertex(), vertex);
-        let has_exists = self
-            .snapshot
+        let has_exists = snapshot
             .get_mapped(has.into_storage_key().as_reference(), |_value| true)
             .map_err(|err| ConceptReadError::SnapshotGet { source: err })?
             .unwrap_or(false);
@@ -236,21 +236,23 @@ impl<Snapshot: ReadableSnapshot> ThingManager<Snapshot> {
 
     pub(crate) fn get_has_unordered<'this, 'a>(
         &'this self,
+        snapshot: &'this Snapshot,
         owner: impl ObjectAPI<'a>,
     ) -> HasAttributeIterator<'this, { ThingEdgeHas::LENGTH_PREFIX_FROM_OBJECT }> {
         let prefix = ThingEdgeHas::prefix_from_object(owner.into_vertex());
         HasAttributeIterator::new(
-            self.snapshot.iterate_range(KeyRange::new_within(prefix, ThingEdgeHas::FIXED_WIDTH_ENCODING)),
+            snapshot.iterate_range(KeyRange::new_within(prefix, ThingEdgeHas::FIXED_WIDTH_ENCODING)),
         )
     }
 
     pub(crate) fn get_has_type_unordered<'this, 'a>(
         &'this self,
+        snapshot: &'this Snapshot,
         owner: impl ObjectAPI<'a>,
         attribute_type: AttributeType<'static>,
     ) -> Result<HasAttributeIterator<'this, { ThingEdgeHas::LENGTH_PREFIX_FROM_OBJECT_TO_TYPE }>, ConceptReadError>
     {
-        let value_type = match attribute_type.get_value_type(self.type_manager())? {
+        let value_type = match attribute_type.get_value_type(snapshot, self.type_manager())? {
             None => {
                 todo!("Handle missing value type - for abstract attributes. Or assume this will never happen")
             }
@@ -259,24 +261,24 @@ impl<Snapshot: ReadableSnapshot> ThingManager<Snapshot> {
         let prefix =
             ThingEdgeHas::prefix_from_object_to_type(owner.into_vertex(), value_type, attribute_type.into_vertex());
         Ok(HasAttributeIterator::new(
-            self.snapshot.iterate_range(KeyRange::new_within(prefix, ThingEdgeHas::FIXED_WIDTH_ENCODING)),
+            snapshot.iterate_range(KeyRange::new_within(prefix, ThingEdgeHas::FIXED_WIDTH_ENCODING)),
         ))
     }
 
     pub(crate) fn get_has_type_ordered<'this, 'a>(
         &'this self,
+        snapshot: &Snapshot,
         owner: impl ObjectAPI<'a>,
         attribute_type: AttributeType<'static>,
     ) -> Result<Vec<Attribute<'static>>, ConceptReadError> {
         let key = HAS_ORDER_PROPERTY_FACTORY.build(owner.into_vertex(), attribute_type.vertex());
-        let value_type = match attribute_type.get_value_type(self.type_manager())? {
+        let value_type = match attribute_type.get_value_type(snapshot, self.type_manager())? {
             None => {
                 todo!("Handle missing value type - for abstract attributes. Or assume this will never happen")
             }
             Some(value_type) => value_type,
         };
-        let attributes = self
-            .snapshot
+        let attributes = snapshot
             .get_mapped(key.as_storage_key().as_reference(), |bytes| {
                 decode_attribute_ids(value_type, bytes.bytes())
                     .map(|id| Attribute::new(AttributeVertex::new(Bytes::Array(ByteArray::copy(id.bytes())))))
@@ -289,69 +291,83 @@ impl<Snapshot: ReadableSnapshot> ThingManager<Snapshot> {
 
     pub(crate) fn get_owners<'this, 'a>(
         &'this self,
+        snapshot: &'this Snapshot,
         attribute: Attribute<'a>,
     ) -> AttributeOwnerIterator<'this, { ThingEdgeHasReverse::LENGTH_BOUND_PREFIX_FROM }> {
         let prefix = ThingEdgeHasReverse::prefix_from_attribute(attribute.into_vertex());
         AttributeOwnerIterator::new(
-            self.snapshot.iterate_range(KeyRange::new_within(prefix, ThingEdgeHasReverse::FIXED_WIDTH_ENCODING)),
+            snapshot.iterate_range(KeyRange::new_within(prefix, ThingEdgeHasReverse::FIXED_WIDTH_ENCODING)),
         )
     }
 
-    pub(crate) fn has_owners<'a>(&self, attribute: Attribute<'a>, buffered_only: bool) -> bool {
+    pub(crate) fn has_owners<'a>(
+        &self,
+        snapshot: &Snapshot,
+        attribute: Attribute<'a>,
+        buffered_only: bool,
+    ) -> bool {
         let prefix = ThingEdgeHasReverse::prefix_from_attribute(attribute.into_vertex());
-        self.snapshot
+        snapshot
             .any_in_range(KeyRange::new_within(prefix, ThingEdgeHasReverse::FIXED_WIDTH_ENCODING), buffered_only)
     }
 
     pub(crate) fn get_relations_roles<'this, 'a>(
         &'this self,
+        snapshot: &'this Snapshot,
         player: impl ObjectAPI<'a>,
     ) -> RelationRoleIterator<'this, { ThingEdgeRolePlayer::LENGTH_PREFIX_FROM }> {
         let prefix = ThingEdgeRolePlayer::prefix_reverse_from_player(player.into_vertex());
         RelationRoleIterator::new(
-            self.snapshot.iterate_range(KeyRange::new_within(prefix, ThingEdgeRolePlayer::FIXED_WIDTH_ENCODING)),
+            snapshot.iterate_range(KeyRange::new_within(prefix, ThingEdgeRolePlayer::FIXED_WIDTH_ENCODING)),
         )
     }
 
     pub(crate) fn has_role_players<'a>(
         &self,
+        snapshot: &Snapshot,
         relation: Relation<'a>,
         buffered_only: bool, // FIXME use enums
     ) -> bool {
         let prefix = ThingEdgeRolePlayer::prefix_from_relation(relation.into_vertex());
-        self.snapshot
+        snapshot
             .any_in_range(KeyRange::new_within(prefix, ThingEdgeRolePlayer::FIXED_WIDTH_ENCODING), buffered_only)
     }
 
     pub(crate) fn get_role_players<'a>(
-        &self,
+        &'a self,
+        snapshot: &'a Snapshot,
         relation: impl ObjectAPI<'a>,
     ) -> RolePlayerIterator<'_, { ThingEdgeHas::LENGTH_PREFIX_FROM_OBJECT }> {
         let prefix = ThingEdgeRolePlayer::prefix_from_relation(relation.into_vertex());
         RolePlayerIterator::new(
-            self.snapshot.iterate_range(KeyRange::new_within(prefix, ThingEdgeRolePlayer::FIXED_WIDTH_ENCODING)),
+            snapshot.iterate_range(KeyRange::new_within(prefix, ThingEdgeRolePlayer::FIXED_WIDTH_ENCODING)),
         )
     }
 
-    pub(crate) fn get_indexed_players(
-        &self,
+    pub(crate) fn get_indexed_players<'a>(
+        &'a self,
+        snapshot: &'a Snapshot,
         from: Object<'_>,
     ) -> IndexedPlayersIterator<'_, { ThingEdgeRelationIndex::LENGTH_PREFIX_FROM }> {
         let prefix = ThingEdgeRelationIndex::prefix_from(from.vertex());
         IndexedPlayersIterator::new(
-            self.snapshot.iterate_range(KeyRange::new_within(prefix, ThingEdgeRelationIndex::FIXED_WIDTH_ENCODING)),
+            snapshot.iterate_range(KeyRange::new_within(prefix, ThingEdgeRelationIndex::FIXED_WIDTH_ENCODING)),
         )
     }
 
-    pub(crate) fn get_status(&self, key: StorageKey<'_, BUFFER_KEY_INLINE>) -> ConceptStatus {
-        self.snapshot
+    pub(crate) fn get_status(
+        &self,
+        snapshot: &Snapshot,
+        key: StorageKey<'_, BUFFER_KEY_INLINE>,
+    ) -> ConceptStatus {
+        snapshot
             .get_buffered_write_mapped(key.as_reference(), |write| match write {
                 Write::Insert { .. } => ConceptStatus::Inserted,
                 Write::Put { .. } => ConceptStatus::Put,
                 Write::Delete => ConceptStatus::Deleted,
             })
             .unwrap_or_else(|| {
-                debug_assert!(self.snapshot.get::<BUFFER_KEY_INLINE>(key.as_reference()).unwrap().is_some());
+                debug_assert!(snapshot.get::<BUFFER_KEY_INLINE>(key.as_reference()).unwrap().is_some());
                 ConceptStatus::Persisted
             })
     }
@@ -362,14 +378,18 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
         &self.relation_lock
     }
 
-    pub(crate) fn lock_existing<'a>(&self, object: impl ObjectAPI<'a>) {
-        self.snapshot.unmodifiable_lock_add(object.into_vertex().as_storage_key().into_owned_array())
+    pub(crate) fn lock_existing<'a>(
+        &self,
+        snapshot: &mut Snapshot,
+        object: impl ObjectAPI<'a>,
+    ) {
+        snapshot.unmodifiable_lock_add(object.into_vertex().as_storage_key().into_owned_array())
     }
 
-    pub fn finalise(self) -> Result<(), Vec<ConceptWriteError>> {
-        self.cleanup_relations().map_err(|err| Vec::from([err]))?;
-        self.cleanup_attributes().map_err(|err| Vec::from([err]))?;
-        let thing_errors = self.thing_errors();
+    pub fn finalise(self, snapshot: &mut Snapshot) -> Result<(), Vec<ConceptWriteError>> {
+        self.cleanup_relations(snapshot).map_err(|err| Vec::from([err]))?;
+        self.cleanup_attributes(snapshot).map_err(|err| Vec::from([err]))?;
+        let thing_errors = self.thing_errors(snapshot);
         match thing_errors {
             Ok(errors) => {
                 if errors.is_empty() {
@@ -382,22 +402,23 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
         }
     }
 
-    fn cleanup_relations(&self) -> Result<(), ConceptWriteError> {
+    fn cleanup_relations(&self, snapshot: &mut Snapshot) -> Result<(), ConceptWriteError> {
         let mut any_deleted = true;
         while any_deleted {
             any_deleted = false;
-            for (key, _) in self
-                .snapshot
+            for (key, _) in snapshot
                 .iterate_writes_range(KeyRange::new_within(
                     ThingEdgeRolePlayer::prefix().into_byte_array_or_ref(),
                     ThingEdgeRolePlayer::FIXED_WIDTH_ENCODING,
                 ))
                 .filter(|(_, write)| matches!(write, Write::Delete))
+                .collect::<Vec<_>>()
+                .into_iter()
             {
                 let edge = ThingEdgeRolePlayer::new(Bytes::Reference(key.byte_array().as_ref()));
                 let relation = Relation::new(edge.to());
-                if !relation.has_players(self) {
-                    relation.delete(self)?;
+                if !relation.has_players(snapshot, self) {
+                    relation.delete(snapshot, self)?;
                     any_deleted = true;
                 }
             }
@@ -405,61 +426,71 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
         Ok(())
     }
 
-    fn cleanup_attributes(&self) -> Result<(), ConceptWriteError> {
-        for (key, _) in self
-            .snapshot
+    fn cleanup_attributes(&self, snapshot: &mut Snapshot) -> Result<(), ConceptWriteError> {
+        for (key, _) in snapshot
             .iterate_writes_range(KeyRange::new_within(
                 ThingEdgeHas::prefix().into_byte_array_or_ref(),
                 ThingEdgeHas::FIXED_WIDTH_ENCODING,
             ))
             .filter(|(_, write)| matches!(write, Write::Delete))
+            .collect::<Vec<_>>()
+            .into_iter()
         {
             let edge = ThingEdgeHas::new(Bytes::Reference(key.byte_array().as_ref()));
             let attribute = Attribute::new(edge.to());
             let is_independent = attribute
                 .type_()
-                .is_independent(self.type_manager())
+                .is_independent(snapshot, self.type_manager())
                 .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
-            if !is_independent && !attribute.has_owners(self) {
-                attribute.delete(self)?;
+            if !is_independent && !attribute.has_owners(snapshot, self) {
+                attribute.delete(snapshot, self)?;
             }
         }
         Ok(())
     }
 
-    fn thing_errors(&self) -> Result<Vec<ConceptWriteError>, ConceptReadError> {
+    fn thing_errors(&self, snapshot: &mut Snapshot) -> Result<Vec<ConceptWriteError>, ConceptReadError> {
         let mut errors = Vec::new();
         let mut relations_validated = HashSet::new();
-        for (key, _) in self.snapshot.iterate_writes_range(KeyRange::new_within(
+        for (key, _) in snapshot.iterate_writes_range(KeyRange::new_within(
             ThingEdgeRolePlayer::prefix().into_byte_array_or_ref(),
             ThingEdgeRolePlayer::FIXED_WIDTH_ENCODING,
         )) {
             let edge = ThingEdgeRolePlayer::new(Bytes::Reference(key.byte_array().as_ref()));
             let relation = Relation::new(edge.from());
             if !relations_validated.contains(&relation) {
-                errors.extend(relation.errors(self)?);
+                errors.extend(relation.errors(snapshot, self)?);
                 relations_validated.insert(relation.into_owned());
             }
         }
         Ok(errors)
     }
 
-    pub fn create_entity(&self, entity_type: EntityType<'static>) -> Result<Entity<'_>, ConceptWriteError> {
-        Ok(Entity::new(self.vertex_generator.create_entity(entity_type.vertex().type_id_(), self.snapshot.as_ref())))
+    pub fn create_entity(
+        &self,
+        snapshot: &mut Snapshot,
+        entity_type: EntityType<'static>,
+    ) -> Result<Entity<'_>, ConceptWriteError> {
+        Ok(Entity::new(self.vertex_generator.create_entity(entity_type.vertex().type_id_(), snapshot)))
     }
 
-    pub fn create_relation(&self, relation_type: RelationType<'static>) -> Result<Relation<'_>, ConceptWriteError> {
+    pub fn create_relation(
+        &self,
+        snapshot: &mut Snapshot,
+        relation_type: RelationType<'static>,
+    ) -> Result<Relation<'_>, ConceptWriteError> {
         Ok(Relation::new(
-            self.vertex_generator.create_relation(relation_type.vertex().type_id_(), self.snapshot.as_ref()),
+            self.vertex_generator.create_relation(relation_type.vertex().type_id_(), snapshot),
         ))
     }
 
     pub fn create_attribute(
         &self,
+        snapshot: &mut Snapshot,
         attribute_type: AttributeType<'static>,
         value: Value<'_>,
     ) -> Result<Attribute<'_>, ConceptWriteError> {
-        let value_type = attribute_type.get_value_type(self.type_manager.as_ref())?;
+        let value_type = attribute_type.get_value_type(snapshot, self.type_manager.as_ref())?;
         if Some(value.value_type()) == value_type {
             let vertex = match value {
                 Value::Boolean(_bool) => {
@@ -470,7 +501,7 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
                     self.vertex_generator.create_attribute_long(
                         attribute_type.vertex().type_id_(),
                         encoded_long,
-                        self.snapshot.as_ref(),
+                        snapshot,
                     )
                 }
                 Value::Double(_double) => {
@@ -482,7 +513,7 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
                         .create_attribute_string(
                             attribute_type.vertex().type_id_(),
                             encoded_string,
-                            self.snapshot.as_ref(),
+                            snapshot,
                         )
                         .map_err(|err| ConceptWriteError::SnapshotIterate { source: err })?
                 }
@@ -493,92 +524,125 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
         }
     }
 
-    pub(crate) fn delete_entity(&self, entity: Entity<'_>) {
+    pub(crate) fn delete_entity(&self, snapshot: &mut Snapshot, entity: Entity<'_>) {
         let key = entity.into_vertex().into_storage_key().into_owned_array();
-        self.snapshot.unmodifiable_lock_remove(&key);
-        self.snapshot.delete(key)
+        snapshot.unmodifiable_lock_remove(&key);
+        snapshot.delete(key)
     }
 
-    pub(crate) fn delete_relation(&self, relation: Relation<'_>) {
+    pub(crate) fn delete_relation(&self, snapshot: &mut Snapshot, relation: Relation<'_>) {
         let key = relation.into_vertex().into_storage_key().into_owned_array();
-        self.snapshot.unmodifiable_lock_remove(&key);
-        self.snapshot.delete(key)
+        snapshot.unmodifiable_lock_remove(&key);
+        snapshot.delete(key)
     }
 
-    pub(crate) fn delete_attribute(&self, attribute: Attribute<'_>) {
+    pub(crate) fn delete_attribute(&self, snapshot: &mut Snapshot, attribute: Attribute<'_>) {
         let key = attribute.into_vertex().into_storage_key().into_owned_array();
-        self.snapshot.delete(key);
+        snapshot.delete(key);
     }
 
-    pub(crate) fn set_has<'a>(&self, owner: impl ObjectAPI<'a>, attribute: Attribute<'_>) {
+    pub(crate) fn set_has<'a>(&self, snapshot: &mut Snapshot, owner: impl ObjectAPI<'a>, attribute: Attribute<'_>) {
         // TODO: handle duplicates
         // note: we always re-put the attribute. TODO: optimise knowing when the attribute pre-exists.
-        self.snapshot.put(attribute.vertex().as_storage_key().into_owned_array());
-        owner.set_modified(self);
+        snapshot.put(attribute.vertex().as_storage_key().into_owned_array());
+        owner.set_modified(snapshot, self);
         let has = ThingEdgeHas::build(owner.vertex(), attribute.vertex());
-        self.snapshot.put_val(has.into_storage_key().into_owned_array(), encode_value_u64(1));
+        snapshot.put_val(has.into_storage_key().into_owned_array(), encode_value_u64(1));
         let has_reverse = ThingEdgeHasReverse::build(attribute.into_vertex(), owner.into_vertex());
-        self.snapshot.put_val(has_reverse.into_storage_key().into_owned_array(), encode_value_u64(1));
+        snapshot.put_val(has_reverse.into_storage_key().into_owned_array(), encode_value_u64(1));
     }
 
-    pub(crate) fn delete_has<'a>(&self, owner: impl ObjectAPI<'a>, attribute: Attribute<'_>) {
-        owner.set_modified(self);
+    pub(crate) fn delete_has<'a>(&self, snapshot: &mut Snapshot, owner: impl ObjectAPI<'a>, attribute: Attribute<'_>) {
+        owner.set_modified(snapshot, self);
         let has = ThingEdgeHas::build(owner.vertex(), attribute.vertex());
-        self.snapshot.delete(has.into_storage_key().into_owned_array());
+        snapshot.delete(has.into_storage_key().into_owned_array());
         let has_reverse = ThingEdgeHasReverse::build(attribute.into_vertex(), owner.into_vertex());
-        self.snapshot.delete(has_reverse.into_storage_key().into_owned_array());
+        snapshot.delete(has_reverse.into_storage_key().into_owned_array());
     }
 
     pub(crate) fn set_has_ordered<'a>(
         &self,
+        snapshot: &mut Snapshot,
         owner: impl ObjectAPI<'a>,
         attribute_type: AttributeType<'static>,
         attributes: Vec<Attribute<'_>>,
     ) {
-        owner.set_modified(self);
+        owner.set_modified(snapshot, self);
         let key = HAS_ORDER_PROPERTY_FACTORY.build(owner.into_vertex(), attribute_type.into_vertex());
         let value = encode_attribute_ids(attributes.into_iter().map(|attr| attr.into_vertex().attribute_id()));
-        self.snapshot.put_val(key.into_storage_key().into_owned_array(), value)
+        snapshot.put_val(key.into_storage_key().into_owned_array(), value)
     }
 
-    pub(crate) fn increment_has<'a>(&self, owner: impl ObjectAPI<'a>, attribute: Attribute<'_>) {
+    pub(crate) fn increment_has<'a>(&self, snapshot: &mut Snapshot, owner: impl ObjectAPI<'a>, attribute: Attribute<'_>) {
         todo!()
     }
 
-    pub(crate) fn decrement_has<'a>(&self, owner: impl ObjectAPI<'a>, attribute: Attribute<'a>, decrement_count: u64) {
+    pub(crate) fn decrement_has<'a>(
+        &self,
+        snapshot: &mut Snapshot,
+        owner: impl ObjectAPI<'a>,
+        attribute: Attribute<'a>,
+        decrement_count: u64,
+    ) {
         todo!()
     }
 
-    pub(crate) fn delete_has_ordered<'a>(&self, owner: impl ObjectAPI<'a>, attribute_type: AttributeType<'static>) {
-        owner.set_modified(self);
+    pub(crate) fn delete_has_ordered<'a>(
+        &self,
+        snapshot: &mut Snapshot,
+        owner: impl ObjectAPI<'a>,
+        attribute_type: AttributeType<'static>,
+    ) {
+        owner.set_modified(snapshot, self);
         let order_property = HAS_ORDER_PROPERTY_FACTORY.build(owner.into_vertex(), attribute_type.into_vertex());
-        self.snapshot.delete(order_property.into_storage_key().into_owned_array())
+        snapshot.delete(order_property.into_storage_key().into_owned_array())
     }
 
-    pub fn set_role_player<'a>(&self, relation: Relation<'_>, player: impl ObjectAPI<'a>, role_type: RoleType<'_>) {
+    pub fn set_role_player<'a>(
+        &self,
+        snapshot: &mut Snapshot,
+        relation: Relation<'_>,
+        player: impl ObjectAPI<'a>,
+        role_type: RoleType<'_>,
+    ) {
         let role_player =
             ThingEdgeRolePlayer::build_role_player(relation.vertex(), player.vertex(), role_type.clone().into_vertex());
         let count: u64 = 1;
-        self.snapshot.put_val(role_player.into_storage_key().into_owned_array(), encode_value_u64(count));
+        snapshot.put_val(role_player.into_storage_key().into_owned_array(), encode_value_u64(count));
         let role_player_reverse = ThingEdgeRolePlayer::build_role_player_reverse(
             player.into_vertex(),
             relation.into_vertex(),
             role_type.into_vertex(),
         );
         // must be idempotent, so no lock required -- cannot fail
-        self.snapshot.put_val(role_player_reverse.into_storage_key().into_owned_array(), encode_value_u64(count));
+        snapshot.put_val(role_player_reverse.into_storage_key().into_owned_array(), encode_value_u64(count));
     }
 
-    pub fn delete_role_player<'a>(&self, relation: Relation<'_>, player: impl ObjectAPI<'a>, role_type: RoleType<'_>) {
+    ///
+    /// Delete all counts of the specific role player in a given relation, and update indexes if required
+    ///
+    pub fn delete_role_player<'a>(
+        &self,
+        snapshot: &mut Snapshot,
+        relation: Relation<'_>,
+        player: impl ObjectAPI<'a>,
+        role_type: RoleType<'_>,
+    ) -> Result<(), ConceptWriteError> {
         let role_player =
             ThingEdgeRolePlayer::build_role_player(relation.vertex(), player.vertex(), role_type.clone().into_vertex());
-        self.snapshot.delete(role_player.into_storage_key().into_owned_array());
+        snapshot.delete(role_player.into_storage_key().into_owned_array());
         let role_player_reverse = ThingEdgeRolePlayer::build_role_player_reverse(
-            player.into_vertex(),
-            relation.into_vertex(),
-            role_type.into_vertex(),
+            player.clone().into_vertex(),
+            relation.clone().into_vertex(),
+            role_type.clone().into_vertex(),
         );
-        self.snapshot.delete(role_player_reverse.into_storage_key().into_owned_array());
+        snapshot.delete(role_player_reverse.into_storage_key().into_owned_array());
+
+        if self.type_manager.relation_index_available(snapshot, relation.type_())
+            .map_err(|err| ConceptWriteError::ConceptRead { source: err })? {
+            self.relation_index_player_deleted(snapshot, relation, player, role_type)
+        }
+        Ok(())
     }
 
     ///
@@ -587,6 +651,7 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
     ///
     pub(crate) fn increment_role_player<'a>(
         &self,
+        snapshot: &mut Snapshot,
         relation: Relation<'_>,
         player: impl ObjectAPI<'a>,
         role_type: RoleType<'_>,
@@ -599,20 +664,19 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
 
         let mut count = 0;
         let rp_count =
-            self.snapshot.get_mapped(role_player.as_storage_key().as_reference(), |val| decode_value_u64(val)).unwrap();
-        let rp_reverse_count = self
-            .snapshot
+            snapshot.get_mapped(role_player.as_storage_key().as_reference(), |val| decode_value_u64(val)).unwrap();
+        let rp_reverse_count = snapshot
             .get_mapped(role_player_reverse.as_storage_key().as_reference(), |val| decode_value_u64(val))
             .unwrap();
         debug_assert_eq!(&rp_count, &rp_reverse_count);
 
         count = rp_count.unwrap_or(0) + 1;
         let reverse_count = rp_reverse_count.unwrap_or(0) + 1;
-        self.snapshot.put_val(role_player.as_storage_key().into_owned_array(), encode_value_u64(count));
-        self.snapshot.put_val(role_player_reverse.as_storage_key().into_owned_array(), encode_value_u64(reverse_count));
+        snapshot.put_val(role_player.as_storage_key().into_owned_array(), encode_value_u64(count));
+        snapshot.put_val(role_player_reverse.as_storage_key().into_owned_array(), encode_value_u64(reverse_count));
 
         // must lock to fail concurrent transactions updating the same counters
-        self.snapshot.exclusive_lock_add(role_player.into_storage_key().into_owned_array().into_byte_array());
+        snapshot.exclusive_lock_add(role_player.into_storage_key().into_owned_array().into_byte_array());
         count
     }
 
@@ -622,6 +686,7 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
     ///
     pub(crate) fn decrement_role_player<'a>(
         &self,
+        snapshot: &mut Snapshot,
         relation: Relation<'_>,
         player: impl ObjectAPI<'a>,
         role_type: RoleType<'_>,
@@ -634,9 +699,8 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
             ThingEdgeRolePlayer::build_role_player_reverse(player.vertex(), relation.vertex(), role_type.into_vertex());
 
         let rp_count =
-            self.snapshot.get_mapped(role_player.as_storage_key().as_reference(), |val| decode_value_u64(val)).unwrap();
-        let rp_reverse_count = self
-            .snapshot
+            snapshot.get_mapped(role_player.as_storage_key().as_reference(), |val| decode_value_u64(val)).unwrap();
+        let rp_reverse_count = snapshot
             .get_mapped(role_player_reverse.as_storage_key().as_reference(), |val| decode_value_u64(val))
             .unwrap();
         debug_assert_eq!(&rp_count, &rp_reverse_count);
@@ -646,34 +710,32 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
         let reverse_count = rp_reverse_count.unwrap() - decrement_count;
         debug_assert!(reverse_count >= 0);
         if count == 0 {
-            self.snapshot.delete(role_player.as_storage_key().into_owned_array());
-            self.snapshot.delete(role_player_reverse.as_storage_key().into_owned_array());
+            snapshot.delete(role_player.as_storage_key().into_owned_array());
+            snapshot.delete(role_player_reverse.as_storage_key().into_owned_array());
         } else {
-            self.snapshot.put_val(role_player.as_storage_key().into_owned_array(), encode_value_u64(count));
-            self.snapshot
+            snapshot.put_val(role_player.as_storage_key().into_owned_array(), encode_value_u64(count));
+            snapshot
                 .put_val(role_player_reverse.as_storage_key().into_owned_array(), encode_value_u64(reverse_count));
         }
 
         // must lock to fail concurrent transactions updating the same counters
-        self.snapshot.exclusive_lock_add(role_player.into_storage_key().into_owned_array().into_byte_array());
+        snapshot.exclusive_lock_add(role_player.into_storage_key().into_owned_array().into_byte_array());
         count
     }
 
     ///
     /// Clean up all parts of a relation index to do with a specific role player.
-    /// Caller must provide a lock that guarantees the relation's player is removed before and atomically
     ///
-    pub(crate) fn relation_index_player_deleted(
+    pub(crate) fn relation_index_player_deleted<'a>(
         &self,
+        snapshot: &mut Snapshot,
         relation: Relation<'_>,
-        player: Object<'_>,
+        player: impl ObjectAPI<'a>,
         role_type: RoleType<'_>,
-        _update_guard: &MutexGuard<'_, ()>,
     ) {
-        let mut players = relation.get_players(self);
+        let mut players = relation.get_players(snapshot, self);
         let mut role_player = players.next().transpose().unwrap();
-        while let Some((rp, count)) = role_player {
-            debug_assert_eq!(count, 1);
+        while let Some((rp, _)) = role_player {
             let index = ThingEdgeRelationIndex::build(
                 player.vertex(),
                 rp.player().vertex(),
@@ -681,7 +743,7 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
                 role_type.vertex().type_id_(),
                 rp.role_type().vertex().type_id_(),
             );
-            self.snapshot.delete(index.as_storage_key().into_owned_array());
+            snapshot.delete(index.as_storage_key().into_owned_array());
             let index_reverse = ThingEdgeRelationIndex::build(
                 rp.player().vertex(),
                 player.vertex(),
@@ -689,7 +751,7 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
                 rp.role_type().vertex().type_id_(),
                 role_type.vertex().type_id_(),
             );
-            self.snapshot.delete(index_reverse.as_storage_key().into_owned_array());
+            snapshot.delete(index_reverse.as_storage_key().into_owned_array());
             role_player = players.next().transpose().unwrap();
         }
     }
@@ -700,6 +762,7 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
     ///
     pub(crate) fn relation_index_player_regenerate(
         &self,
+        snapshot: &mut Snapshot,
         relation: Relation<'_>,
         player: Object<'_>,
         role_type: RoleType<'_>,
@@ -707,9 +770,9 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
         _update_guard: &MutexGuard<'_, ()>,
     ) {
         debug_assert_ne!(total_player_count, 0);
-        let mut players = relation.get_players(self);
+        let mut players = relation.get_players(snapshot, self);
         let mut role_player = players.next().transpose().unwrap();
-        while let Some((rp, count)) = role_player.as_ref() {
+        while let Some((rp, count)) = role_player {
             let is_same_rp = rp.player() == player && rp.role_type() == role_type;
             if is_same_rp && total_player_count > 1 {
                 let repetitions = total_player_count - 1;
@@ -720,9 +783,9 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
                     role_type.vertex().type_id_(),
                     role_type.vertex().type_id_(),
                 );
-                self.snapshot.put_val(index.as_storage_key().into_owned_array(), encode_value_u64(repetitions));
+                snapshot.put_val(index.as_storage_key().into_owned_array(), encode_value_u64(repetitions));
             } else if !is_same_rp {
-                let rp_repetitions = *count;
+                let rp_repetitions = count;
                 let index = ThingEdgeRelationIndex::build(
                     player.vertex(),
                     rp.player().vertex(),
@@ -730,7 +793,7 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
                     role_type.vertex().type_id_(),
                     rp.role_type().vertex().type_id_(),
                 );
-                self.snapshot.put_val(index.as_storage_key().into_owned_array(), encode_value_u64(rp_repetitions));
+                snapshot.put_val(index.as_storage_key().into_owned_array(), encode_value_u64(rp_repetitions));
                 let player_repetitions = total_player_count;
                 let index_reverse = ThingEdgeRelationIndex::build(
                     rp.player().vertex(),
@@ -739,7 +802,7 @@ impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
                     rp.role_type().vertex().type_id_(),
                     role_type.vertex().type_id_(),
                 );
-                self.snapshot
+                snapshot
                     .put_val(index_reverse.as_storage_key().into_owned_array(), encode_value_u64(player_repetitions));
             }
             role_player = players.next().transpose().unwrap();

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -57,13 +57,12 @@ use crate::{
 pub struct ThingManager<Snapshot> {
     vertex_generator: Arc<ThingVertexGenerator>,
     type_manager: Arc<TypeManager<Snapshot>>,
-    relation_lock: Mutex<()>,
     snapshot: PhantomData<Snapshot>,
 }
 
 impl<Snapshot: ReadableSnapshot> ThingManager<Snapshot> {
     pub fn new(vertex_generator: Arc<ThingVertexGenerator>, type_manager: Arc<TypeManager<Snapshot>>) -> Self {
-        ThingManager { vertex_generator, type_manager, relation_lock: Mutex::new(()), snapshot: PhantomData::default() }
+        ThingManager { vertex_generator, type_manager, snapshot: PhantomData::default() }
     }
 
     pub(crate) fn type_manager(&self) -> &TypeManager<Snapshot> {
@@ -374,10 +373,6 @@ impl<Snapshot: ReadableSnapshot> ThingManager<Snapshot> {
 }
 
 impl<'txn, Snapshot: WritableSnapshot> ThingManager<Snapshot> {
-    pub(crate) fn relation_compound_update_mutex(&self) -> &Mutex<()> {
-        &self.relation_lock
-    }
-
     pub(crate) fn lock_existing<'a>(
         &self,
         snapshot: &mut Snapshot,

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -9,6 +9,7 @@ use std::{
     collections::HashSet,
     sync::{Arc, Mutex, MutexGuard},
 };
+use std::marker::PhantomData;
 
 use bytes::{byte_array::ByteArray, Bytes};
 use encoding::{

--- a/concept/type_/mod.rs
+++ b/concept/type_/mod.rs
@@ -39,67 +39,91 @@ pub trait TypeAPI<'a>: ConceptAPI<'a> + Sized + Clone {
 
     fn into_vertex(self) -> TypeVertex<'a>;
 
-    fn is_abstract(&self, type_manager: &TypeManager<impl ReadableSnapshot>) -> Result<bool, ConceptReadError>;
+    fn is_abstract<Snapshot: ReadableSnapshot>(
+        &self, snapshot: &Snapshot, type_manager: &TypeManager<Snapshot>
+    ) -> Result<bool, ConceptReadError>;
 
-    fn delete(self, type_manager: &TypeManager<impl WritableSnapshot>) -> Result<(), ConceptWriteError>;
+    fn delete<Snapshot: WritableSnapshot>(
+        self, snapshot: &mut Snapshot, type_manager: &TypeManager<Snapshot>
+    ) -> Result<(), ConceptWriteError>;
 }
 
 pub trait ObjectTypeAPI<'a>: TypeAPI<'a> {}
 
 pub trait OwnerAPI<'a>: TypeAPI<'a> {
-    fn set_owns(
+    fn set_owns<Snapshot: WritableSnapshot>(
         &self,
-        type_manager: &TypeManager<impl WritableSnapshot>,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>,
         attribute_type: AttributeType<'static>,
         ordering: Ordering,
     ) -> Owns<'static>;
 
-    fn delete_owns(&self, type_manager: &TypeManager<impl WritableSnapshot>, attribute_type: AttributeType<'static>);
-
-    fn get_owns<'m>(
+    fn delete_owns<Snapshot: WritableSnapshot>(
         &self,
-        type_manager: &'m TypeManager<impl ReadableSnapshot>,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>,
+        attribute_type: AttributeType<'static>
+    );
+
+    fn get_owns<'m, Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        type_manager: &'m TypeManager<Snapshot>,
     ) -> Result<MaybeOwns<'m, HashSet<Owns<'static>>>, ConceptReadError>;
 
-    fn get_owns_attribute(
+    fn get_owns_attribute<Snapshot: ReadableSnapshot>(
         &self,
-        type_manager: &TypeManager<impl ReadableSnapshot>,
+        snapshot: &Snapshot,
+        type_manager: &TypeManager<Snapshot>,
         attribute_type: AttributeType<'static>,
     ) -> Result<Option<Owns<'static>>, ConceptReadError>;
 
-    fn has_owns_attribute(
+    fn has_owns_attribute<Snapshot: ReadableSnapshot>(
         &self,
-        type_manager: &TypeManager<impl ReadableSnapshot>,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>,
         attribute_type: AttributeType<'static>,
     ) -> Result<bool, ConceptReadError> {
-        Ok(self.get_owns_attribute(type_manager, attribute_type)?.is_some())
+        Ok(self.get_owns_attribute(snapshot, type_manager, attribute_type)?.is_some())
     }
 }
 
 pub trait PlayerAPI<'a>: TypeAPI<'a> {
-    fn set_plays(
-        &self, type_manager: &TypeManager<impl WritableSnapshot>, role_type: RoleType<'static>
+    fn set_plays<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>,
+        role_type: RoleType<'static>,
     ) -> Plays<'static>;
 
-    fn delete_plays(&self, type_manager: &TypeManager<impl WritableSnapshot>, role_type: RoleType<'static>);
-
-    fn get_plays<'m>(
+    fn delete_plays<Snapshot: WritableSnapshot>(
         &self,
-        type_manager: &'m TypeManager<impl ReadableSnapshot>,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>,
+        role_type: RoleType<'static>
+    );
+
+    fn get_plays<'m, Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        type_manager: &'m TypeManager<Snapshot>,
     ) -> Result<MaybeOwns<'m, HashSet<Plays<'static>>>, ConceptReadError>;
 
-    fn get_plays_role(
+    fn get_plays_role<Snapshot: ReadableSnapshot>(
         &self,
-        type_manager: &TypeManager<impl ReadableSnapshot>,
+        snapshot: &Snapshot,
+        type_manager: &TypeManager<Snapshot>,
         role_type: RoleType<'static>,
     ) -> Result<Option<Plays<'static>>, ConceptReadError>;
 
-    fn has_plays_role(
+    fn has_plays_role<Snapshot: ReadableSnapshot>(
         &self,
-        type_manager: &TypeManager<impl ReadableSnapshot>,
+        snapshot: &Snapshot,
+        type_manager: &TypeManager<Snapshot>,
         role_type: RoleType<'static>,
     ) -> Result<bool, ConceptReadError> {
-        Ok(self.get_plays_role(type_manager, role_type)?.is_some())
+        Ok(self.get_plays_role(snapshot, type_manager, role_type)?.is_some())
     }
 }
 

--- a/concept/type_/mod.rs
+++ b/concept/type_/mod.rs
@@ -40,7 +40,9 @@ pub trait TypeAPI<'a>: ConceptAPI<'a> + Sized + Clone {
     fn into_vertex(self) -> TypeVertex<'a>;
 
     fn is_abstract<Snapshot: ReadableSnapshot>(
-        &self, snapshot: &Snapshot, type_manager: &TypeManager<Snapshot>
+        &self,
+        snapshot: &Snapshot,
+        type_manager: &TypeManager<Snapshot>
     ) -> Result<bool, ConceptReadError>;
 
     fn delete<Snapshot: WritableSnapshot>(

--- a/concept/type_/mod.rs
+++ b/concept/type_/mod.rs
@@ -81,7 +81,7 @@ pub trait OwnerAPI<'a>: TypeAPI<'a> {
 
     fn has_owns_attribute<Snapshot: ReadableSnapshot>(
         &self,
-        snapshot: &mut Snapshot,
+        snapshot: &Snapshot,
         type_manager: &TypeManager<Snapshot>,
         attribute_type: AttributeType<'static>,
     ) -> Result<bool, ConceptReadError> {

--- a/concept/type_/object_type.rs
+++ b/concept/type_/object_type.rs
@@ -36,44 +36,52 @@ impl<'a> ObjectType<'a> {
 }
 
 impl<'a> OwnerAPI<'a> for ObjectType<'a> {
-    fn set_owns(
+    fn set_owns<Snapshot: WritableSnapshot>(
         &self,
-        type_manager: &TypeManager<impl WritableSnapshot>,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>,
         attribute_type: AttributeType<'static>,
         ordering: Ordering,
     ) -> Owns<'static> {
         // TODO: decide behaviour (ok or error) if already owning
         match self {
-            ObjectType::Entity(entity) => entity.set_owns(type_manager, attribute_type, ordering),
-            ObjectType::Relation(relation) => relation.set_owns(type_manager, attribute_type, ordering),
+            ObjectType::Entity(entity) => entity.set_owns(snapshot, type_manager, attribute_type, ordering),
+            ObjectType::Relation(relation) => relation.set_owns(snapshot, type_manager, attribute_type, ordering),
         }
     }
 
-    fn delete_owns(&self, type_manager: &TypeManager<impl WritableSnapshot>, attribute_type: AttributeType<'static>) {
-        match self {
-            ObjectType::Entity(entity) => entity.delete_owns(type_manager, attribute_type),
-            ObjectType::Relation(relation) => relation.delete_owns(type_manager, attribute_type),
-        }
-    }
-
-    fn get_owns<'m>(
+    fn delete_owns<Snapshot: WritableSnapshot>(
         &self,
-        type_manager: &'m TypeManager<impl ReadableSnapshot>,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>,
+        attribute_type: AttributeType<'static>
+    ) {
+        match self {
+            ObjectType::Entity(entity) => entity.delete_owns(snapshot, type_manager, attribute_type),
+            ObjectType::Relation(relation) => relation.delete_owns(snapshot, type_manager, attribute_type),
+        }
+    }
+
+    fn get_owns<'m, Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        type_manager: &'m TypeManager<Snapshot>,
     ) -> Result<MaybeOwns<'m, HashSet<Owns<'static>>>, ConceptReadError> {
         match self {
-            ObjectType::Entity(entity) => entity.get_owns(type_manager),
-            ObjectType::Relation(relation) => relation.get_owns(type_manager),
+            ObjectType::Entity(entity) => entity.get_owns(snapshot, type_manager),
+            ObjectType::Relation(relation) => relation.get_owns(snapshot, type_manager),
         }
     }
 
-    fn get_owns_attribute(
+    fn get_owns_attribute<Snapshot: ReadableSnapshot>(
         &self,
-        type_manager: &TypeManager<impl ReadableSnapshot>,
+        snapshot: &Snapshot,
+        type_manager: &TypeManager<Snapshot>,
         attribute_type: AttributeType<'static>,
     ) -> Result<Option<Owns<'static>>, ConceptReadError> {
         match self {
-            ObjectType::Entity(entity) => entity.get_owns_attribute(type_manager, attribute_type),
-            ObjectType::Relation(relation) => relation.get_owns_attribute(type_manager, attribute_type),
+            ObjectType::Entity(entity) => entity.get_owns_attribute(snapshot, type_manager, attribute_type),
+            ObjectType::Relation(relation) => relation.get_owns_attribute(snapshot, type_manager, attribute_type),
         }
     }
 }
@@ -95,56 +103,74 @@ impl<'a> TypeAPI<'a> for ObjectType<'a> {
         }
     }
 
-    fn is_abstract(
-        &self, type_manager: &TypeManager<impl ReadableSnapshot>,
+    fn is_abstract<Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        type_manager: &TypeManager<Snapshot>,
     ) -> Result<bool, ConceptReadError> {
         match self {
-            ObjectType::Entity(entity) => entity.is_abstract(type_manager),
-            ObjectType::Relation(relation) => relation.is_abstract(type_manager)
+            ObjectType::Entity(entity) => entity.is_abstract(snapshot, type_manager),
+            ObjectType::Relation(relation) => relation.is_abstract(snapshot, type_manager)
         }
     }
 
-    fn delete(self, type_manager: &TypeManager<impl WritableSnapshot>) -> Result<(), ConceptWriteError> {
+    fn delete<Snapshot: WritableSnapshot>(
+        self,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>
+    ) -> Result<(), ConceptWriteError> {
         match self {
-            ObjectType::Entity(entity) => entity.delete(type_manager),
-            ObjectType::Relation(relation) => relation.delete(type_manager)
+            ObjectType::Entity(entity) => entity.delete(snapshot, type_manager),
+            ObjectType::Relation(relation) => relation.delete(snapshot, type_manager)
         }
     }
 }
 
 impl<'a> PlayerAPI<'a> for ObjectType<'a> {
-    fn set_plays(&self, type_manager: &TypeManager<impl WritableSnapshot>, role_type: RoleType<'static>) -> Plays<'static> {
-        match self {
-            ObjectType::Entity(entity) => entity.set_plays(type_manager, role_type),
-            ObjectType::Relation(relation) => relation.set_plays(type_manager, role_type),
-        }
-    }
-
-    fn delete_plays(&self, type_manager: &TypeManager<impl WritableSnapshot>, role_type: RoleType<'static>) {
-        match self {
-            ObjectType::Entity(entity) => entity.delete_plays(type_manager, role_type),
-            ObjectType::Relation(relation) => relation.delete_plays(type_manager, role_type),
-        }
-    }
-
-    fn get_plays<'m>(
+    fn set_plays<Snapshot: WritableSnapshot>(
         &self,
-        type_manager: &'m TypeManager<impl ReadableSnapshot>,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>,
+        role_type: RoleType<'static>
+    ) -> Plays<'static> {
+        match self {
+            ObjectType::Entity(entity) => entity.set_plays(snapshot, type_manager, role_type),
+            ObjectType::Relation(relation) => relation.set_plays(snapshot, type_manager, role_type),
+        }
+    }
+
+    fn delete_plays<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>,
+        role_type: RoleType<'static>
+    ) {
+        match self {
+            ObjectType::Entity(entity) => entity.delete_plays(snapshot, type_manager, role_type),
+            ObjectType::Relation(relation) => relation.delete_plays(snapshot, type_manager, role_type),
+        }
+    }
+
+    fn get_plays<'m, Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        type_manager: &'m TypeManager<Snapshot>,
     ) -> Result<MaybeOwns<'m, HashSet<Plays<'static>>>, ConceptReadError> {
         match self {
-            ObjectType::Entity(entity) => entity.get_plays(type_manager),
-            ObjectType::Relation(relation) => relation.get_plays(type_manager),
+            ObjectType::Entity(entity) => entity.get_plays(snapshot, type_manager),
+            ObjectType::Relation(relation) => relation.get_plays(snapshot, type_manager),
         }
     }
 
-    fn get_plays_role(
+    fn get_plays_role<Snapshot: ReadableSnapshot>(
         &self,
-        type_manager: &TypeManager<impl ReadableSnapshot>,
+        snapshot: &Snapshot,
+        type_manager: &TypeManager<Snapshot>,
         role_type: RoleType<'static>,
     ) -> Result<Option<Plays<'static>>, ConceptReadError> {
         match self {
-            ObjectType::Entity(entity) => entity.get_plays_role(type_manager, role_type),
-            ObjectType::Relation(relation) => relation.get_plays_role(type_manager, role_type),
+            ObjectType::Entity(entity) => entity.get_plays_role(snapshot, type_manager, role_type),
+            ObjectType::Relation(relation) => relation.get_plays_role(snapshot, type_manager, role_type),
         }
     }
 }

--- a/concept/type_/owns.rs
+++ b/concept/type_/owns.rs
@@ -13,7 +13,6 @@ use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 use crate::error::ConceptReadError;
 use crate::type_::{attribute_type::AttributeType, IntoCanonicalTypeEdge, object_type::ObjectType, Ordering, TypeAPI};
 use crate::type_::annotation::{Annotation, AnnotationCardinality, AnnotationDistinct};
-use crate::type_::entity_type::EntityType;
 use crate::type_::type_manager::TypeManager;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -27,7 +26,6 @@ impl<'a> Owns<'a> {
         Owns { owner: owner_type, attribute: attribute_type }
     }
 
-
     pub fn owner(&self) -> ObjectType<'a> {
         self.owner.clone()
     }
@@ -36,48 +34,73 @@ impl<'a> Owns<'a> {
         self.attribute.clone()
     }
 
-    pub fn is_distinct<'this>(&self, type_manager: &TypeManager<impl ReadableSnapshot>) -> Result<bool, ConceptReadError> {
+    pub fn is_distinct<'this, Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        type_manager: &TypeManager<Snapshot>
+    ) -> Result<bool, ConceptReadError> {
         let is_ordered = false; // TODO
         if is_ordered {
-            let annotations = self.get_annotations(type_manager)?;
+            let annotations = self.get_annotations(snapshot, type_manager)?;
             Ok(annotations.contains(&OwnsAnnotation::Distinct(AnnotationDistinct::new())))
         } else {
             Ok(true)
         }
     }
 
-    pub(crate) fn get_annotations<'this>(
-        &'this self, type_manager: &'this TypeManager<impl ReadableSnapshot>,
+    pub(crate) fn get_annotations<'this, Snapshot: ReadableSnapshot>(
+        &'this self,
+        snapshot: &Snapshot,
+        type_manager: &'this TypeManager<Snapshot>,
     ) -> Result<MaybeOwns<'this, HashSet<OwnsAnnotation>>, ConceptReadError> {
-        type_manager.get_owns_annotations(self.clone())
+        type_manager.get_owns_annotations(snapshot, self.clone())
     }
 
-    pub fn set_annotation(&self, type_manager: &TypeManager<impl WritableSnapshot>, annotation: OwnsAnnotation) {
+    pub fn set_annotation<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>, annotation: OwnsAnnotation
+    ) {
         match annotation {
-            OwnsAnnotation::Distinct(_) => type_manager.storage_set_edge_annotation_distinct(self.clone()),
+            OwnsAnnotation::Distinct(_) => type_manager.storage_set_edge_annotation_distinct(
+                snapshot,
+                self.clone()
+            ),
             OwnsAnnotation::Cardinality(cardinality) => {
-                type_manager.storage_set_edge_annotation_cardinality(self.clone(), cardinality)
+                type_manager.storage_set_edge_annotation_cardinality(snapshot, self.clone(), cardinality)
             }
         }
     }
 
-    pub fn delete_annotation(&self, type_manager: &TypeManager<impl WritableSnapshot>, annotation: OwnsAnnotation) {
+    pub fn delete_annotation<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>,
+        annotation: OwnsAnnotation
+    ) {
         match annotation {
-            OwnsAnnotation::Distinct(_) => type_manager.storage_delete_edge_annotation_distinct(self.clone()),
+            OwnsAnnotation::Distinct(_) => type_manager.storage_delete_edge_annotation_distinct(snapshot, self.clone()),
             OwnsAnnotation::Cardinality(_) => {
-                type_manager.storage_delete_edge_annotation_cardinality(self.clone())
+                type_manager.storage_delete_edge_annotation_cardinality(snapshot, self.clone())
             }
         }
     }
 
-    pub fn set_ordering(&self, type_manager: &TypeManager<impl WritableSnapshot>, ordering: Ordering) {
-        type_manager.storage_set_owns_ordering(self.clone().into_type_edge(), ordering)
+    pub fn set_ordering<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>,
+        ordering: Ordering
+    ) {
+        type_manager.storage_set_owns_ordering(snapshot, self.clone().into_type_edge(), ordering)
     }
 
-    pub fn get_ordering(
-        &self, type_manager: &TypeManager<impl ReadableSnapshot>
+    pub fn get_ordering<Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        type_manager: &TypeManager<Snapshot>
     ) -> Result<Ordering, ConceptReadError> {
-        type_manager.get_owns_ordering(self.clone().into_owned())
+        type_manager.get_owns_ordering(snapshot, self.clone().into_owned())
     }
 
     fn into_owned(self) -> Owns<'static> {

--- a/concept/type_/role_type.rs
+++ b/concept/type_/role_type.rs
@@ -56,74 +56,98 @@ impl<'a> TypeAPI<'a> for RoleType<'a> {
         self.vertex
     }
 
-    fn is_abstract(
-        &self, type_manager: &TypeManager<impl ReadableSnapshot>
+    fn is_abstract<Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        type_manager: &TypeManager<Snapshot>,
     ) -> Result<bool, ConceptReadError> {
-        let annotations = self.get_annotations(type_manager)?;
+        let annotations = self.get_annotations(snapshot, type_manager)?;
         Ok(annotations.contains(&RoleTypeAnnotation::Abstract(AnnotationAbstract::new())))
     }
 
-    fn delete(self, type_manager: &TypeManager<impl WritableSnapshot>) -> Result<(), ConceptWriteError> {
+    fn delete<Snapshot: WritableSnapshot>(
+        self,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>,
+    ) -> Result<(), ConceptWriteError> {
         todo!()
     }
 }
 
 impl<'a> RoleType<'a> {
-    pub fn is_root(&self, type_manager: &TypeManager<impl ReadableSnapshot>) -> Result<bool, ConceptReadError> {
-        type_manager.get_role_type_is_root(self.clone().into_owned())
-    }
-
-    pub fn get_label<'m>(
+    pub fn is_root<Snapshot: ReadableSnapshot>(
         &self,
-        type_manager: &'m TypeManager<impl ReadableSnapshot>,
-    ) -> Result<MaybeOwns<'m, Label<'static>>, ConceptReadError> {
-        type_manager.get_role_type_label(self.clone().into_owned())
+        snapshot: &Snapshot,
+        type_manager: &TypeManager<Snapshot>) -> Result<bool, ConceptReadError> {
+        type_manager.get_role_type_is_root(snapshot, self.clone().into_owned())
     }
 
-    fn set_name(&self, _type_manager: &TypeManager<impl WritableSnapshot>, _name: &str) {
+    pub fn get_label<'m, Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        type_manager: &'m TypeManager<Snapshot>,
+    ) -> Result<MaybeOwns<'m, Label<'static>>, ConceptReadError> {
+        type_manager.get_role_type_label(snapshot, self.clone().into_owned())
+    }
+
+    fn set_name<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &mut Snapshot,
+        _type_manager: &TypeManager<Snapshot>,
+        _name: &str,
+    ) {
         // // TODO: setLabel should fail is setting label on Root type
         // type_manager.set_storage_label(self.clone().into_owned(), label);
 
         todo!()
     }
 
-    pub fn get_supertype(
+    pub fn get_supertype<Snapshot: ReadableSnapshot>(
         &self,
-        type_manager: &TypeManager<impl ReadableSnapshot>,
+        snapshot: &Snapshot,
+        type_manager: &TypeManager<Snapshot>,
     ) -> Result<Option<RoleType<'_>>, ConceptReadError> {
-        type_manager.get_role_type_supertype(self.clone().into_owned())
+        type_manager.get_role_type_supertype(snapshot, self.clone().into_owned())
     }
 
-    pub fn set_supertype(&self, type_manager: &TypeManager<impl WritableSnapshot>, supertype: RoleType<'static>) -> Result<(), ConceptWriteError> {
-        type_manager.storage_set_supertype(self.clone().into_owned(), supertype);
+    pub fn set_supertype<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>, supertype: RoleType<'static>) -> Result<(), ConceptWriteError> {
+        type_manager.storage_set_supertype(snapshot, self.clone().into_owned(), supertype);
         Ok(())
     }
 
-    pub fn get_supertypes<'m>(
+    pub fn get_supertypes<'m, Snapshot: ReadableSnapshot>(
         &self,
-        type_manager: &'m TypeManager<impl ReadableSnapshot>,
+        snapshot: &Snapshot,
+        type_manager: &'m TypeManager<Snapshot>,
     ) -> Result<MaybeOwns<'m, Vec<RoleType<'static>>>, ConceptReadError> {
-        type_manager.get_role_type_supertypes(self.clone().into_owned())
+        type_manager.get_role_type_supertypes(snapshot, self.clone().into_owned())
     }
 
-    pub fn get_subtypes<'m>(
+    pub fn get_subtypes<'m, Snapshot: ReadableSnapshot>(
         &self,
-        type_manager: &'m TypeManager<impl ReadableSnapshot>,
+        snapshot: &Snapshot,
+        type_manager: &'m TypeManager<Snapshot>,
     ) -> Result<MaybeOwns<'m, Vec<RoleType<'static>>>, ConceptReadError> {
-        type_manager.get_role_type_subtypes(self.clone().into_owned())
+        type_manager.get_role_type_subtypes(snapshot, self.clone().into_owned())
     }
 
-    pub fn get_subtypes_transitive<'m>(
+    pub fn get_subtypes_transitive<'m, Snapshot: ReadableSnapshot>(
         &self,
-        type_manager: &'m TypeManager<impl ReadableSnapshot>,
+        snapshot: &Snapshot,
+        type_manager: &'m TypeManager<Snapshot>,
     ) -> Result<MaybeOwns<'m, Vec<RoleType<'static>>>, ConceptReadError> {
-        type_manager.get_role_type_subtypes_transitive(self.clone().into_owned())
+        type_manager.get_role_type_subtypes_transitive(snapshot, self.clone().into_owned())
     }
 
-    pub fn get_cardinality(
-        &self, type_manager: &TypeManager<impl ReadableSnapshot>,
+    pub fn get_cardinality<Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        type_manager: &TypeManager<Snapshot>,
     ) -> Result<AnnotationCardinality, ConceptReadError> {
-        let annotations = self.get_annotations(type_manager)?;
+        let annotations = self.get_annotations(snapshot, type_manager)?;
         let card: AnnotationCardinality = annotations.iter().filter_map(|annotation|
             match annotation {
                 RoleTypeAnnotation::Cardinality(card) => Some(card.clone()),
@@ -133,43 +157,54 @@ impl<'a> RoleType<'a> {
         Ok(card)
     }
 
-    pub fn get_annotations<'m>(
+    pub fn get_annotations<'m, Snapshot: ReadableSnapshot>(
         &self,
-        type_manager: &'m TypeManager<impl ReadableSnapshot>,
+        snapshot: &Snapshot,
+        type_manager: &'m TypeManager<Snapshot>,
     ) -> Result<MaybeOwns<'m, HashSet<RoleTypeAnnotation>>, ConceptReadError> {
-        type_manager.get_role_type_annotations(self.clone().into_owned())
+        type_manager.get_role_type_annotations(snapshot, self.clone().into_owned())
     }
 
-    pub fn set_annotation(
+    pub fn set_annotation<Snapshot: WritableSnapshot>(
         &self,
-        type_manager: &TypeManager<impl WritableSnapshot>,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>,
         annotation: RoleTypeAnnotation,
-    )  -> Result<(), ConceptWriteError>  {
+    ) -> Result<(), ConceptWriteError> {
         match annotation {
-            RoleTypeAnnotation::Abstract(_) => type_manager.storage_set_annotation_abstract(self.clone().into_owned()),
-            RoleTypeAnnotation::Distinct(_) => type_manager.storage_set_annotation_distinct(self.clone().into_owned()),
+            RoleTypeAnnotation::Abstract(_) => {
+                type_manager.storage_set_annotation_abstract(snapshot, self.clone().into_owned())
+            }
+            RoleTypeAnnotation::Distinct(_) => {
+                type_manager.storage_set_annotation_distinct(snapshot, self.clone().into_owned())
+            }
             RoleTypeAnnotation::Cardinality(cardinality) => {
-                type_manager.storage_set_annotation_cardinality(self.clone().into_owned(), cardinality)
+                type_manager.storage_set_annotation_cardinality(snapshot, self.clone().into_owned(), cardinality)
             }
         };
         Ok(())
     }
 
-    fn delete_annotation(&self, type_manager: &TypeManager<impl WritableSnapshot>, annotation: RoleTypeAnnotation) {
+    fn delete_annotation<Snapshot: WritableSnapshot>(
+        &self,
+        snapshot: &mut Snapshot,
+        type_manager: &TypeManager<Snapshot>,
+        annotation: RoleTypeAnnotation,
+    ) {
         match annotation {
             RoleTypeAnnotation::Abstract(_) => {
-                type_manager.storage_delete_annotation_abstract(self.clone().into_owned())
+                type_manager.storage_delete_annotation_abstract(snapshot, self.clone().into_owned())
             }
             RoleTypeAnnotation::Distinct(_) => {
-                type_manager.storage_delete_annotation_distinct(self.clone().into_owned())
+                type_manager.storage_delete_annotation_distinct(snapshot, self.clone().into_owned())
             }
             RoleTypeAnnotation::Cardinality(_) => {
-                type_manager.storage_delete_annotation_cardinality(self.clone().into_owned())
+                type_manager.storage_delete_annotation_cardinality(snapshot, self.clone().into_owned())
             }
         }
     }
 
-    fn get_relates(&self, _type_manager: &TypeManager<impl ReadableSnapshot>) -> Relates<'static> {
+    fn get_relates<Snapshot: ReadableSnapshot>(&self, _type_manager: &TypeManager<Snapshot>) -> Relates<'static> {
         todo!()
     }
 
@@ -180,9 +215,10 @@ impl<'a> RoleType<'a> {
 
 // --- Played API ---
 impl<'a> RoleType<'a> {
-    fn get_plays<'m>(
+    fn get_plays<'m, Snapshot: ReadableSnapshot>(
         &self,
-        _type_manager: &'m TypeManager<impl ReadableSnapshot>,
+        snapshot: &Snapshot,
+        _type_manager: &'m TypeManager<Snapshot>,
     ) -> MaybeOwns<'m, HashSet<Plays<'static>>> {
         todo!()
     }

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -5,6 +5,7 @@
  */
 
 use std::{collections::HashSet, hash::Hash, sync::Arc};
+use std::marker::PhantomData;
 
 use bytes::{byte_array::ByteArray, Bytes};
 use durability::DurabilityService;
@@ -36,6 +37,7 @@ use storage::{
     snapshot::{CommittableSnapshot, ReadableSnapshot, WritableSnapshot},
     MVCCStorage,
 };
+use storage::snapshot::WriteSnapshot;
 
 use crate::{
     error::{ConceptReadError, ConceptWriteError},
@@ -60,9 +62,9 @@ use crate::{
 pub(crate) const RELATION_INDEX_THRESHOLD: u64 = 8;
 
 pub struct TypeManager<Snapshot> {
-    snapshot: Arc<Snapshot>,
     vertex_generator: Arc<TypeVertexGenerator>,
     type_cache: Option<Arc<TypeCache>>,
+    snapshot: PhantomData<Snapshot>,
 }
 
 impl<Snapshot> TypeManager<Snapshot> {
@@ -70,25 +72,24 @@ impl<Snapshot> TypeManager<Snapshot> {
         storage: Arc<MVCCStorage<D>>,
         vertex_generator: Arc<TypeVertexGenerator>,
     ) -> Result<(), ConceptWriteError> {
-        let snapshot = Arc::new(storage.clone().open_snapshot_write());
+        let mut snapshot = storage.clone().open_snapshot_write();
         {
-            let type_manager = TypeManager::new(snapshot.clone(), vertex_generator.clone(), None);
-            let root_entity = type_manager.create_entity_type(&Kind::Entity.root_label(), true)?;
+            let type_manager = TypeManager::<WriteSnapshot<D>>::new(vertex_generator.clone(), None);
+            let root_entity = type_manager.create_entity_type(&mut snapshot, &Kind::Entity.root_label(), true)?;
             root_entity.set_annotation(&type_manager, EntityTypeAnnotation::Abstract(AnnotationAbstract::new()))?;
-            let root_relation = type_manager.create_relation_type(&Kind::Relation.root_label(), true)?;
+            let root_relation = type_manager.create_relation_type(&mut snapshot, &Kind::Relation.root_label(), true)?;
             root_relation.set_annotation(&type_manager, RelationTypeAnnotation::Abstract(AnnotationAbstract::new()))?;
             let root_role = type_manager.create_role_type(
-                &Kind::Role.root_label(),
-                root_relation.clone(),
-                true,
-                Ordering::Unordered,
+                &mut snapshot, &Kind::Role.root_label(), root_relation.clone(), true, Ordering::Unordered
+            ,
             )?;
             root_role.set_annotation(&type_manager, RoleTypeAnnotation::Abstract(AnnotationAbstract::new()))?;
-            let root_attribute = type_manager.create_attribute_type(&Kind::Attribute.root_label(), true)?;
+            let root_attribute = type_manager.create_attribute_type(&mut snapshot, &Kind::Attribute.root_label(), true)?;
             root_attribute
                 .set_annotation(&type_manager, AttributeTypeAnnotation::Abstract(AnnotationAbstract::new()))?;
         }
-        Arc::into_inner(snapshot).unwrap().commit().unwrap();
+        // TODO: pass error up
+        snapshot.commit().unwrap();
         Ok(())
     }
 
@@ -98,20 +99,18 @@ impl<Snapshot> TypeManager<Snapshot> {
     }
 }
 
-// TODO:
-//   if we drop/close without committing, then we need to release all the IDs taken back to the IDGenerator
-//   this is only applicable for type manager where we can only have 1 concurrent txn and IDs are precious
-
 macro_rules! get_type_methods {
     ($(
         fn $method_name:ident() -> $output_type:ident = $cache_method:ident | $new_vertex_method:ident;
     )*) => {
         $(
-            pub fn $method_name(&self, label: &Label<'_>) -> Result<Option<$output_type<'static>>, ConceptReadError> {
+            pub fn $method_name(
+                &self, snapshot: &Snapshot, label: &Label<'_>
+            ) -> Result<Option<$output_type<'static>>, ConceptReadError> {
                 if let Some(cache) = &self.type_cache {
                     Ok(cache.$cache_method(label))
                 } else {
-                    TypeReader::get_labelled_type::<$output_type<'static>>(self.snapshot.as_ref(), label)
+                    TypeReader::get_labelled_type::<$output_type<'static>>(snapshot, label)
                 }
             }
         )*
@@ -123,11 +122,13 @@ macro_rules! get_supertype_methods {
         fn $method_name:ident() -> $type_:ident = $cache_method:ident;
     )*) => {
         $(
-            pub(crate) fn $method_name(&self, type_: $type_<'static>) -> Result<Option<$type_<'static>>, ConceptReadError> {
+            pub(crate) fn $method_name(
+                &self, snapshot: &Snapshot, type_: $type_<'static>
+            ) -> Result<Option<$type_<'static>>, ConceptReadError> {
                 if let Some(cache) = &self.type_cache {
                     Ok(cache.$cache_method(type_))
                 } else {
-                    TypeReader::get_supertype(self.snapshot.as_ref(), type_)
+                    TypeReader::get_supertype(snapshot, type_)
                 }
             }
         )*
@@ -140,11 +141,13 @@ macro_rules! get_supertypes_methods {
     )*) => {
         $(
             // WARN: supertypes currently do NOT include themselves
-            pub(crate) fn $method_name(&self, type_: $type_<'static>) -> Result<MaybeOwns<'_, Vec<$type_<'static>>>, ConceptReadError> {
+            pub(crate) fn $method_name(
+                &self, snapshot: &Snapshot, type_: $type_<'static>
+            ) -> Result<MaybeOwns<'_, Vec<$type_<'static>>>, ConceptReadError> {
                 if let Some(cache) = &self.type_cache {
                     Ok(MaybeOwns::Borrowed(cache.$cache_method(type_)))
                 } else {
-                    let supertypes = TypeReader::get_supertypes_transitive(self.snapshot.as_ref(), type_)?;
+                    let supertypes = TypeReader::get_supertypes_transitive(snapshot, type_)?;
                     Ok(MaybeOwns::Owned(supertypes))
                 }
             }
@@ -157,11 +160,13 @@ macro_rules! get_subtypes_methods {
         fn $method_name:ident() -> $type_:ident = $cache_method:ident;
     )*) => {
         $(
-            pub(crate) fn $method_name(&self, type_: $type_<'static>) -> Result<MaybeOwns<'_, Vec<$type_<'static>>>, ConceptReadError> {
+            pub(crate) fn $method_name(
+                &self, snapshot: &Snapshot, type_: $type_<'static>
+            ) -> Result<MaybeOwns<'_, Vec<$type_<'static>>>, ConceptReadError> {
                 if let Some(cache) = &self.type_cache {
                     Ok(MaybeOwns::Borrowed(cache.$cache_method(type_)))
                 } else {
-                    let subtypes = TypeReader::get_subtypes(self.snapshot.as_ref(), type_)?;
+                    let subtypes = TypeReader::get_subtypes(snapshot, type_)?;
                     Ok(MaybeOwns::Owned(subtypes))
                 }
             }
@@ -175,11 +180,13 @@ macro_rules! get_subtypes_transitive_methods {
     )*) => {
         $(
             // WARN: supertypes currently do NOT include themselves
-            pub(crate) fn $method_name(&self, type_: $type_<'static>) -> Result<MaybeOwns<'_, Vec<$type_<'static>>>, ConceptReadError> {
+            pub(crate) fn $method_name(
+                &self, snapshot: &Snapshot, type_: $type_<'static>
+            ) -> Result<MaybeOwns<'_, Vec<$type_<'static>>>, ConceptReadError> {
                 if let Some(cache) = &self.type_cache {
                     Ok(MaybeOwns::Borrowed(cache.$cache_method(type_)))
                 } else {
-                    let subtypes = TypeReader::get_subtypes_transitive(self.snapshot.as_ref(), type_)?;
+                    let subtypes = TypeReader::get_subtypes_transitive(snapshot, type_)?;
                     Ok(MaybeOwns::Owned(subtypes))
                 }
             }
@@ -192,11 +199,13 @@ macro_rules! get_type_is_root_methods {
         fn $method_name:ident() -> $type_:ident = $cache_method:ident | $base_variant:expr;
     )*) => {
         $(
-            pub(crate) fn $method_name(&self, type_: $type_<'static>) -> Result<bool, ConceptReadError> {
+            pub(crate) fn $method_name(
+                &self, snapshot: &Snapshot, type_: $type_<'static>
+            ) -> Result<bool, ConceptReadError> {
                 if let Some(cache) = &self.type_cache {
                     Ok(cache.$cache_method(type_))
                 } else {
-                    let type_label = TypeReader::get_label(self.snapshot.as_ref(), type_)?.unwrap();
+                    let type_label = TypeReader::get_label(snapshot, type_)?.unwrap();
                     Ok(Self::check_type_is_root(&type_label, $base_variant))
                 }
             }
@@ -209,11 +218,13 @@ macro_rules! get_type_label_methods {
         fn $method_name:ident() -> $type_:ident = $cache_method:ident;
     )*) => {
         $(
-            pub(crate) fn $method_name(&self, type_: $type_<'static>) -> Result<MaybeOwns<'_, Label<'static>>, ConceptReadError> {
+            pub(crate) fn $method_name(
+                &self, snapshot: &Snapshot, type_: $type_<'static>
+            ) -> Result<MaybeOwns<'_, Label<'static>>, ConceptReadError> {
                 if let Some(cache) = &self.type_cache {
                     Ok(MaybeOwns::Borrowed(cache.$cache_method(type_)))
                 } else {
-                    Ok(MaybeOwns::Owned(TypeReader::get_label(self.snapshot.as_ref(), type_)?.unwrap()))
+                    Ok(MaybeOwns::Owned(TypeReader::get_label(snapshot, type_)?.unwrap()))
                 }
             }
         )*
@@ -226,13 +237,13 @@ macro_rules! get_type_annotations {
     )*) => {
         $(
             pub(crate) fn $method_name(
-                &self, type_: $type_<'static>
+                &self, snapshot: &Snapshot, type_: $type_<'static>
             ) -> Result<MaybeOwns<'_, HashSet<$annotation_type>>, ConceptReadError> {
                  if let Some(cache) = &self.type_cache {
                     Ok(MaybeOwns::Borrowed(cache.$cache_method(type_)))
                 } else {
                     let mut annotations: HashSet<$annotation_type> = HashSet::new();
-                    let annotations = TypeReader::get_type_annotations(self.snapshot.as_ref(), type_)?
+                    let annotations = TypeReader::get_type_annotations(snapshot, type_)?
                         .into_iter()
                         .map(|annotation| $annotation_type::from(annotation))
                         .collect();
@@ -249,12 +260,12 @@ where
     '_s: 'static,
 {
     pub fn new(
-        snapshot: Arc<Snapshot>,
         vertex_generator: Arc<TypeVertexGenerator>,
         schema_cache: Option<Arc<TypeCache>>,
     ) -> Self {
-        TypeManager { snapshot, vertex_generator, type_cache: schema_cache }
+        TypeManager { vertex_generator, type_cache: schema_cache, snapshot: PhantomData::default() }
     }
+
     pub(crate) fn check_type_is_root(type_label: &Label<'_>, kind: Kind) -> bool {
         type_label == &kind.root_label()
     }
@@ -310,36 +321,39 @@ where
 
     pub(crate) fn get_entity_type_owns(
         &self,
+        snapshot: &Snapshot,
         entity_type: EntityType<'static>,
     ) -> Result<MaybeOwns<'_, HashSet<Owns<'static>>>, ConceptReadError> {
         if let Some(cache) = &self.type_cache {
             Ok(MaybeOwns::Borrowed(cache.get_entity_type_owns(entity_type)))
         } else {
-            let owns = TypeReader::get_owns(self.snapshot.as_ref(), entity_type.clone())?;
+            let owns = TypeReader::get_owns(snapshot, entity_type.clone())?;
             Ok(MaybeOwns::Owned(owns))
         }
     }
 
     pub(crate) fn get_relation_type_owns(
         &self,
+        snapshot: &Snapshot,
         relation_type: RelationType<'static>,
     ) -> Result<MaybeOwns<'_, HashSet<Owns<'static>>>, ConceptReadError> {
         if let Some(cache) = &self.type_cache {
             Ok(MaybeOwns::Borrowed(cache.get_relation_type_owns(relation_type)))
         } else {
-            let owns = TypeReader::get_owns(self.snapshot.as_ref(), relation_type.clone())?;
+            let owns = TypeReader::get_owns(snapshot, relation_type.clone())?;
             Ok(MaybeOwns::Owned(owns))
         }
     }
 
     pub(crate) fn get_relation_type_relates(
         &self,
+        snapshot: &Snapshot,
         relation_type: RelationType<'static>,
     ) -> Result<MaybeOwns<'_, HashSet<Relates<'static>>>, ConceptReadError> {
         if let Some(cache) = &self.type_cache {
             Ok(MaybeOwns::Borrowed(cache.get_relation_type_relates(relation_type)))
         } else {
-            let relates = TypeReader::get_relates(self.snapshot.as_ref(), relation_type.clone())?;
+            let relates = TypeReader::get_relates(snapshot, relation_type.clone())?;
             Ok(MaybeOwns::Owned(relates))
         }
     }
@@ -360,24 +374,26 @@ where
 
     pub(crate) fn get_entity_type_plays<'this>(
         &'this self,
+        snapshot: &Snapshot,
         entity_type: EntityType<'static>,
     ) -> Result<MaybeOwns<'this, HashSet<Plays<'static>>>, ConceptReadError> {
         if let Some(cache) = &self.type_cache {
             Ok(MaybeOwns::Borrowed(cache.get_entity_type_plays(entity_type)))
         } else {
-            let plays = TypeReader::get_plays(self.snapshot.as_ref(), entity_type.clone())?;
+            let plays = TypeReader::get_plays(snapshot, entity_type.clone())?;
             Ok(MaybeOwns::Owned(plays))
         }
     }
 
     pub(crate) fn get_attribute_type_value_type(
         &self,
+        snapshot: &Snapshot,
         attribute_type: AttributeType<'static>,
     ) -> Result<Option<ValueType>, ConceptReadError> {
         if let Some(cache) = &self.type_cache {
             Ok(cache.get_attribute_type_value_type(attribute_type))
         } else {
-            TypeReader::get_value_type(self.snapshot.as_ref(), attribute_type)
+            TypeReader::get_value_type(snapshot, attribute_type)
         }
     }
 
@@ -390,13 +406,14 @@ where
 
     pub(crate) fn get_owns_annotations<'this>(
         &'this self,
+        snapshot: &Snapshot,
         owns: Owns<'this>,
     ) -> Result<MaybeOwns<'this, HashSet<OwnsAnnotation>>, ConceptReadError> {
         if let Some(cache) = &self.type_cache {
             Ok(MaybeOwns::Borrowed(cache.get_owns_annotations(owns)))
         } else {
             let annotations: HashSet<OwnsAnnotation> =
-                TypeReader::get_type_edge_annotations(self.snapshot.as_ref(), owns)?
+                TypeReader::get_type_edge_annotations(snapshot, owns)?
                     .into_iter()
                     .map(|annotation| OwnsAnnotation::from(annotation))
                     .collect();
@@ -404,11 +421,11 @@ where
         }
     }
 
-    pub(crate) fn get_owns_ordering(&self, owns: Owns<'_s>) -> Result<Ordering, ConceptReadError> {
+    pub(crate) fn get_owns_ordering(&self, snapshot: &Snapshot, owns: Owns<'_s>) -> Result<Ordering, ConceptReadError> {
         if let Some(cache) = &self.type_cache {
             Ok(cache.get_owns_ordering(owns))
         } else {
-            TypeReader::get_type_edge_ordering(self.snapshot.as_ref(), owns)
+            TypeReader::get_type_edge_ordering(snapshot, owns)
         }
     }
 
@@ -421,42 +438,42 @@ where
 // TODO: Move this somewhere too?
 impl<Snapshot: WritableSnapshot> TypeManager<Snapshot> {
     pub fn create_entity_type(
-        &self,
-        label: &Label<'_>,
+        &self, snapshot: &mut Snapshot, label: &Label<'_>,
         is_root: bool,
     ) -> Result<EntityType<'static>, ConceptWriteError> {
         // TODO: validate type doesn't exist already
         let type_vertex = self
             .vertex_generator
-            .create_entity_type(self.snapshot.as_ref())
+            .create_entity_type(snapshot)
             .map_err(|err| ConceptWriteError::Encoding { source: err })?;
         let entity = EntityType::new(type_vertex);
-        self.storage_set_label(entity.clone(), label);
+        self.storage_set_label(snapshot, entity.clone(), label);
         if !is_root {
             self.storage_set_supertype(
+                snapshot,
                 entity.clone(),
-                self.get_entity_type(&Kind::Entity.root_label()).unwrap().unwrap(),
+                self.get_entity_type(snapshot, &Kind::Entity.root_label()).unwrap().unwrap(),
             );
         }
         Ok(entity)
     }
 
     pub fn create_relation_type(
-        &self,
-        label: &Label<'_>,
+        &self, snapshot: &mut Snapshot, label: &Label<'_>,
         is_root: bool,
     ) -> Result<RelationType<'static>, ConceptWriteError> {
         // TODO: validate type doesn't exist already
         let type_vertex = self
             .vertex_generator
-            .create_relation_type(self.snapshot.as_ref())
+            .create_relation_type(snapshot)
             .map_err(|err| ConceptWriteError::Encoding { source: err })?;
         let relation = RelationType::new(type_vertex);
-        self.storage_set_label(relation.clone(), label);
+        self.storage_set_label(snapshot, relation.clone(), label);
         if !is_root {
             self.storage_set_supertype(
+                snapshot,
                 relation.clone(),
-                self.get_relation_type(&Kind::Relation.root_label()).unwrap().unwrap(),
+                self.get_relation_type(snapshot, &Kind::Relation.root_label()).unwrap().unwrap(),
             );
         }
         Ok(relation)
@@ -464,6 +481,7 @@ impl<Snapshot: WritableSnapshot> TypeManager<Snapshot> {
 
     pub(crate) fn create_role_type(
         &self,
+        snapshot: &mut Snapshot,
         label: &Label<'_>,
         relation_type: RelationType<'static>,
         is_root: bool,
@@ -472,253 +490,261 @@ impl<Snapshot: WritableSnapshot> TypeManager<Snapshot> {
         // TODO: validate type doesn't exist already
         let type_vertex = self
             .vertex_generator
-            .create_role_type(self.snapshot.as_ref())
+            .create_role_type(snapshot)
             .map_err(|err| ConceptWriteError::Encoding { source: err })?;
         let role = RoleType::new(type_vertex);
-        self.storage_set_label(role.clone(), label);
-        self.storage_set_relates(relation_type, role.clone());
-        self.storage_set_role_ordering(role.clone(), ordering);
+        self.storage_set_label(snapshot, role.clone(), label);
+        self.storage_set_relates(snapshot, relation_type, role.clone());
+        self.storage_set_role_ordering(snapshot, role.clone(), ordering);
         if !is_root {
-            self.storage_set_supertype(role.clone(), self.get_role_type(&Kind::Role.root_label()).unwrap().unwrap());
+            self.storage_set_supertype(
+                snapshot, role.clone(), self.get_role_type(snapshot, &Kind::Role.root_label()).unwrap().unwrap(),
+            );
         }
         Ok(role)
     }
 
     pub fn create_attribute_type(
-        &self,
-        label: &Label<'_>,
+        &self, snapshot: &mut Snapshot, label: &Label<'_>,
         is_root: bool,
     ) -> Result<AttributeType<'static>, ConceptWriteError> {
         // TODO: validate type doesn't exist already
         let type_vertex = self
             .vertex_generator
-            .create_attribute_type(self.snapshot.as_ref())
+            .create_attribute_type(snapshot)
             .map_err(|err| ConceptWriteError::Encoding { source: err })?;
         let attribute_type = AttributeType::new(type_vertex);
-        self.storage_set_label(attribute_type.clone(), label);
+        self.storage_set_label(snapshot, attribute_type.clone(), label);
         if !is_root {
             self.storage_set_supertype(
+                snapshot,
                 attribute_type.clone(),
-                self.get_attribute_type(&Kind::Attribute.root_label()).unwrap().unwrap(),
+                self.get_attribute_type(snapshot, &Kind::Attribute.root_label()).unwrap().unwrap(),
             );
         }
         Ok(attribute_type)
     }
 
-    pub(crate) fn delete_entity_type(&self, entity_type: EntityType<'_>) {
+    pub(crate) fn delete_entity_type(&self, snapshot: &mut Snapshot, entity_type: EntityType<'_>) {
         let key = entity_type.into_vertex().into_storage_key().into_owned_array();
         todo!("Do we need to lock?");
-        self.snapshot.delete(key)
+        snapshot.delete(key)
     }
 
-    pub(crate) fn delete_relation_type(&self, relation_type: RelationType<'_>) {
+    pub(crate) fn delete_relation_type(&self, snapshot: &mut Snapshot, relation_type: RelationType<'_>) {
         let key = relation_type.into_vertex().into_storage_key().into_owned_array();
         todo!("Do we need to lock?");
-        self.snapshot.delete(key)
+        snapshot.delete(key)
     }
 
-    pub(crate) fn delete_attribute_type(&self, attribute_type: AttributeType<'_>) {
+    pub(crate) fn delete_attribute_type(&self, snapshot: &mut Snapshot, attribute_type: AttributeType<'_>) {
         let key = attribute_type.into_vertex().into_storage_key().into_owned_array();
         todo!("Do we need to lock?");
-        self.snapshot.delete(key);
+        snapshot.delete(key);
     }
 
-    pub(crate) fn delete_role_type(&self, role_type: RoleType<'_>) {
+    pub(crate) fn delete_role_type(&self, snapshot: &mut Snapshot, role_type: RoleType<'_>) {
         let key = role_type.into_vertex().into_storage_key().into_owned_array();
         todo!("Do we need to lock?");
-        self.snapshot.delete(key);
+        snapshot.delete(key);
     }
 
-    pub(crate) fn storage_set_label(&self, owner: impl TypeAPI<'static>, label: &Label<'_>) {
-        self.storage_may_delete_label(owner.clone());
+    pub(crate) fn storage_set_label(&self, snapshot: &mut Snapshot, owner: impl TypeAPI<'static>, label: &Label<'_>) {
+        self.storage_may_delete_label(snapshot, owner.clone());
 
         let vertex_to_label_key = build_property_type_label(owner.clone().into_vertex());
         let label_value = ByteArray::from(label.scoped_name().bytes());
-        self.snapshot.as_ref().put_val(vertex_to_label_key.into_storage_key().into_owned_array(), label_value);
+        snapshot.put_val(vertex_to_label_key.into_storage_key().into_owned_array(), label_value);
 
         let label_to_vertex_key = LabelToTypeVertexIndex::build(label);
         let vertex_value = ByteArray::from(owner.into_vertex().bytes());
-        self.snapshot.as_ref().put_val(label_to_vertex_key.into_storage_key().into_owned_array(), vertex_value);
+        snapshot.put_val(label_to_vertex_key.into_storage_key().into_owned_array(), vertex_value);
     }
 
-    fn storage_may_delete_label(&self, owner: impl TypeAPI<'static>) {
-        let existing_label = TypeReader::get_label(self.snapshot.as_ref(), owner.clone()).unwrap();
+    fn storage_may_delete_label(&self, snapshot: &mut Snapshot, owner: impl TypeAPI<'static>) {
+        let existing_label = TypeReader::get_label(snapshot, owner.clone()).unwrap();
         if let Some(label) = existing_label {
             let vertex_to_label_key = build_property_type_label(owner.into_vertex());
-            self.snapshot.as_ref().delete(vertex_to_label_key.into_storage_key().into_owned_array());
+            snapshot.delete(vertex_to_label_key.into_storage_key().into_owned_array());
             let label_to_vertex_key = LabelToTypeVertexIndex::build(&label);
-            self.snapshot.as_ref().delete(label_to_vertex_key.into_storage_key().into_owned_array());
+            snapshot.delete(label_to_vertex_key.into_storage_key().into_owned_array());
         }
     }
 
-    fn storage_set_role_ordering(&self, role: RoleType<'_>, ordering: Ordering) {
-        self.snapshot.as_ref().put_val(
+    fn storage_set_role_ordering(&self, snapshot: &mut Snapshot, role: RoleType<'_>, ordering: Ordering) {
+        snapshot.put_val(
             build_property_type_ordering(role.into_vertex()).into_storage_key().into_owned_array(),
             ByteArray::boxed(serialise_ordering(ordering)),
         )
     }
 
-    pub(crate) fn storage_set_supertype<K: TypeAPI<'static>>(&self, subtype: K, supertype: K) {
-        self.storage_may_delete_supertype(subtype.clone());
+    pub(crate) fn storage_set_supertype<K: TypeAPI<'static>>(&self, snapshot: &mut Snapshot, subtype: K, supertype: K) {
+        self.storage_may_delete_supertype(snapshot, subtype.clone());
         let sub = build_edge_sub(subtype.clone().into_vertex(), supertype.clone().into_vertex());
-        self.snapshot.as_ref().put(sub.into_storage_key().into_owned_array());
+        snapshot.put(sub.into_storage_key().into_owned_array());
         let sub_reverse = build_edge_sub_reverse(supertype.into_vertex(), subtype.into_vertex());
-        self.snapshot.as_ref().put(sub_reverse.into_storage_key().into_owned_array());
+        snapshot.put(sub_reverse.into_storage_key().into_owned_array());
     }
 
-    fn storage_may_delete_supertype(&self, subtype: impl TypeAPI<'static>) {
+    fn storage_may_delete_supertype(&self, snapshot: &mut Snapshot, subtype: impl TypeAPI<'static>) {
         let supertype_vertex =
-            TypeReader::get_supertype_vertex(self.snapshot.as_ref(), subtype.clone().into_vertex()).unwrap();
+            TypeReader::get_supertype_vertex(snapshot, subtype.clone().into_vertex()).unwrap();
         if let Some(supertype) = supertype_vertex {
             let sub = build_edge_sub(subtype.clone().into_vertex(), supertype.clone());
-            self.snapshot.as_ref().delete(sub.into_storage_key().into_owned_array());
+            snapshot.delete(sub.into_storage_key().into_owned_array());
             let sub_reverse = build_edge_sub_reverse(supertype, subtype.into_vertex());
-            self.snapshot.as_ref().delete(sub_reverse.into_storage_key().into_owned_array());
+            snapshot.delete(sub_reverse.into_storage_key().into_owned_array());
         }
     }
 
-    pub(crate) fn storage_set_owns(
-        &self,
-        owner: impl ObjectTypeAPI<'static>,
+    pub(crate) fn storage_set_owns(&self, snapshot: &mut Snapshot, owner: impl ObjectTypeAPI<'static>,
         attribute: AttributeType<'static>,
         ordering: Ordering,
     ) {
         let owns = build_edge_owns(owner.clone().into_vertex(), attribute.clone().into_vertex());
-        self.snapshot.as_ref().put(owns.clone().into_storage_key().into_owned_array());
+        snapshot.put(owns.clone().into_storage_key().into_owned_array());
         let owns_reverse = build_edge_owns_reverse(attribute.into_vertex(), owner.into_vertex());
-        self.snapshot.as_ref().put(owns_reverse.into_storage_key().into_owned_array());
-        self.storage_set_owns_ordering(owns, ordering);
+        snapshot.put(owns_reverse.into_storage_key().into_owned_array());
+        self.storage_set_owns_ordering(snapshot, owns, ordering);
     }
 
-    pub(crate) fn storage_set_owns_ordering(&self, owns_edge: TypeEdge<'_>, ordering: Ordering) {
+    pub(crate) fn storage_set_owns_ordering(&self, snapshot: &mut Snapshot, owns_edge: TypeEdge<'_>, ordering: Ordering) {
         debug_assert_eq!(owns_edge.prefix(), Prefix::EdgeOwns);
-        self.snapshot.as_ref().put_val(
+        snapshot.put_val(
             build_property_type_edge_ordering(owns_edge).into_storage_key().into_owned_array(),
             ByteArray::boxed(serialise_ordering(ordering)),
         )
     }
 
-    pub(crate) fn storage_delete_owns(&self, owner: impl ObjectTypeAPI<'static>, attribute: AttributeType<'static>) {
+    pub(crate) fn storage_delete_owns(&self, snapshot: &mut Snapshot, owner: impl ObjectTypeAPI<'static>, attribute: AttributeType<'static>) {
         let owns_edge = build_edge_owns(owner.clone().into_vertex(), attribute.clone().into_vertex());
-        self.snapshot.as_ref().delete(owns_edge.as_storage_key().into_owned_array());
+        snapshot.delete(owns_edge.as_storage_key().into_owned_array());
         let owns_reverse = build_edge_owns_reverse(attribute.into_vertex(), owner.into_vertex());
-        self.snapshot.as_ref().delete(owns_reverse.into_storage_key().into_owned_array());
-        self.storage_delete_owns_ordering(owns_edge);
+        snapshot.delete(owns_reverse.into_storage_key().into_owned_array());
+        self.storage_delete_owns_ordering(snapshot, owns_edge);
     }
 
-    pub(crate) fn storage_delete_owns_ordering(&self, owns_edge: TypeEdge<'_>) {
+    pub(crate) fn storage_delete_owns_ordering(&self, snapshot: &mut Snapshot, owns_edge: TypeEdge<'_>) {
         debug_assert_eq!(owns_edge.prefix(), Prefix::EdgeOwns);
-        self.snapshot
-            .as_ref()
-            .delete(build_property_type_edge_ordering(owns_edge).into_storage_key().into_owned_array())
+        snapshot.delete(
+            build_property_type_edge_ordering(owns_edge).into_storage_key().into_owned_array(),
+        )
     }
-    pub(crate) fn storage_set_plays(&self, player: impl ObjectTypeAPI<'static>, role: RoleType<'static>) {
+    pub(crate) fn storage_set_plays(&self, snapshot: &mut Snapshot, player: impl ObjectTypeAPI<'static>, role: RoleType<'static>) {
         let plays = build_edge_plays(player.clone().into_vertex(), role.clone().into_vertex());
-        self.snapshot.as_ref().put(plays.into_storage_key().into_owned_array());
+        snapshot.put(plays.into_storage_key().into_owned_array());
         let plays_reverse = build_edge_plays_reverse(role.into_vertex(), player.into_vertex());
-        self.snapshot.as_ref().put(plays_reverse.into_storage_key().into_owned_array());
+        snapshot.put(plays_reverse.into_storage_key().into_owned_array());
     }
 
-    pub(crate) fn storage_delete_plays(&self, player: impl ObjectTypeAPI<'static>, role: RoleType<'static>) {
+    pub(crate) fn storage_delete_plays(&self, snapshot: &mut Snapshot, player: impl ObjectTypeAPI<'static>, role: RoleType<'static>) {
         let plays = build_edge_plays(player.clone().into_vertex(), role.clone().into_vertex());
-        self.snapshot.as_ref().delete(plays.into_storage_key().into_owned_array());
+        snapshot.delete(plays.into_storage_key().into_owned_array());
         let plays_reverse = build_edge_plays_reverse(role.into_vertex(), player.into_vertex());
-        self.snapshot.as_ref().delete(plays_reverse.into_storage_key().into_owned_array());
+        snapshot.delete(plays_reverse.into_storage_key().into_owned_array());
     }
 
-    pub(crate) fn storage_set_relates(&self, relation: RelationType<'static>, role: RoleType<'static>) {
+    pub(crate) fn storage_set_relates(&self, snapshot: &mut Snapshot, relation: RelationType<'static>, role: RoleType<'static>) {
         let relates = build_edge_relates(relation.clone().into_vertex(), role.clone().into_vertex());
-        self.snapshot.as_ref().put(relates.into_storage_key().into_owned_array());
+        snapshot.put(relates.into_storage_key().into_owned_array());
         let relates_reverse = build_edge_relates_reverse(role.into_vertex(), relation.into_vertex());
-        self.snapshot.as_ref().put(relates_reverse.into_storage_key().into_owned_array());
+        snapshot.put(relates_reverse.into_storage_key().into_owned_array());
     }
 
-    pub(crate) fn storage_delete_relates(&self, relation: RelationType<'static>, role: RoleType<'static>) {
+    pub(crate) fn storage_delete_relates(&self, snapshot: &mut Snapshot, relation: RelationType<'static>, role: RoleType<'static>) {
         let relates = build_edge_relates(relation.clone().into_vertex(), role.clone().into_vertex());
-        self.snapshot.as_ref().delete(relates.into_storage_key().into_owned_array());
+        snapshot.delete(relates.into_storage_key().into_owned_array());
         let relates_reverse = build_edge_relates_reverse(role.into_vertex(), relation.into_vertex());
-        self.snapshot.as_ref().delete(relates_reverse.into_storage_key().into_owned_array());
+        snapshot.delete(relates_reverse.into_storage_key().into_owned_array());
     }
 
-    pub(crate) fn storage_set_value_type(&self, attribute: AttributeType<'static>, value_type: ValueType) {
+    pub(crate) fn storage_set_value_type(&self, snapshot: &mut Snapshot, attribute: AttributeType<'static>, value_type: ValueType) {
         let property_key =
             build_property_type_value_type(attribute.into_vertex()).into_storage_key().into_owned_array();
         let property_value = ByteArray::copy(&value_type.value_type_id().bytes());
-        self.snapshot.as_ref().put_val(property_key, property_value);
+        snapshot.put_val(property_key, property_value);
     }
 
-    pub(crate) fn storage_set_annotation_abstract(&self, type_: impl TypeAPI<'static>) {
+    pub(crate) fn storage_set_annotation_abstract(&self, snapshot: &mut Snapshot, type_: impl TypeAPI<'static>) {
         let annotation_property = build_property_type_annotation_abstract(type_.into_vertex());
-        self.snapshot.as_ref().put(annotation_property.into_storage_key().into_owned_array());
+        snapshot.put(annotation_property.into_storage_key().into_owned_array());
     }
 
-    pub(crate) fn storage_delete_annotation_abstract(&self, type_: impl TypeAPI<'static>) {
+    pub(crate) fn storage_delete_annotation_abstract(&self, snapshot: &mut Snapshot, type_: impl TypeAPI<'static>) {
         let annotation_property = build_property_type_annotation_abstract(type_.into_vertex());
-        self.snapshot.as_ref().delete(annotation_property.into_storage_key().into_owned_array());
+        snapshot.delete(annotation_property.into_storage_key().into_owned_array());
     }
 
-    pub(crate) fn storage_set_annotation_distinct(&self, type_: impl TypeAPI<'static>) {
+    pub(crate) fn storage_set_annotation_distinct(&self, snapshot: &mut Snapshot, type_: impl TypeAPI<'static>) {
         let annotation_property = build_property_type_annotation_distinct(type_.into_vertex());
-        self.snapshot.as_ref().put(annotation_property.into_storage_key().into_owned_array());
+        snapshot.put(annotation_property.into_storage_key().into_owned_array());
     }
 
-    pub(crate) fn storage_delete_annotation_distinct(&self, type_: impl TypeAPI<'static>) {
+    pub(crate) fn storage_delete_annotation_distinct(&self, snapshot: &mut Snapshot, type_: impl TypeAPI<'static>) {
         let annotation_property = build_property_type_annotation_distinct(type_.into_vertex());
-        self.snapshot.as_ref().delete(annotation_property.into_storage_key().into_owned_array());
+        snapshot.delete(annotation_property.into_storage_key().into_owned_array());
     }
 
-    pub(crate) fn storage_set_edge_annotation_distinct<'b>(&self, edge: impl IntoCanonicalTypeEdge<'b>) {
+    pub(crate) fn storage_set_edge_annotation_distinct<'b>(&self, snapshot: &mut Snapshot, edge: impl IntoCanonicalTypeEdge<'b>) {
         let annotation_property = build_property_type_edge_annotation_distinct(edge.into_type_edge());
-        self.snapshot.as_ref().put(annotation_property.into_storage_key().into_owned_array());
+        snapshot.put(annotation_property.into_storage_key().into_owned_array());
     }
 
-    pub(crate) fn storage_delete_edge_annotation_distinct<'b>(&self, edge: impl IntoCanonicalTypeEdge<'b>) {
+    pub(crate) fn storage_delete_edge_annotation_distinct<'b>(&self, snapshot: &mut Snapshot, edge: impl IntoCanonicalTypeEdge<'b>) {
         let annotation_property = build_property_type_edge_annotation_distinct(edge.into_type_edge());
-        self.snapshot.as_ref().delete(annotation_property.into_storage_key().into_owned_array());
+        snapshot.delete(annotation_property.into_storage_key().into_owned_array());
     }
 
-    pub(crate) fn storage_set_annotation_independent(&self, type_: impl TypeAPI<'static>) {
+    pub(crate) fn storage_set_annotation_independent(&self, snapshot: &mut Snapshot, type_: impl TypeAPI<'static>) {
         let annotation_property = build_property_type_annotation_independent(type_.into_vertex());
-        self.snapshot.as_ref().put(annotation_property.into_storage_key().into_owned_array());
+        snapshot.put(annotation_property.into_storage_key().into_owned_array());
     }
 
-    pub(crate) fn storage_storage_annotation_independent(&self, type_: impl TypeAPI<'static>) {
+    pub(crate) fn storage_storage_annotation_independent(&self, snapshot: &mut Snapshot, type_: impl TypeAPI<'static>) {
         let annotation_property = build_property_type_annotation_independent(type_.into_vertex());
-        self.snapshot.as_ref().delete(annotation_property.into_storage_key().into_owned_array());
+        snapshot.delete(annotation_property.into_storage_key().into_owned_array());
     }
 
     pub(crate) fn storage_set_annotation_cardinality(
         &self,
+        snapshot: &mut Snapshot,
         type_: impl TypeAPI<'static>,
         annotation: AnnotationCardinality,
     ) {
-        self.snapshot.as_ref().put_val(
-            build_property_type_annotation_cardinality(type_.into_vertex()).into_storage_key().into_owned_array(),
-            ByteArray::boxed(serialise_annotation_cardinality(annotation)),
-        );
+        snapshot.put_val(
+                build_property_type_annotation_cardinality(type_.into_vertex()).into_storage_key().into_owned_array(),
+                ByteArray::boxed(serialise_annotation_cardinality(annotation)),
+            );
     }
 
-    pub(crate) fn storage_delete_annotation_cardinality(&self, type_: impl TypeAPI<'static>) {
+    pub(crate) fn storage_delete_annotation_cardinality(
+        &self,
+        snapshot: &mut Snapshot,
+        type_: impl TypeAPI<'static>,
+    ) {
         let annotation_property = build_property_type_annotation_cardinality(type_.into_vertex());
-        self.snapshot.as_ref().delete(annotation_property.into_storage_key().into_owned_array());
+        snapshot.delete(annotation_property.into_storage_key().into_owned_array());
     }
 
     pub(crate) fn storage_set_edge_annotation_cardinality<'b>(
         &self,
+        snapshot: &mut Snapshot,
         edge: impl IntoCanonicalTypeEdge<'b>,
         annotation: AnnotationCardinality,
     ) {
-        self.snapshot.as_ref().put_val(
-            build_property_type_edge_annotation_cardinality(edge.into_type_edge())
-                .into_storage_key()
-                .into_owned_array(),
-            ByteArray::boxed(serialise_annotation_cardinality(annotation)),
-        );
+        snapshot.put_val(
+                build_property_type_edge_annotation_cardinality(edge.into_type_edge()).into_storage_key().into_owned_array(),
+                ByteArray::boxed(serialise_annotation_cardinality(annotation)),
+            );
     }
 
-    pub(crate) fn storage_delete_edge_annotation_cardinality<'b>(&self, edge: impl IntoCanonicalTypeEdge<'b>) {
+    pub(crate) fn storage_delete_edge_annotation_cardinality<'b>(
+        &self,
+        snapshot: &mut Snapshot,
+        edge: impl IntoCanonicalTypeEdge<'b>,
+    ) {
         let annotation_property = build_property_type_edge_annotation_cardinality(edge.into_type_edge());
-        self.snapshot.as_ref().delete(annotation_property.into_storage_key().into_owned_array());
+        snapshot.delete(annotation_property.into_storage_key().into_owned_array());
     }
 }
 

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -76,17 +76,16 @@ impl<Snapshot> TypeManager<Snapshot> {
         {
             let type_manager = TypeManager::<WriteSnapshot<D>>::new(vertex_generator.clone(), None);
             let root_entity = type_manager.create_entity_type(&mut snapshot, &Kind::Entity.root_label(), true)?;
-            root_entity.set_annotation(&type_manager, EntityTypeAnnotation::Abstract(AnnotationAbstract::new()))?;
+            root_entity.set_annotation(&mut snapshot, &type_manager, EntityTypeAnnotation::Abstract(AnnotationAbstract::new()))?;
             let root_relation = type_manager.create_relation_type(&mut snapshot, &Kind::Relation.root_label(), true)?;
-            root_relation.set_annotation(&type_manager, RelationTypeAnnotation::Abstract(AnnotationAbstract::new()))?;
+            root_relation.set_annotation(&mut snapshot, &type_manager, RelationTypeAnnotation::Abstract(AnnotationAbstract::new()))?;
             let root_role = type_manager.create_role_type(
                 &mut snapshot, &Kind::Role.root_label(), root_relation.clone(), true, Ordering::Unordered
             ,
             )?;
-            root_role.set_annotation(&type_manager, RoleTypeAnnotation::Abstract(AnnotationAbstract::new()))?;
+            root_role.set_annotation(&mut snapshot, &type_manager, RoleTypeAnnotation::Abstract(AnnotationAbstract::new()))?;
             let root_attribute = type_manager.create_attribute_type(&mut snapshot, &Kind::Attribute.root_label(), true)?;
-            root_attribute
-                .set_annotation(&type_manager, AttributeTypeAnnotation::Abstract(AnnotationAbstract::new()))?;
+            root_attribute.set_annotation(&mut snapshot, &type_manager, AttributeTypeAnnotation::Abstract(AnnotationAbstract::new()))?;
         }
         // TODO: pass error up
         snapshot.commit().unwrap();
@@ -358,12 +357,12 @@ where
         }
     }
 
-    pub(crate) fn relation_index_available(&self, relation_type: RelationType<'_>) -> Result<bool, ConceptReadError> {
+    pub(crate) fn relation_index_available(&self, snapshot: &Snapshot, relation_type: RelationType<'_>) -> Result<bool, ConceptReadError> {
         // TODO: it would be good if this doesn't require recomputation
         let mut max_card = 0;
-        let relates = relation_type.get_relates(self)?;
+        let relates = relation_type.get_relates(snapshot, self)?;
         for relates in relates.iter() {
-            let card = relates.role().get_cardinality(self)?;
+            let card = relates.role().get_cardinality(snapshot, self)?;
             match card.end() {
                 None => return Ok(false),
                 Some(end) => max_card += end,

--- a/database/tests/database.rs
+++ b/database/tests/database.rs
@@ -24,7 +24,7 @@ fn create_delete_database() {
 
     let txn = TransactionRead::open(db.clone());
     let types = txn.type_manager();
-    let root_entity_type = types.get_entity_type(&Kind::Entity.root_label());
+    let root_entity_type = types.get_entity_type(txn.snapshot(), &Kind::Entity.root_label());
     eprintln!("Root entity type: {:?}", root_entity_type);
     // let delete_result = db.delete();
     // assert!(delete_result.is_ok());

--- a/encoding/benches/benchmark.rs
+++ b/encoding/benches/benchmark.rs
@@ -24,7 +24,7 @@ use test_utils::{create_tmp_dir, init_logging};
 fn vertex_generation<D>(
     thing_vertex_generator: Arc<ThingVertexGenerator>,
     type_id: TypeID,
-    write_snapshot: &WriteSnapshot<D>,
+    write_snapshot: &mut WriteSnapshot<D>,
 ) -> ObjectVertex<'static> {
     thing_vertex_generator.create_entity(type_id, write_snapshot)
 }
@@ -32,7 +32,7 @@ fn vertex_generation<D>(
 fn vertex_generation_to_key<D>(
     thing_vertex_generator: Arc<ThingVertexGenerator>,
     type_id: TypeID,
-    write_snapshot: &WriteSnapshot<D>,
+    write_snapshot: &mut WriteSnapshot<D>,
 ) -> StorageKey<'static, { BUFFER_KEY_INLINE }> {
     thing_vertex_generator.create_entity(type_id, write_snapshot).into_storage_key()
 }
@@ -45,14 +45,14 @@ fn criterion_benchmark(c: &mut Criterion) {
     let type_id = TypeID::build(0);
     let vertex_generator = Arc::new(ThingVertexGenerator::new());
 
-    let snapshot = storage.clone().open_snapshot_write();
+    let mut snapshot = storage.clone().open_snapshot_write();
     c.bench_function("vertex_generation", |b| {
-        b.iter(|| vertex_generation(vertex_generator.clone(), type_id, &snapshot))
+        b.iter(|| vertex_generation(vertex_generator.clone(), type_id, &mut snapshot))
     });
 
-    let snapshot = storage.clone().open_snapshot_write();
+    let mut snapshot = storage.clone().open_snapshot_write();
     c.bench_function("vertex_generation_to_storage_key", |b| {
-        b.iter(|| vertex_generation_to_key(vertex_generator.clone(), type_id, &snapshot))
+        b.iter(|| vertex_generation_to_key(vertex_generator.clone(), type_id, &mut snapshot))
     });
 }
 

--- a/encoding/graph/thing/vertex_generator.rs
+++ b/encoding/graph/thing/vertex_generator.rs
@@ -133,7 +133,7 @@ impl ThingVertexGenerator {
         vertex
     }
 
-    pub fn create_relation<Snapshot>(&self, type_id: TypeID, snapshot: &Snapshot) -> ObjectVertex<'static>
+    pub fn create_relation<Snapshot>(&self, type_id: TypeID, snapshot: &mut Snapshot) -> ObjectVertex<'static>
     where
         Snapshot: WritableSnapshot,
     {

--- a/encoding/graph/thing/vertex_generator.rs
+++ b/encoding/graph/thing/vertex_generator.rs
@@ -123,7 +123,7 @@ impl ThingVertexGenerator {
         ObjectVertex::new(Bytes::Array(ByteArray::copy(k.key())))
     }
 
-    pub fn create_entity<Snapshot>(&self, type_id: TypeID, snapshot: &Snapshot) -> ObjectVertex<'static>
+    pub fn create_entity<Snapshot>(&self, type_id: TypeID, snapshot: &mut Snapshot) -> ObjectVertex<'static>
     where
         Snapshot: WritableSnapshot,
     {
@@ -147,7 +147,7 @@ impl ThingVertexGenerator {
         &self,
         type_id: TypeID,
         value: LongBytes,
-        snapshot: &Snapshot,
+        snapshot: &mut Snapshot,
     ) -> AttributeVertex<'static>
     where
         Snapshot: WritableSnapshot,
@@ -176,7 +176,7 @@ impl ThingVertexGenerator {
         &self,
         type_id: TypeID,
         value: StringBytes<'_, INLINE_LENGTH>,
-        snapshot: &Snapshot,
+        snapshot: &mut Snapshot,
     ) -> Result<AttributeVertex<'static>, Arc<SnapshotIteratorError>>
     where
         Snapshot: WritableSnapshot,
@@ -191,7 +191,7 @@ impl ThingVertexGenerator {
         &self,
         type_id: TypeID,
         string: StringBytes<'_, INLINE_LENGTH>,
-        snapshot: &Snapshot,
+        snapshot: &mut Snapshot,
     ) -> Result<StringAttributeID, Arc<SnapshotIteratorError>>
     where
         Snapshot: WritableSnapshot,

--- a/encoding/graph/type_/vertex_generator.rs
+++ b/encoding/graph/type_/vertex_generator.rs
@@ -103,19 +103,19 @@ impl TypeVertexGenerator {
         Ok(vertex)
     }
 
-    pub fn create_relation_type<Snapshot: WritableSnapshot>(&self, snapshot: &Snapshot) -> Result<TypeVertex<'static>, EncodingError> {
+    pub fn create_relation_type<Snapshot: WritableSnapshot>(&self, snapshot: &mut Snapshot) -> Result<TypeVertex<'static>, EncodingError> {
         let vertex = self.next_relation.allocate(snapshot)?;
         snapshot.put(vertex.as_storage_key().into_owned_array());
         Ok(vertex)
     }
 
-    pub fn create_role_type<Snapshot: WritableSnapshot>(&self, snapshot: &Snapshot) -> Result<TypeVertex<'static>, EncodingError> {
+    pub fn create_role_type<Snapshot: WritableSnapshot>(&self, snapshot: &mut Snapshot) -> Result<TypeVertex<'static>, EncodingError> {
         let vertex = self.next_role.allocate(snapshot)?;
         snapshot.put(vertex.as_storage_key().into_owned_array());
         Ok(vertex)
     }
 
-    pub fn create_attribute_type<Snapshot: WritableSnapshot>(&self, snapshot: &Snapshot) -> Result<TypeVertex<'static>, EncodingError> {
+    pub fn create_attribute_type<Snapshot: WritableSnapshot>(&self, snapshot: &mut Snapshot) -> Result<TypeVertex<'static>, EncodingError> {
         let vertex = self.next_attribute.allocate(snapshot)?;
         snapshot.put(vertex.as_storage_key().into_owned_array());
         Ok(vertex)

--- a/encoding/graph/type_/vertex_generator.rs
+++ b/encoding/graph/type_/vertex_generator.rs
@@ -97,7 +97,7 @@ impl TypeVertexGenerator {
         }
     }
 
-    pub fn create_entity_type<Snapshot: WritableSnapshot>(&self, snapshot: &Snapshot) -> Result<TypeVertex<'static>, EncodingError> {
+    pub fn create_entity_type<Snapshot: WritableSnapshot>(&self, snapshot: &mut Snapshot) -> Result<TypeVertex<'static>, EncodingError> {
         let vertex = self.next_entity.allocate(snapshot)?;
         snapshot.put(vertex.as_storage_key().into_owned_array());
         Ok(vertex)

--- a/encoding/tests/test_attribute_vertex.rs
+++ b/encoding/tests/test_attribute_vertex.rs
@@ -115,10 +115,10 @@ fn next_entity_and_relation_ids_are_determined_from_storage() {
     let type_id = TypeID::build(0);
     {
         let storage = Arc::new(MVCCStorage::<WAL>::open::<EncodingKeyspace>("storage", &storage_path).unwrap());
-        let snapshot = storage.clone().open_snapshot_write();
+        let mut snapshot = storage.clone().open_snapshot_write();
         let generator = TypeVertexGenerator::new();
 
-        let entity_type_vertex = generator.create_entity_type(&snapshot).unwrap();
+        let entity_type_vertex = generator.create_entity_type(&mut snapshot).unwrap();
         debug_assert_eq!(type_id, entity_type_vertex.type_id_());
 
         let relation_type_vertex = generator.create_relation_type(&snapshot).unwrap();
@@ -129,9 +129,9 @@ fn next_entity_and_relation_ids_are_determined_from_storage() {
 
     for i in 0..5 {
         let storage = Arc::new(MVCCStorage::<WAL>::open::<EncodingKeyspace>("storage", &storage_path).unwrap());
-        let snapshot = storage.clone().open_snapshot_write();
+        let mut snapshot = storage.clone().open_snapshot_write();
         let generator = ThingVertexGenerator::load(storage.clone()).unwrap();
-        let vertex = generator.create_entity(type_id, &snapshot);
+        let vertex = generator.create_entity(type_id, &mut snapshot);
         assert_eq!(type_id, vertex.type_id_());
         assert_eq!(i as u64, vertex.object_id().as_u64());
         snapshot.commit().unwrap();
@@ -139,9 +139,9 @@ fn next_entity_and_relation_ids_are_determined_from_storage() {
 
     for i in 0..5 {
         let storage = Arc::new(MVCCStorage::<WAL>::open::<EncodingKeyspace>("storage", &storage_path).unwrap());
-        let snapshot = storage.clone().open_snapshot_write();
+        let mut snapshot = storage.clone().open_snapshot_write();
         let generator = ThingVertexGenerator::load(storage.clone()).unwrap();
-        let vertex = generator.create_relation(type_id, &snapshot);
+        let vertex = generator.create_relation(type_id, &mut snapshot);
         assert_eq!(type_id, vertex.type_id_());
         assert_eq!(i as u64, vertex.object_id().as_u64());
         snapshot.commit().unwrap();

--- a/encoding/tests/test_attribute_vertex.rs
+++ b/encoding/tests/test_attribute_vertex.rs
@@ -28,7 +28,7 @@ fn generate_string_attribute_vertex() {
     let storage_path = create_tmp_dir();
     let storage = Arc::new(MVCCStorage::<WAL>::open::<EncodingKeyspace>(Rc::from("storage"), &storage_path).unwrap());
 
-    let snapshot = storage.clone().open_snapshot_write();
+    let mut snapshot = storage.clone().open_snapshot_write();
     let type_id = TypeID::build(0);
 
     let thing_vertex_generator = ThingVertexGenerator::new();
@@ -38,7 +38,7 @@ fn generate_string_attribute_vertex() {
         let short_string = "Hello";
         let short_string_bytes: StringBytes<'_, BUFFER_KEY_INLINE> = StringBytes::build_ref(short_string);
         let vertex = thing_vertex_generator
-            .create_attribute_string(type_id, short_string_bytes.as_reference(), &snapshot)
+            .create_attribute_string(type_id, short_string_bytes.as_reference(), &mut snapshot)
             .unwrap();
         let vertex_id = vertex.attribute_id().unwrap_string();
         assert!(vertex_id.is_inline());
@@ -51,7 +51,7 @@ fn generate_string_attribute_vertex() {
         let string = "Hello world, this is a long attribute string to be encoded.";
         let string_bytes: StringBytes<'_, BUFFER_KEY_INLINE> = StringBytes::build_ref(string);
         let vertex =
-            thing_vertex_generator.create_attribute_string(type_id, string_bytes.as_reference(), &snapshot).unwrap();
+            thing_vertex_generator.create_attribute_string(type_id, string_bytes.as_reference(), &mut snapshot).unwrap();
         let vertex_id = vertex.attribute_id().unwrap_string();
         assert!(!vertex_id.is_inline());
         assert_eq!(
@@ -74,7 +74,7 @@ fn generate_string_attribute_vertex() {
         let string = "Hello world, this is a long attribute string to be encoded with a constant hash.";
         let string_bytes: StringBytes<'_, BUFFER_KEY_INLINE> = StringBytes::build_ref(string);
         let vertex =
-            thing_vertex_generator.create_attribute_string(type_id, string_bytes.as_reference(), &snapshot).unwrap();
+            thing_vertex_generator.create_attribute_string(type_id, string_bytes.as_reference(), &mut snapshot).unwrap();
 
         let vertex_id = vertex.attribute_id().unwrap_string();
         assert!(!vertex_id.is_inline());
@@ -91,7 +91,7 @@ fn generate_string_attribute_vertex() {
         let string_collide = "Hello world, this is using the same prefix and will collide.";
         let string_collide_bytes: StringBytes<'_, BUFFER_KEY_INLINE> = StringBytes::build_ref(string_collide);
         let collide_vertex = thing_vertex_generator
-            .create_attribute_string(type_id, string_collide_bytes.as_reference(), &snapshot)
+            .create_attribute_string(type_id, string_collide_bytes.as_reference(), &mut snapshot)
             .unwrap();
 
         let collide_id = collide_vertex.attribute_id().unwrap_string();
@@ -121,7 +121,7 @@ fn next_entity_and_relation_ids_are_determined_from_storage() {
         let entity_type_vertex = generator.create_entity_type(&mut snapshot).unwrap();
         debug_assert_eq!(type_id, entity_type_vertex.type_id_());
 
-        let relation_type_vertex = generator.create_relation_type(&snapshot).unwrap();
+        let relation_type_vertex = generator.create_relation_type(&mut snapshot).unwrap();
         debug_assert_eq!(type_id, relation_type_vertex.type_id_());
 
         snapshot.commit().unwrap();

--- a/encoding/tests/test_type_vertex.rs
+++ b/encoding/tests/test_type_vertex.rs
@@ -54,7 +54,7 @@ fn entity_type_vertexes_are_reused() {
     }
 
     {
-        let snapshot = storage.clone().open_snapshot_write();
+        let mut snapshot = storage.clone().open_snapshot_write();
         for i in 0..=create_till {
             if i % 2 == 0 {
                 let vertex = build_vertex_entity_type(TypeID::build(i));
@@ -119,30 +119,30 @@ fn loading_storage_assigns_next_vertex() {
 
     for i in 0..create_till {
         let storage = Arc::new(MVCCStorage::<WAL>::open::<EncodingKeyspace>("storage", &storage_path).unwrap());
-        let snapshot = storage.clone().open_snapshot_write();
+        let mut snapshot = storage.clone().open_snapshot_write();
         let generator = TypeVertexGenerator::new();
 
-        let vertex = generator.create_attribute_type(&snapshot).unwrap();
+        let vertex = generator.create_attribute_type(&mut snapshot).unwrap();
         assert_eq!(i, vertex.type_id_().as_u16());
         snapshot.commit().unwrap();
     }
 
     for i in 0..create_till {
         let storage = Arc::new(MVCCStorage::<WAL>::open::<EncodingKeyspace>("storage", &storage_path).unwrap());
-        let snapshot = storage.clone().open_snapshot_write();
+        let mut snapshot = storage.clone().open_snapshot_write();
         let generator = TypeVertexGenerator::new();
 
-        let vertex = generator.create_relation_type(&snapshot).unwrap();
+        let vertex = generator.create_relation_type(&mut snapshot).unwrap();
         assert_eq!(i, vertex.type_id_().as_u16());
         snapshot.commit().unwrap();
     }
 
     for i in 0..create_till {
         let storage = Arc::new(MVCCStorage::<WAL>::open::<EncodingKeyspace>("storage", &storage_path).unwrap());
-        let snapshot = storage.clone().open_snapshot_write();
+        let mut snapshot = storage.clone().open_snapshot_write();
         let generator = TypeVertexGenerator::new();
 
-        let vertex = generator.create_role_type(&snapshot).unwrap();
+        let vertex = generator.create_role_type(&mut snapshot).unwrap();
         assert_eq!(i, vertex.type_id_().as_u16());
         snapshot.commit().unwrap();
     }

--- a/encoding/tests/test_type_vertex.rs
+++ b/encoding/tests/test_type_vertex.rs
@@ -34,9 +34,9 @@ fn entity_type_vertexes_are_reused() {
     // If we don't commit, it doesn't move.
     {
         for _ in 0..5 {
-            let snapshot = storage.clone().open_snapshot_write();
+            let mut snapshot = storage.clone().open_snapshot_write();
             let generator = TypeVertexGenerator::new();
-            let vertex = generator.create_entity_type(&snapshot).unwrap();
+            let vertex = generator.create_entity_type(&mut snapshot).unwrap();
             assert_eq!(0, vertex.type_id_().as_u16());
         }
     }
@@ -44,10 +44,10 @@ fn entity_type_vertexes_are_reused() {
     // create a bunch of types, delete, and assert that the IDs are re-used
     let create_till = 32;
     {
-        let snapshot = storage.clone().open_snapshot_write();
+        let mut snapshot = storage.clone().open_snapshot_write();
         let generator = TypeVertexGenerator::new();
         for i in 0..=create_till {
-            let vertex = generator.create_entity_type(&snapshot).unwrap();
+            let vertex = generator.create_entity_type(&mut snapshot).unwrap();
             assert_eq!(i, vertex.type_id_().as_u16());
         }
         snapshot.commit().unwrap();
@@ -66,10 +66,10 @@ fn entity_type_vertexes_are_reused() {
 
     {
         let generator = TypeVertexGenerator::new();
-        let snapshot = storage.clone().open_snapshot_write();
+        let mut snapshot = storage.clone().open_snapshot_write();
         for i in 0..=create_till {
             if i % 2 == 0 {
-                let vertex = generator.create_entity_type(&snapshot).unwrap();
+                let vertex = generator.create_entity_type(&mut snapshot).unwrap();
                 assert_eq!(i, vertex.type_id_().as_u16());
             }
         }
@@ -83,20 +83,20 @@ fn max_entity_type_vertexes() {
     let storage = Arc::new(MVCCStorage::<WAL>::open::<EncodingKeyspace>("storage", &storage_path).unwrap());
     let create_till = u16::MAX;
     {
-        let snapshot = storage.clone().open_snapshot_write();
+        let mut snapshot = storage.clone().open_snapshot_write();
         let generator = TypeVertexGenerator::new();
         for i in 0..=create_till {
-            let vertex = generator.create_entity_type(&snapshot).unwrap();
+            let vertex = generator.create_entity_type(&mut snapshot).unwrap();
             assert_eq!(i, vertex.type_id_().as_u16());
         }
         snapshot.commit().unwrap();
     }
 
     {
-        let snapshot = storage.clone().open_snapshot_write();
+        let mut snapshot = storage.clone().open_snapshot_write();
         let generator = TypeVertexGenerator::new();
 
-        let res = generator.create_entity_type(&snapshot); // Crashes
+        let res = generator.create_entity_type(&mut snapshot); // Crashes
         assert!(matches!(res, Err(EncodingError::TypeIDsExhausted { kind: encoding::graph::type_::Kind::Entity })));
     }
 }
@@ -109,10 +109,10 @@ fn loading_storage_assigns_next_vertex() {
 
     for i in 0..create_till {
         let storage = Arc::new(MVCCStorage::<WAL>::open::<EncodingKeyspace>("storage", &storage_path).unwrap());
-        let snapshot = storage.clone().open_snapshot_write();
+        let mut snapshot = storage.clone().open_snapshot_write();
         let generator = TypeVertexGenerator::new();
 
-        let vertex = generator.create_entity_type(&snapshot).unwrap();
+        let vertex = generator.create_entity_type(&mut snapshot).unwrap();
         assert_eq!(i, vertex.type_id_().as_u16());
         snapshot.commit().unwrap();
     }

--- a/storage/benches/bench_mvcc_storage.rs
+++ b/storage/benches/bench_mvcc_storage.rs
@@ -101,7 +101,7 @@ fn bench_snapshot_read_iterate<const ITERATE_COUNT: usize>(
 }
 
 fn bench_snapshot_write_put(storage: Arc<MVCCStorage<WAL>>, keyspace: TestKeyspaceSet, batch_size: usize) {
-    let snapshot = storage.open_snapshot_write();
+    let mut snapshot = storage.open_snapshot_write();
     for _ in 0..batch_size {
         snapshot.put(random_key_24(keyspace));
     }

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -659,6 +659,10 @@ impl CommitRecord {
         &self.operations
     }
 
+    pub(crate) fn operations_mut(&mut self) -> &mut OperationsBuffer {
+        &mut self.operations
+    }
+
     pub(crate) fn open_sequence_number(&self) -> SequenceNumber {
         self.open_sequence_number
     }
@@ -683,15 +687,15 @@ impl CommitRecord {
         //   if our buffer contains a delete, we check the predecessor doesn't have an Existing lock on it
         // We check
 
-        let locks = self.operations().locks().read().unwrap();
-        let predecessor_locks = predecessor.operations().locks().read().unwrap();
+        let locks = self.operations().locks();
+        let predecessor_locks = predecessor.operations().locks();
         for (write_buffer, pred_write_buffer) in self.operations().write_buffers().zip(predecessor.operations()) {
-            let writes = write_buffer.writes().read().unwrap();
+            let writes = write_buffer.writes();
             // if writes.is_empty() && locks.is_empty() {
             //     continue;
             // }
 
-            let predecessor_writes = pred_write_buffer.writes().read().unwrap();
+            let predecessor_writes = pred_write_buffer.writes();
             // if predecessor_writes.is_empty() && predecessor_locks.is_empty() {
             //     continue;
             // }

--- a/storage/snapshot/buffer.rs
+++ b/storage/snapshot/buffer.rs
@@ -116,12 +116,11 @@ impl WriteBuffer {
     }
 
     pub(crate) fn put(&mut self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
-        self.writes.write()
-            .unwrap()
+        self.writes
             .insert(key, Write::Put { value, reinsert: Arc::new(AtomicBool::new(false)), known_to_exist: false });
     }
 
-    pub(crate) fn put_existing(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
+    pub(crate) fn put_existing(&mut self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
         self.writes
             .insert(key, Write::Put { value, reinsert: Arc::new(AtomicBool::new(false)), known_to_exist: true });
     }

--- a/storage/snapshot/buffer.rs
+++ b/storage/snapshot/buffer.rs
@@ -32,18 +32,18 @@ use crate::{
 #[derive(Debug)]
 pub(crate) struct OperationsBuffer {
     write_buffers: [WriteBuffer; KEYSPACE_MAXIMUM_COUNT],
-    locks: RwLock<BTreeMap<ByteArray<BUFFER_KEY_INLINE>, LockType>>,
+    locks: BTreeMap<ByteArray<BUFFER_KEY_INLINE>, LockType>,
 }
 
 impl OperationsBuffer {
     pub(crate) fn new() -> OperationsBuffer {
         OperationsBuffer {
             write_buffers: core::array::from_fn(|i| WriteBuffer::new(KeyspaceId(i as u8))),
-            locks: RwLock::new(BTreeMap::new()),
+            locks: BTreeMap::new(),
         }
     }
 
-    pub(crate) fn writes_empty(&self) -> bool {
+    pub(crate) fn is_writes_empty(&self) -> bool {
         self.write_buffers.iter().all(|buffer| buffer.is_empty())
     }
 
@@ -51,26 +51,32 @@ impl OperationsBuffer {
         &self.write_buffers[keyspace_id.0 as usize]
     }
 
+    pub(crate) fn writes_in_mut(&mut self, keyspace_id: KeyspaceId) -> &mut WriteBuffer {
+        &mut self.write_buffers[keyspace_id.0 as usize]
+    }
+
     pub(crate) fn write_buffers(&self) -> impl Iterator<Item = &WriteBuffer> {
         self.write_buffers.iter()
     }
 
-    pub(crate) fn lock_add(&self, key: ByteArray<BUFFER_KEY_INLINE>, lock_type: LockType) {
-        let mut locks = self.locks.write().unwrap();
-        locks.insert(key, lock_type);
+    pub(crate) fn write_buffers_mut(&mut self) -> impl Iterator<Item=&mut WriteBuffer> {
+        self.write_buffers.iter_mut()
     }
 
-    pub(crate) fn lock_remove(&self, key: &ByteArray<BUFFER_KEY_INLINE>) {
-        let mut locks = self.locks.write().unwrap();
-        locks.remove(key);
+    pub(crate) fn lock_add(&mut self, key: ByteArray<BUFFER_KEY_INLINE>, lock_type: LockType) {
+        self.locks.insert(key, lock_type);
     }
 
-    pub(crate) fn locks(&self) -> &RwLock<BTreeMap<ByteArray<BUFFER_KEY_INLINE>, LockType>> {
+    pub(crate) fn lock_remove(&mut self, key: &ByteArray<BUFFER_KEY_INLINE>) {
+        self.locks.remove(key);
+    }
+
+    pub(crate) fn locks(&self) -> &BTreeMap<ByteArray<BUFFER_KEY_INLINE>, LockType> {
         &self.locks
     }
 
     pub(crate) fn locks_empty(&self) -> bool {
-        self.locks().read().unwrap().is_empty()
+        self.locks.is_empty()
     }
 }
 
@@ -93,51 +99,46 @@ impl<'a> IntoIterator for &'a OperationsBuffer {
 #[derive(Debug)]
 pub(crate) struct WriteBuffer {
     pub(crate) keyspace_id: KeyspaceId,
-    writes: RwLock<BTreeMap<ByteArray<BUFFER_KEY_INLINE>, Write>>,
+    writes: BTreeMap<ByteArray<BUFFER_KEY_INLINE>, Write>,
 }
 
 impl WriteBuffer {
     pub(crate) fn new(keyspace_id: KeyspaceId) -> WriteBuffer {
-        WriteBuffer { keyspace_id, writes: RwLock::new(BTreeMap::new()) }
+        WriteBuffer { keyspace_id, writes: BTreeMap::new() }
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.writes.read().unwrap().is_empty()
+        self.writes.is_empty()
     }
 
-    pub(crate) fn insert(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
-        self.writes.write().unwrap().insert(key, Write::Insert { value });
+    pub(crate) fn insert(&mut self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
+        self.writes.insert(key, Write::Insert { value });
     }
 
-    pub(crate) fn put(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
-        self.writes
-            .write()
+    pub(crate) fn put(&mut self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
+        self.writes.write()
             .unwrap()
             .insert(key, Write::Put { value, reinsert: Arc::new(AtomicBool::new(false)), known_to_exist: false });
     }
 
     pub(crate) fn put_existing(&self, key: ByteArray<BUFFER_KEY_INLINE>, value: ByteArray<BUFFER_VALUE_INLINE>) {
         self.writes
-            .write()
-            .unwrap()
             .insert(key, Write::Put { value, reinsert: Arc::new(AtomicBool::new(false)), known_to_exist: true });
     }
 
-    pub(crate) fn delete(&self, key: ByteArray<BUFFER_KEY_INLINE>) {
-        let mut map = self.writes.write().unwrap();
+    pub(crate) fn delete(&mut self, key: ByteArray<BUFFER_KEY_INLINE>) {
         // note: If this snapshot has Inserted the key, we don't know if it's a preexisting key
         // with a different value for overwrite or a brand new key so we always have to write a
         // delete marker instead of removing an element from the map in some cases
-        map.insert(key, Write::Delete);
+        self.writes.insert(key, Write::Delete);
     }
 
     pub(crate) fn contains(&self, key: &ByteArray<BUFFER_KEY_INLINE>) -> bool {
-        self.writes.read().unwrap().get(key.bytes()).is_some()
+        self.writes.get(key.bytes()).is_some()
     }
 
     pub(crate) fn get<const INLINE_BYTES: usize>(&self, key: &[u8]) -> Option<ByteArray<INLINE_BYTES>> {
-        let map = self.writes.read().unwrap();
-        match map.get(key) {
+        match self.writes.get(key) {
             Some(Write::Insert { value }) | Some(Write::Put { value, .. }) => Some(ByteArray::copy(value.bytes())),
             Some(Write::Delete) | None => None,
         }
@@ -154,11 +155,11 @@ impl WriteBuffer {
         } else {
             Bound::Excluded(exclusive_end_bytes.bytes())
         };
-        let map = self.writes.read().unwrap();
         BufferedPrefixIterator::new(
-            map.range::<[u8], _>((Bound::Included(range_start.bytes()), end))
+            self.writes
+                .range::<[u8], _>((Bound::Included(range_start.bytes()), end))
                 .map(|(key, val)| (StorageKeyArray::new_raw(self.keyspace_id, key.clone()), val.clone()))
-                .collect::<Vec<_>>(),
+                .collect::<Vec<_>>()
         )
     }
 
@@ -170,8 +171,8 @@ impl WriteBuffer {
         } else {
             Bound::Excluded(exclusive_end_bytes.bytes())
         };
-        let map = self.writes.read().unwrap();
-        map.range::<[u8], _>((Bound::Included(range_start.bytes()), end))
+        self.writes
+            .range::<[u8], _>((Bound::Included(range_start.bytes()), end))
             .map(|(key, val)| (StorageKeyArray::new_raw(self.keyspace_id, key.clone()), val.clone()))
             .next()
             .is_some()
@@ -197,13 +198,16 @@ impl WriteBuffer {
         }
     }
 
-    pub(crate) fn writes(&self) -> &RwLock<BTreeMap<ByteArray<BUFFER_KEY_INLINE>, Write>> {
+    pub(crate) fn writes(&self) -> &BTreeMap<ByteArray<BUFFER_KEY_INLINE>, Write> {
         &self.writes
     }
 
+    pub(crate) fn writes_mut(&mut self) -> &mut BTreeMap<ByteArray<BUFFER_KEY_INLINE>, Write> {
+        &mut self.writes
+    }
+
     pub(crate) fn get_write_mapped<T>(&self, key: ByteReference<'_>, mapper: impl FnMut(&Write) -> T) -> Option<T> {
-        let writes = self.writes.read().unwrap();
-        writes.get(key.bytes()).map(mapper)
+        self.writes.get(key.bytes()).map(mapper)
     }
 }
 
@@ -322,7 +326,7 @@ impl Serialize for OperationsBuffer {
     {
         let mut state = serializer.serialize_struct("OperationsBuffer", 2)?;
         state.serialize_field("WriteBuffers", &self.write_buffers)?;
-        state.serialize_field("Locks", &*self.locks.read().unwrap())?;
+        state.serialize_field("Locks", &self.locks)?;
         state.end()
     }
 }
@@ -383,7 +387,7 @@ impl<'de> Deserialize<'de> for OperationsBuffer {
                 let write_buffers = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(1, &self))?;
                 let locks: BTreeMap<ByteArray<BUFFER_KEY_INLINE>, LockType> =
                     seq.next_element()?.ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                Ok(OperationsBuffer { write_buffers, locks: RwLock::new(locks) })
+                Ok(OperationsBuffer { write_buffers, locks: locks })
             }
         }
 
@@ -398,7 +402,7 @@ impl Serialize for WriteBuffer {
     {
         let mut state = serializer.serialize_struct("KeyspaceBuffer", 2)?;
         state.serialize_field("KeyspaceId", &self.keyspace_id)?;
-        state.serialize_field("Buffer", &*self.writes.read().unwrap())?;
+        state.serialize_field("Buffer", &self.writes)?;
         state.end()
     }
 }
@@ -459,7 +463,7 @@ impl<'de> Deserialize<'de> for WriteBuffer {
                 let keyspace_id = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(1, &self))?;
                 let buffer: BTreeMap<ByteArray<BUFFER_KEY_INLINE>, Write> =
                     seq.next_element()?.ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                Ok(WriteBuffer { keyspace_id, writes: RwLock::new(buffer) })
+                Ok(WriteBuffer { keyspace_id, writes: buffer })
             }
 
             fn visit_map<V>(self, mut map: V) -> Result<WriteBuffer, V::Error>
@@ -488,7 +492,7 @@ impl<'de> Deserialize<'de> for WriteBuffer {
                 let keyspace_id = keyspace_id.ok_or_else(|| de::Error::invalid_length(1, &self))?;
                 let buffer: BTreeMap<ByteArray<BUFFER_KEY_INLINE>, Write> =
                     buffer.ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                Ok(WriteBuffer { keyspace_id, writes: RwLock::new(buffer) })
+                Ok(WriteBuffer { keyspace_id, writes: buffer })
             }
         }
 

--- a/storage/tests/test_snapshot.rs
+++ b/storage/tests/test_snapshot.rs
@@ -35,7 +35,7 @@ fn snapshot_buffered_put_get() {
     let storage_path = create_tmp_dir();
     let storage = Arc::new(MVCCStorage::<WAL>::open::<TestKeyspaceSet>("storage", &storage_path).unwrap());
 
-    let snapshot = storage.open_snapshot_write();
+    let mut snapshot = storage.open_snapshot_write();
 
     let key_1 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x0, 0x0, 0x1]));
     let key_2 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x1, 0x0, 0x10]));
@@ -61,7 +61,7 @@ fn snapshot_buffered_put_iterate() {
     let storage_path = create_tmp_dir();
     let storage = Arc::new(MVCCStorage::<WAL>::open::<TestKeyspaceSet>("storage", &storage_path).unwrap());
 
-    let snapshot = storage.open_snapshot_write();
+    let mut snapshot = storage.open_snapshot_write();
 
     let key_1 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x0, 0x0, 0x1]));
     let key_2 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x1, 0x0, 0x10]));
@@ -86,7 +86,7 @@ fn snapshot_buffered_delete() {
     let storage_path = create_tmp_dir();
     let storage = Arc::new(MVCCStorage::<WAL>::open::<TestKeyspaceSet>("storage", &storage_path).unwrap());
 
-    let snapshot = storage.open_snapshot_write();
+    let mut snapshot = storage.open_snapshot_write();
 
     let key_1 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x0, 0x0, 0x1]));
     let key_2 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x1, 0x0, 0x10]));
@@ -121,7 +121,7 @@ fn snapshot_read_through() {
     let key_3 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x1, 0x0, 0xff]));
     let key_4 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x2, 0x0, 0xff]));
 
-    let snapshot = storage.clone().open_snapshot_write();
+    let mut snapshot = storage.clone().open_snapshot_write();
     snapshot.put(key_1.clone());
     snapshot.put(key_2.clone());
     snapshot.put(key_3.clone());
@@ -131,7 +131,7 @@ fn snapshot_read_through() {
     let key_5 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x1, 0x2, 0x0]));
 
     // test put - iterate read-through
-    let snapshot = storage.open_snapshot_write();
+    let mut snapshot = storage.open_snapshot_write();
     snapshot.put(key_5.clone());
 
     let key_prefix = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x1]));
@@ -168,11 +168,11 @@ fn snapshot_delete_reinserted() {
     let value_0 = ByteArray::copy(&[0, 0, 0, 0]);
     let value_1 = ByteArray::copy(&[0, 0, 0, 1]);
 
-    let snapshot_0 = storage.clone().open_snapshot_write();
+    let mut snapshot_0 = storage.clone().open_snapshot_write();
     snapshot_0.put_val(key_1.clone(), value_0);
     snapshot_0.commit().unwrap();
 
-    let snapshot_1 = storage.clone().open_snapshot_write();
+    let mut snapshot_1 = storage.clone().open_snapshot_write();
     snapshot_1.put_val(key_1.clone(), value_1);
     snapshot_1.delete(key_1.clone());
     snapshot_1.commit().unwrap();

--- a/storage/write_batches.rs
+++ b/storage/write_batches.rs
@@ -28,10 +28,10 @@ impl WriteBatches {
         let mut write_batches = Self::default();
 
         for (index, buffer) in operations.write_buffers().enumerate() {
-            let map = buffer.writes().read().unwrap();
-            if !map.is_empty() {
+            let writes = buffer.writes();
+            if !writes.is_empty() {
                 let write_batch = write_batches[index].insert(WriteBatch::default());
-                for (key, write) in &*map {
+                for (key, write) in &*writes {
                     match write {
                         Write::Insert { value } => write_batch
                             .put(MVCCKey::build(key.bytes(), seq, StorageOperation::Insert).bytes(), value.bytes()),

--- a/tests/behaviour/steps/concept/type_/attribute_type.rs
+++ b/tests/behaviour/steps/concept/type_/attribute_type.rs
@@ -21,7 +21,7 @@ pub async fn put_attribute_type(context: &mut Context, type_label: params::Label
     let tx = context.transaction().unwrap();
     tx_as_schema! (tx, {
         let attribute_type = tx.type_manager().create_attribute_type(&type_label.to_typedb(), false).unwrap();
-        attribute_type.set_value_type(tx.type_manager(), value_type.to_typedb())
+        attribute_type.set_value_type(&mut snapshot, tx.type_manager(), value_type.to_typedb())
     });
 }
 


### PR DESCRIPTION
## Usage and product changes

We architecturally formalise multi-reader, single-writer transactions. This allows us to remove locks within a single transaction and greatly simplify the mental model of writes to remove race conditions. Snapshots are now owned directly by transactions and passed by reference, mutably or immutably, to the methods requiring snapshots.

## Implementation

* Remove multiple ownerships of Snapshots - they are now exclusively owned by Transactions
* Pass transactions by reference or mutable reference to all methods that need to access storage
* Update all implementation and tests to use the new architecture