### PR TITLE
Fix generics on ReadableType trait

### DIFF
--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -29,7 +29,7 @@ use crate::{
     concept_iterator,
     ConceptAPI,
     ConceptStatus,
-    error::ConceptWriteError, GetStatus, thing::{
+    error::ConceptWriteError, thing::{
         attribute::Attribute,
         object::{HasAttributeIterator, Object},
         ObjectAPI,

--- a/concept/type_/type_cache.rs
+++ b/concept/type_/type_cache.rs
@@ -171,9 +171,9 @@ impl TypeCache {
         })
     }
 
-    fn build_common_cache<Snapshot: ReadableSnapshot, OUT: 'static, T>(snapshot: &Snapshot, type_: T) -> CommonTypeCache<OUT>
+    fn build_common_cache<Snapshot: ReadableSnapshot, OUT, T>(snapshot: &Snapshot, type_: T) -> CommonTypeCache<OUT>
     where
-        T: TypeAPI<'static> + ReadableType<'static, OUT>,
+        T: TypeAPI<'static> + ReadableType<Out<'static>=OUT>,
         OUT: TypeAPI<'static> + TypeAPITraits + 'static
     {
         let label = TypeReader::get_label(snapshot, type_.clone()).unwrap().unwrap();

--- a/concept/type_/type_cache.rs
+++ b/concept/type_/type_cache.rs
@@ -171,24 +171,23 @@ impl TypeCache {
         })
     }
 
-    fn build_common_cache<Snapshot: ReadableSnapshot, OUT, T>(snapshot: &Snapshot, type_: T) -> CommonTypeCache<OUT>
+    fn build_common_cache<Snapshot: ReadableSnapshot, T>(snapshot: &Snapshot, type_: T) -> CommonTypeCache<T>
     where
