### PR TITLE
Turn off statistics reporting in CI

### DIFF
--- a/test/assembly/AssemblyTest.java
+++ b/test/assembly/AssemblyTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 import static com.vaticle.typedb.common.collection.Collections.map;
@@ -19,12 +20,15 @@ import static com.vaticle.typedb.common.collection.Collections.pair;
 
 public class AssemblyTest {
 
+    private static final Map<String, String> TYPEDB_OPTIONS = map(
+            pair("--diagnostics.reporting.errors", "false"),
+            pair("--diagnostics.reporting.statistics", "false"),
+            pair("--diagnostics.monitoring.enable", "false")
+    );
+
     @Test
     public void bootup() throws InterruptedException, TimeoutException, IOException {
-        TypeDBCoreRunner server = new TypeDBCoreRunner(map(
-            pair("--diagnostics.reporting.errors", "false"),
-            pair("--diagnostics.monitoring.enable", "false")
-        ));
+        TypeDBCoreRunner server = new TypeDBCoreRunner(TYPEDB_OPTIONS);
         try {
             server.start();
         } finally {
@@ -34,10 +38,7 @@ public class AssemblyTest {
 
     @Test
     public void console() throws InterruptedException, TimeoutException, IOException {
-        TypeDBCoreRunner server = new TypeDBCoreRunner(map(
-            pair("--diagnostics.reporting.errors", "false"),
-            pair("--diagnostics.monitoring.enable", "false")
-        ));
+        TypeDBCoreRunner server = new TypeDBCoreRunner(TYPEDB_OPTIONS);
         try {
             server.start();
             TypeDBConsoleRunner console = new TypeDBConsoleRunner();

--- a/test/assembly/DockerTest.java
+++ b/test/assembly/DockerTest.java
@@ -40,7 +40,7 @@ public class DockerTest {
                 "docker", "run", "--name", "typedb",
                 "--rm", "-t", "-p", String.format("%d:%d", typeDBPort, typeDBPort),
                 "bazel:assemble-docker",
-                "/opt/typedb-all-linux-x86_64/typedb", "server", "--diagnostics.reporting.errors=false"
+                "/opt/typedb-all-linux-x86_64/typedb", "server", "--diagnostics.reporting.errors=false", "--diagnostics.reporting.statistics=false"
         ).start();
         TypeDBConsoleRunner consoleRunner = new TypeDBConsoleRunner();
         testIsReady(consoleRunner);

--- a/test/deployment/AptTest.java
+++ b/test/deployment/AptTest.java
@@ -67,7 +67,7 @@ public class AptTest {
     }
 
     private void start() throws InterruptedException, IOException {
-        typeDBProcess = executor.command("typedb", "server", "--diagnostics.reporting.errors=false").start();
+        typeDBProcess = executor.command("typedb", "server", "--diagnostics.reporting.errors=false", "--diagnostics.reporting.statistics=false").start();
 
         waitUntilReady();
         assertTrue("TypeDB failed to start", typeDBProcess.getProcess().isAlive());

--- a/test/integration/server/ParametersTest.java
+++ b/test/integration/server/ParametersTest.java
@@ -47,7 +47,8 @@ public class ParametersTest {
                             new Option("log.output.file.archive-age-limit", "2 minutes"),
                             new Option("log.logger.default.level", "trace"),
                             new Option("log.logger.storage.level", "trace"),
-                            new Option("diagnostics.reporting.errors", "false")
+                            new Option("diagnostics.reporting.errors", "false"),
+                            new Option("diagnostics.reporting.statistics", "false")
                     ),
                     new CoreConfigParser()
             );


### PR DESCRIPTION
## Usage and product changes
We turn off the `--diagnostics.reporting.statistics` in our CI builds not to send non-real diagnostics data.

In version 2.28 and earlier, this flag purely prevents `TypeDB` from sending any diagnostics data.
In the upcoming version 2.28.1, this flag still allows `TypeDB` to send a single diagnostics snapshot with the information of when the diagnostics data has been turned off, but it happens only after the server runs for 1 hour, so we expect the CI builds not to reach this point and not to send any diagnostics data as well.