-        T: TypeAPI<'static> + ReadableType<Output<'static>=OUT>,
-        OUT: TypeAPI<'static> + TypeAPITraits + 'static
+        T: TypeAPI<'static> + TypeAPITraits + ReadableType<Output<'static>=T>,
     {
         let label = TypeReader::get_label(snapshot, type_.clone()).unwrap().unwrap();
-        let is_root = TypeManager::<Snapshot>::check_type_is_root(&label, OUT::ROOT_KIND);
+        let is_root = TypeManager::<Snapshot>::check_type_is_root(&label, T::ROOT_KIND);
         let annotations_declared = TypeReader::get_type_annotations(snapshot, type_.clone())
             .unwrap()
             .into_iter()
-            .map(|annotation| OUT::AnnotationType::from(annotation))
-            .collect::<HashSet<OUT::AnnotationType>>();
+            .map(|annotation| T::AnnotationType::from(annotation))
+            .collect::<HashSet<T::AnnotationType>>();
         let supertype = TypeReader::get_supertype(snapshot, type_.clone()).unwrap();
         let supertypes = TypeReader::get_supertypes_transitive(snapshot, type_.clone()).unwrap();
         let subtypes_declared = TypeReader::get_subtypes(snapshot, type_.clone()).unwrap();
         let subtypes_transitive = TypeReader::get_subtypes_transitive(snapshot, type_.clone()).unwrap();
         CommonTypeCache {
-            type_ : T::read_from(type_.vertex().into_bytes().into_owned()),
+            type_,
             label,
             is_root,
             annotations_declared,

--- a/concept/type_/type_cache.rs
+++ b/concept/type_/type_cache.rs
@@ -39,7 +39,7 @@ use crate::type_::{
     type_reader::TypeReader,
     Ordering, TypeAPI,
 };
-use crate::type_::type_manager::CommonType;
+use crate::type_::type_manager::TypeAPITraits;
 
 // TODO: could/should we slab allocate the schema cache?
 pub struct TypeCache {
@@ -60,7 +60,7 @@ pub struct TypeCache {
 }
 
 #[derive(Debug)]
-struct CommonTypeCache<T: TypeAPI<'static> + CommonType<'static>> {
+struct CommonTypeCache<T: TypeAPI<'static> + TypeAPITraits> {
     type_: T,
     label: Label<'static>,
     is_root: bool,
@@ -174,7 +174,7 @@ impl TypeCache {
     fn build_common_cache<Snapshot: ReadableSnapshot, OUT: 'static, T>(snapshot: &Snapshot, type_: T) -> CommonTypeCache<OUT>
     where
         T: TypeAPI<'static> + ReadableType<'static, OUT>,
-        OUT: TypeAPI<'static> + CommonType<'static> + 'static
+        OUT: TypeAPI<'static> + TypeAPITraits + 'static
     {
         let label = TypeReader::get_label(snapshot, type_.clone()).unwrap().unwrap();
         let is_root = TypeManager::<Snapshot>::check_type_is_root(&label, OUT::ROOT_KIND);

--- a/concept/type_/type_cache.rs
+++ b/concept/type_/type_cache.rs
@@ -171,8 +171,9 @@ impl TypeCache {
         })
     }
 
-    fn build_common_cache<Snapshot: ReadableSnapshot, T>(snapshot: &Snapshot, type_: T) -> CommonTypeCache<T>
+    fn build_common_cache<Snapshot, T>(snapshot: &Snapshot, type_: T) -> CommonTypeCache<T>
     where
+        Snapshot: ReadableSnapshot,
         T: TypeAPI<'static> + TypeAPITraits + ReadableType<Output<'static>=T>,
     {
         let label = TypeReader::get_label(snapshot, type_.clone()).unwrap().unwrap();

--- a/concept/type_/type_cache.rs
+++ b/concept/type_/type_cache.rs
@@ -173,7 +173,7 @@ impl TypeCache {
 
     fn build_common_cache<Snapshot: ReadableSnapshot, OUT, T>(snapshot: &Snapshot, type_: T) -> CommonTypeCache<OUT>
     where
-        T: TypeAPI<'static> + ReadableType<Out<'static>=OUT>,
+        T: TypeAPI<'static> + ReadableType<Output<'static>=OUT>,
         OUT: TypeAPI<'static> + TypeAPITraits + 'static
     {
         let label = TypeReader::get_label(snapshot, type_.clone()).unwrap().unwrap();

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -773,27 +773,27 @@ impl<'a, 'out> ReadableType<'out, RoleType<'out>> for RoleType<'a> {
 }
 
 
-pub trait CommonType<'a>: TypeAPI<'a> {
+pub trait TypeAPITraits {
     type AnnotationType: Hash + Eq + From<Annotation>;
     const ROOT_KIND: Kind;
 }
 
-impl<'a> CommonType<'a> for AttributeType<'a> {
+impl<'a> TypeAPITraits for AttributeType<'a> {
     type AnnotationType = AttributeTypeAnnotation;
     const ROOT_KIND: Kind = Kind::Attribute;
 }
 
-impl<'a> CommonType<'a> for EntityType<'a> {
+impl<'a> TypeAPITraits for EntityType<'a> {
     type AnnotationType = EntityTypeAnnotation;
     const ROOT_KIND: Kind = Kind::Entity;
 }
 
-impl<'a> CommonType<'a> for RelationType<'a> {
+impl<'a> TypeAPITraits for RelationType<'a> {
     type AnnotationType = RelationTypeAnnotation;
     const ROOT_KIND: Kind = Kind::Relation;
 }
 
-impl<'a> CommonType<'a> for RoleType<'a> {
+impl<'a> TypeAPITraits for RoleType<'a> {
     type AnnotationType = RoleTypeAnnotation;
     const ROOT_KIND: Kind = Kind::Role;
 }

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -741,35 +741,35 @@ impl<Snapshot: WritableSnapshot> TypeManager<Snapshot> {
 
 pub trait ReadableType {
     // Consider replacing 'b with 'static
-    type Output<'out>: 'out;
-    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Output<'out>;
+    type Output<'b>: 'b;
+    fn read_from<'b>(b: Bytes<'b, BUFFER_KEY_INLINE>) -> Self::Output<'b>;
 }
 
 
 impl<'a> ReadableType for AttributeType<'a> {
-    type Output<'out> = AttributeType<'out>;
-    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Output<'out> {
+    type Output<'b> = AttributeType<'b>;
+    fn read_from<'b>(b: Bytes<'b, BUFFER_KEY_INLINE>) -> Self::Output<'b> {
         AttributeType::new(new_vertex_attribute_type(b))
     }
 }
 
 impl<'a> ReadableType for EntityType<'a> {
-    type Output<'out> = EntityType<'out>;
-    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Output<'out> {
+    type Output<'b> = EntityType<'b>;
+    fn read_from<'b>(b: Bytes<'b, BUFFER_KEY_INLINE>) -> Self::Output<'b> {
         EntityType::new(new_vertex_entity_type(b))
     }
 }
 
 impl<'a> ReadableType for RelationType<'a> {
-    type Output<'out> = RelationType<'out>;
-    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Output<'out> {
+    type Output<'b> = RelationType<'b>;
+    fn read_from<'b>(b: Bytes<'b, BUFFER_KEY_INLINE>) -> Self::Output<'b> {
         RelationType::new(new_vertex_relation_type(b))
     }
 }
 
 impl<'a> ReadableType for RoleType<'a> {
-    type Output<'out> = RoleType<'out>;
-    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Output<'out> {
+    type Output<'b> = RoleType<'b>;
+    fn read_from<'b>(b: Bytes<'b, BUFFER_KEY_INLINE>) -> Self::Output<'b> {
         RoleType::new(new_vertex_role_type(b))
     }
 }

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -740,36 +740,36 @@ impl<Snapshot: WritableSnapshot> TypeManager<Snapshot> {
 }
 
 pub trait ReadableType {
-    // Consider replacing 'b with 'static
-    type Output<'b>: 'b;
-    fn read_from<'b>(b: Bytes<'b, BUFFER_KEY_INLINE>) -> Self::Output<'b>;
+    // Consider replacing 'bytes with 'static
+    type Output<'bytes>: 'bytes;
+    fn read_from<'bytes>(b: Bytes<'bytes, BUFFER_KEY_INLINE>) -> Self::Output<'bytes>;
 }
 
 
 impl<'a> ReadableType for AttributeType<'a> {
-    type Output<'b> = AttributeType<'b>;
-    fn read_from<'b>(b: Bytes<'b, BUFFER_KEY_INLINE>) -> Self::Output<'b> {
+    type Output<'bytes> = AttributeType<'bytes>;
+    fn read_from<'bytes>(b: Bytes<'bytes, BUFFER_KEY_INLINE>) -> Self::Output<'bytes> {
         AttributeType::new(new_vertex_attribute_type(b))
     }
 }
 
 impl<'a> ReadableType for EntityType<'a> {
-    type Output<'b> = EntityType<'b>;
-    fn read_from<'b>(b: Bytes<'b, BUFFER_KEY_INLINE>) -> Self::Output<'b> {
+    type Output<'bytes> = EntityType<'bytes>;
+    fn read_from<'bytes>(b: Bytes<'bytes, BUFFER_KEY_INLINE>) -> Self::Output<'bytes> {
         EntityType::new(new_vertex_entity_type(b))
     }
 }
 
 impl<'a> ReadableType for RelationType<'a> {
-    type Output<'b> = RelationType<'b>;
-    fn read_from<'b>(b: Bytes<'b, BUFFER_KEY_INLINE>) -> Self::Output<'b> {
+    type Output<'bytes> = RelationType<'bytes>;
+    fn read_from<'bytes>(b: Bytes<'bytes, BUFFER_KEY_INLINE>) -> Self::Output<'bytes> {
         RelationType::new(new_vertex_relation_type(b))
     }
 }
 
 impl<'a> ReadableType for RoleType<'a> {
-    type Output<'b> = RoleType<'b>;
-    fn read_from<'b>(b: Bytes<'b, BUFFER_KEY_INLINE>) -> Self::Output<'b> {
+    type Output<'bytes> = RoleType<'bytes>;
+    fn read_from<'bytes>(b: Bytes<'bytes, BUFFER_KEY_INLINE>) -> Self::Output<'bytes> {
         RoleType::new(new_vertex_role_type(b))
     }
 }

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -744,39 +744,38 @@ impl<Snapshot: WritableSnapshot> TypeManager<Snapshot> {
 
 pub trait ReadableType {
     // Consider replacing 'b with 'static
-    type Out<'out>: 'out;
-    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Out<'out>;
+    type Output<'out>: 'out;
+    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Output<'out>;
 }
 
 
 impl<'a> ReadableType for AttributeType<'a> {
-    type Out<'out> = AttributeType<'out>;
-    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Out<'out> {
+    type Output<'out> = AttributeType<'out>;
+    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Output<'out> {
         AttributeType::new(new_vertex_attribute_type(b))
     }
 }
 
 impl<'a> ReadableType for EntityType<'a> {
-    type Out<'out> = EntityType<'out>;
-    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Out<'out> {
+    type Output<'out> = EntityType<'out>;
+    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Output<'out> {
         EntityType::new(new_vertex_entity_type(b))
     }
 }
 
 impl<'a> ReadableType for RelationType<'a> {
-    type Out<'out> = RelationType<'out>;
-    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Out<'out> {
+    type Output<'out> = RelationType<'out>;
+    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Output<'out> {
         RelationType::new(new_vertex_relation_type(b))
     }
 }
 
 impl<'a> ReadableType for RoleType<'a> {
-    type Out<'out> = RoleType<'out>;
-    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Out<'out> {
+    type Output<'out> = RoleType<'out>;
+    fn read_from<'out>(b: Bytes<'out, BUFFER_KEY_INLINE>) -> Self::Output<'out> {
         RoleType::new(new_vertex_role_type(b))
     }
 }
-
 
 pub trait TypeAPITraits {
     type AnnotationType: Hash + Eq + From<Annotation>;

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -252,10 +252,7 @@ macro_rules! get_type_annotations {
     }
 }
 
-// TODO: The '_s is only here for the enforcement of pass-by-value of types. If we drop that, we can move it to the function signatures
-impl<'_s, Snapshot: ReadableSnapshot> TypeManager<Snapshot>
-where
-    '_s: 'static,
+impl<Snapshot: ReadableSnapshot> TypeManager<Snapshot>
 {
     pub fn new(
         vertex_generator: Arc<TypeVertexGenerator>,
@@ -419,7 +416,7 @@ where
         }
     }
 
-    pub(crate) fn get_owns_ordering(&self, snapshot: &Snapshot, owns: Owns<'_s>) -> Result<Ordering, ConceptReadError> {
+    pub(crate) fn get_owns_ordering(&self, snapshot: &Snapshot, owns: Owns<'static>) -> Result<Ordering, ConceptReadError> {
         if let Some(cache) = &self.type_cache {
             Ok(cache.get_owns_ordering(owns))
         } else {

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -109,7 +109,7 @@ macro_rules! get_type_methods {
                 if let Some(cache) = &self.type_cache {
                     Ok(cache.$cache_method(label))
                 } else {
-                    TypeReader::get_labelled_type::<$output_type<'static>>(snapshot, label)
+                    TypeReader::get_labelled_type::<$output_type<'static>, $output_type<'static>>(snapshot, label)
                 }
             }
         )*
@@ -743,36 +743,31 @@ impl<Snapshot: WritableSnapshot> TypeManager<Snapshot> {
     }
 }
 
-pub trait ReadableType<'a, 'b>: TypeAPI<'a> + CommonType<'a> {
+pub trait ReadableType<'out, OUT: 'out> {
     // Consider replacing 'b with 'static
-    type SelfRead: ReadableType<'b, 'b>;
-    fn read_from(b: Bytes<'b, BUFFER_KEY_INLINE>) -> Self::SelfRead;
+    fn read_from(b: Bytes<'out, BUFFER_KEY_INLINE>) -> OUT;
 }
 
-impl<'a, 'b> ReadableType<'a, 'b> for AttributeType<'a> {
-    type SelfRead = AttributeType<'b>;
-    fn read_from(b: Bytes<'b, BUFFER_KEY_INLINE>) -> Self::SelfRead {
+impl<'a, 'out> ReadableType<'out, AttributeType<'out>> for AttributeType<'a> {
+    fn read_from(b: Bytes<'out, BUFFER_KEY_INLINE>) -> AttributeType<'out> {
         AttributeType::new(new_vertex_attribute_type(b))
     }
 }
 
-impl<'a, 'b> ReadableType<'a, 'b> for EntityType<'a> {
-    type SelfRead = EntityType<'b>;
-    fn read_from(b: Bytes<'b, BUFFER_KEY_INLINE>) -> Self::SelfRead {
+impl<'a, 'out> ReadableType<'out, EntityType<'out>> for EntityType<'a> {
+    fn read_from(b: Bytes<'out, BUFFER_KEY_INLINE>) -> EntityType<'out> {
         EntityType::new(new_vertex_entity_type(b))
     }
 }
 
-impl<'a, 'b> ReadableType<'a, 'b> for RelationType<'a> {
-    type SelfRead = RelationType<'b>;
-    fn read_from(b: Bytes<'b, BUFFER_KEY_INLINE>) -> RelationType<'b> {
+impl<'a, 'out> ReadableType<'out, RelationType<'out>> for RelationType<'a> {
+    fn read_from(b: Bytes<'out, BUFFER_KEY_INLINE>) -> RelationType<'out> {
         RelationType::new(new_vertex_relation_type(b))
     }
 }
 
-impl<'a, 'b> ReadableType<'a, 'b> for RoleType<'a> {
-    type SelfRead = RoleType<'b>;
-    fn read_from(b: Bytes<'b, BUFFER_KEY_INLINE>) -> RoleType<'b> {
+impl<'a, 'out> ReadableType<'out, RoleType<'out>> for RoleType<'a> {
+    fn read_from(b: Bytes<'out, BUFFER_KEY_INLINE>) -> RoleType<'out> {
         RoleType::new(new_vertex_role_type(b))
     }
 }

--- a/concept/type_/type_reader.rs
+++ b/concept/type_/type_reader.rs
@@ -56,13 +56,13 @@ impl TypeReader {
             .map(|(key, _)| new_edge_sub(key.into_byte_array_or_ref()).to().into_owned()))
     }
 
-    pub(crate) fn get_supertype<T: ReadableType + TypeAPI<'static>>(snapshot: &impl ReadableSnapshot, subtype: T) -> Result<Option<T::Output<'static>>, ConceptReadError>
+    pub(crate) fn get_supertype<T>(snapshot: &impl ReadableSnapshot, subtype: T) -> Result<Option<T::Output<'static>>, ConceptReadError>
         where T: ReadableType + TypeAPI<'static>
     {
         Ok(Self::get_supertype_vertex(snapshot, subtype.into_vertex())?.map(|supertype_vertex| T::read_from(supertype_vertex.into_bytes())))
     }
 
-    pub fn get_supertypes_transitive<T: ReadableType + TypeAPI<'static>>(snapshot: &impl ReadableSnapshot, subtype: T) -> Result<Vec<T::Output<'static>>, ConceptReadError>
+    pub fn get_supertypes_transitive<T>(snapshot: &impl ReadableSnapshot, subtype: T) -> Result<Vec<T::Output<'static>>, ConceptReadError>
         where T: ReadableType + TypeAPI<'static>
     {
         // WARN: supertypes currently do NOT include themselves
@@ -177,7 +177,7 @@ impl TypeReader {
             .map(|v| { v.first().unwrap().clone() })
     }
 
-    pub(crate) fn get_value_type(snapshot: &impl ReadableSnapshot, type_: AttributeType<'static>) -> Result<Option<ValueType>, ConceptReadError> {
+    pub(crate) fn get_value_type<'a>(snapshot: &impl ReadableSnapshot, type_: AttributeType<'a>) -> Result<Option<ValueType>, ConceptReadError> {
         snapshot
             .get_mapped(
                 build_property_type_value_type(type_.into_vertex()).into_storage_key().as_reference(),
@@ -188,9 +188,9 @@ impl TypeReader {
             .map_err(|error| ConceptReadError::SnapshotGet { source: error })
     }
 
-    pub(crate) fn get_type_annotations(
+    pub(crate) fn get_type_annotations<'a>(
         snapshot: &impl ReadableSnapshot,
-        type_: impl TypeAPI<'static>,
+        type_: impl TypeAPI<'a>,
     ) -> Result<HashSet<Annotation>, ConceptReadError> {
         snapshot
             .iterate_range(KeyRange::new_inclusive(
@@ -252,7 +252,7 @@ impl TypeReader {
             .map_err(|err| ConceptReadError::SnapshotIterate { source: err.clone() })
     }
 
-    pub(crate) fn get_type_ordering<'a>(snapshot: &impl ReadableSnapshot, role_type: RoleType<'static>) -> Result<Ordering, ConceptReadError> {
+    pub(crate) fn get_type_ordering<'a>(snapshot: &impl ReadableSnapshot, role_type: RoleType<'a>) -> Result<Ordering, ConceptReadError> {
         let ordering = snapshot
             .get_mapped(
                 build_property_type_ordering(role_type.vertex()).into_storage_key().as_reference(),
@@ -261,7 +261,7 @@ impl TypeReader {
             .map_err(|err| ConceptReadError::SnapshotGet { source: err })?;
         Ok(ordering.unwrap())
     }
-    pub(crate) fn get_type_edge_ordering<'a>(snapshot: &impl ReadableSnapshot, owns: Owns<'static>)  -> Result<Ordering, ConceptReadError> {
+    pub(crate) fn get_type_edge_ordering<'a>(snapshot: &impl ReadableSnapshot, owns: Owns<'a>)  -> Result<Ordering, ConceptReadError> {
         let ordering = snapshot
             .get_mapped(
                 build_property_type_edge_ordering(owns.into_type_edge()).into_storage_key().as_reference(),

--- a/concept/type_/type_reader.rs
+++ b/concept/type_/type_reader.rs
@@ -37,7 +37,7 @@ pub struct TypeReader { }
 impl<'_s> TypeReader
     where '_s : 'static {
 
-    pub(crate) fn get_labelled_type<U: ReadableType>(snapshot: &impl ReadableSnapshot, label: &Label<'_>) -> Result<Option<U::Out<'static>>, ConceptReadError>
+    pub(crate) fn get_labelled_type<U: ReadableType>(snapshot: &impl ReadableSnapshot, label: &Label<'_>) -> Result<Option<U::Output<'static>>, ConceptReadError>
     {
         let key = LabelToTypeVertexIndex::build(label).into_storage_key();
         match snapshot.get::<BUFFER_KEY_INLINE>(key.as_reference()) {
@@ -57,11 +57,11 @@ impl<'_s> TypeReader
             .map(|(key, _)| new_edge_sub(key.into_byte_array_or_ref()).to().into_owned()))
     }
 
-    pub(crate) fn get_supertype<U: ReadableType + TypeAPI<'_s>>(snapshot: &impl ReadableSnapshot, subtype: U) -> Result<Option<U::Out<'static>>, ConceptReadError> {
+    pub(crate) fn get_supertype<U: ReadableType + TypeAPI<'_s>>(snapshot: &impl ReadableSnapshot, subtype: U) -> Result<Option<U::Output<'static>>, ConceptReadError> {
         Ok(Self::get_supertype_vertex(snapshot, subtype.into_vertex())?.map(|supertype_vertex| U::read_from(supertype_vertex.into_bytes())))
     }
 
-    pub fn get_supertypes_transitive<U: ReadableType + TypeAPI<'_s>>(snapshot: &impl ReadableSnapshot, subtype: U) -> Result<Vec<U::Out<'static>>, ConceptReadError> {
+    pub fn get_supertypes_transitive<U: ReadableType + TypeAPI<'_s>>(snapshot: &impl ReadableSnapshot, subtype: U) -> Result<Vec<U::Output<'static>>, ConceptReadError> {
         // WARN: supertypes currently do NOT include themselves
         // ^ To fix, Just start with `let mut supertype = Some(type_)`
         let mut supertypes = Vec::new();
@@ -81,13 +81,13 @@ impl<'_s> TypeReader
             .map_err(|error| ConceptReadError::SnapshotIterate { source: error })
     }
 
-    pub(crate) fn get_subtypes<U: ReadableType + TypeAPI<'_s>>(snapshot: &impl ReadableSnapshot, supertype: U) -> Result<Vec<U::Out<'static>>, ConceptReadError> {
+    pub(crate) fn get_subtypes<U: ReadableType + TypeAPI<'_s>>(snapshot: &impl ReadableSnapshot, supertype: U) -> Result<Vec<U::Output<'static>>, ConceptReadError> {
         Ok(Self::get_subtypes_vertex(snapshot, supertype.into_vertex())?.into_iter()
             .map(|subtype_vertex| U::read_from(subtype_vertex.into_bytes()))
-            .collect::<Vec<U::Out<'static>>>())
+            .collect::<Vec<U::Output<'static>>>())
     }
 
-    pub fn get_subtypes_transitive<U: TypeAPI<'_s> + ReadableType>(snapshot: &impl ReadableSnapshot, subtype: U) -> Result<Vec<U::Out<'static>>, ConceptReadError> {
+    pub fn get_subtypes_transitive<U: TypeAPI<'_s> + ReadableType>(snapshot: &impl ReadableSnapshot, subtype: U) -> Result<Vec<U::Output<'static>>, ConceptReadError> {
         // WARN: subtypes currently do NOT include themselves
         // ^ To fix, Just start with `let mut stack = vec!(subtype.clone());`
         let mut subtypes = Vec::new();

--- a/concept/type_/type_reader.rs
+++ b/concept/type_/type_reader.rs
@@ -35,7 +35,7 @@ pub struct TypeReader { }
 
 impl TypeReader {
 
-    pub(crate) fn get_labelled_type<Tgi>(snapshot: &impl ReadableSnapshot, label: &Label<'_>) -> Result<Option<T::Output<'static>>, ConceptReadError>
+    pub(crate) fn get_labelled_type<T>(snapshot: &impl ReadableSnapshot, label: &Label<'_>) -> Result<Option<T::Output<'static>>, ConceptReadError>
         where T: ReadableType
     {
         let key = LabelToTypeVertexIndex::build(label).into_storage_key();


### PR DESCRIPTION
## Usage and product changes
Fix generics on ReadableType trait

## Implementation
Changes the output type lifetime to be a generic parameter on the method rather than on the trait.