### PR TITLE
Cleaner logs when transaction close forcibly terminates reasoner

### DIFF
--- a/reasoner/controller/AbstractController.java
+++ b/reasoner/controller/AbstractController.java
@@ -100,20 +100,20 @@ public abstract class AbstractController<
             String code = ((TypeDBException) e).errorMessage().code();
             if (code.equals(RESOURCE_CLOSED.code())) {
                 LOG.debug("Controller interrupted by resource close: {}", e.getMessage());
-                context.registry().terminate(e);
+                context.registry().exception(e);
                 return;
             } else {
                 LOG.debug("Controller interrupted by TypeDB exception: {}", e.getMessage());
             }
         }
         LOG.error("Actor exception", e);
-        context.registry().terminate(e);
+        context.registry().exception(e);
     }
 
     @Override
-    public void terminate(Throwable cause) {
+    public void terminate(@Nullable Throwable cause) {
         super.terminate(cause);
-        LOG.debug("Controller terminated.", cause);
+        if (cause != null) LOG.debug("Controller terminated.", cause);
         processors.values().forEach(p -> p.executeNext(a -> a.terminate(cause)));
     }
 

--- a/reasoner/controller/ConcludableController.java
+++ b/reasoner/controller/ConcludableController.java
@@ -145,7 +145,9 @@ public abstract class ConcludableController<INPUT, OUTPUT,
         @Override
         public void terminate(@Nullable Throwable cause) {
             super.terminate(cause);
-            reasonerConsumer.exception(cause);
+            if (cause != null) {
+                reasonerConsumer.exception(cause);
+            }
         }
 
         @Override

--- a/reasoner/controller/ControllerRegistry.java
+++ b/reasoner/controller/ControllerRegistry.java
@@ -46,7 +46,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.vaticle.typedb.core.common.exception.ErrorMessage.Reasoner.REASONING_TERMINATED_WITH_CAUSE;
-import static com.vaticle.typedb.core.common.exception.ErrorMessage.Transaction.TRANSACTION_CLOSED;
 import static java.util.stream.Collectors.toMap;
 
 public class ControllerRegistry {
@@ -106,10 +105,14 @@ public class ControllerRegistry {
         return logicMgr;
     }
 
-    public void terminate(Throwable cause) {
+    public void exception(Throwable cause) {
+        LOG.error("Terminating reasoning due to exception:", cause);
+        terminate(TypeDBException.of(REASONING_TERMINATED_WITH_CAUSE, cause));
+    }
+
+    public void terminate(TypeDBException cause) {
         if (terminated.compareAndSet(false, true)) {
-            LOG.error("Terminating reasoning due to exception:", cause);
-            terminationCause = TypeDBException.of(REASONING_TERMINATED_WITH_CAUSE, cause);
+            terminationCause = cause;
             controllers.forEach(actor -> actor.executeNext(a -> a.terminate(terminationCause)));
             materialisationController.executeNext(a -> a.terminate(terminationCause));
             controllerContext.processor().monitor().executeNext(a -> a.terminate(terminationCause));
@@ -124,6 +127,7 @@ public class ControllerRegistry {
             ReasonerConsumer<?> reasonerConsumer, Function<Driver<C>, C> actorFn
     ) {
         if (terminated.get()) {  // guard races without synchronized
+            assert terminationCause != null;
             reasonerConsumer.exception(terminationCause);
             throw terminationCause;
         }
@@ -135,6 +139,7 @@ public class ControllerRegistry {
 
     private <C extends AbstractController<?, ?, ?, ?, ?, C>> Driver<C> createController(Function<Driver<C>, C> actorFn) {
         if (terminated.get()) {  // guard races without synchronized
+            assert terminationCause != null;
             throw terminationCause;
         }
         Driver<C> controller = Actor.driver(actorFn, controllerContext.executorService());
@@ -279,10 +284,7 @@ public class ControllerRegistry {
         controllerContext.tracer().ifPresent(Tracer::finishTrace);
         controllerContext.processor().perfCounters().logCounters();
         controllerContext.processor().perfCounters().stopPrinting();
-        terminationCause = null;
-        controllers.forEach(controller -> controller.executeNext(driver -> driver.terminate(terminationCause)));
-        materialisationController.executeNext(a -> a.terminate(terminationCause));
-        controllerContext.processor().monitor().executeNext(a -> a.terminate(terminationCause));
+        terminate(null);
     }
 
     public static abstract class ControllerView {

--- a/reasoner/controller/ControllerRegistry.java
+++ b/reasoner/controller/ControllerRegistry.java
@@ -279,7 +279,7 @@ public class ControllerRegistry {
         controllerContext.tracer().ifPresent(Tracer::finishTrace);
         controllerContext.processor().perfCounters().logCounters();
         controllerContext.processor().perfCounters().stopPrinting();
-        terminationCause = TypeDBException.of(REASONING_TERMINATED_WITH_CAUSE, TypeDBException.of(TRANSACTION_CLOSED));
+        terminationCause = null;
         controllers.forEach(controller -> controller.executeNext(driver -> driver.terminate(terminationCause)));
         materialisationController.executeNext(a -> a.terminate(terminationCause));
         controllerContext.processor().monitor().executeNext(a -> a.terminate(terminationCause));

--- a/reasoner/controller/RootConjunctionController.java
+++ b/reasoner/controller/RootConjunctionController.java
@@ -14,6 +14,7 @@ import com.vaticle.typedb.core.reasoner.processor.reactive.Reactive.Stream;
 import com.vaticle.typedb.core.reasoner.processor.reactive.RootSink;
 import com.vaticle.typedb.core.traversal.common.Modifiers;
 
+import javax.annotation.Nullable;
 import java.util.function.Supplier;
 
 public class RootConjunctionController
@@ -48,9 +49,11 @@ public class RootConjunctionController
     }
 
     @Override
-    public void terminate(Throwable cause) {
+    public void terminate(@Nullable Throwable cause) {
         super.terminate(cause);
-        reasonerConsumer.exception(cause);
+        if (cause != null) {
+            reasonerConsumer.exception(cause);
+        }
     }
 
     protected static class Processor extends ConjunctionController.Processor<Processor> {

--- a/reasoner/controller/RootDisjunctionController.java
+++ b/reasoner/controller/RootDisjunctionController.java
@@ -52,7 +52,9 @@ public class RootDisjunctionController
     @Override
     public void terminate(Throwable cause) {
         super.terminate(cause);
-        reasonerConsumer.exception(cause);
+        if (cause != null) {
+            reasonerConsumer.exception(cause);
+        }
     }
 
     protected static class Processor extends DisjunctionController.Processor<ConceptMap, Processor> {

--- a/reasoner/processor/reactive/Monitor.java
+++ b/reasoner/processor/reactive/Monitor.java
@@ -296,7 +296,7 @@ public class Monitor extends Actor<Monitor> {
 
         private void checkFinished() {
             assert !finishing;
-            if (!finished && activeSources.isEmpty()){
+            if (!finished && activeSources.isEmpty()) {
                 assert activeFrontiers >= 0;
                 if (activeFrontiers == 0) {
                     assert activeAnswers >= 0;
@@ -363,7 +363,7 @@ public class Monitor extends Actor<Monitor> {
     }
 
     public void terminate(Throwable cause) {
-        LOG.debug("Monitor terminated.", cause);
+        if (cause != null) LOG.debug("Monitor terminated.", cause);
         this.terminated = true;
     }
 

--- a/test/integration/reasoner/ReasonerTest.java
+++ b/test/integration/reasoner/ReasonerTest.java
@@ -163,7 +163,7 @@ public class ReasonerTest {
             }
             try (CoreTransaction txn = singleThreadElgTransaction(session, Arguments.Transaction.Type.READ)) {
                 RuntimeException exception = new RuntimeException();
-                txn.reasoner().controllerRegistry().terminate(exception);
+                txn.reasoner().controllerRegistry().exception(exception);
                 try {
                     List<? extends ConceptMap> ans = txn.query().get(TypeQL.parseQuery("match $x isa is-still-good; get;").asGet()).toList();
                 } catch (TypeDBException e) {

--- a/test/integration/reasoner/controller/ControllerTest.java
+++ b/test/integration/reasoner/controller/ControllerTest.java
@@ -138,7 +138,7 @@ public class ControllerTest {
                     fail();
                 }
                 Exception e = new RuntimeException("Intentional kill");
-                registry.terminate(e);
+                registry.exception(e);
                 Throwable receivedException = answerProducer.exceptions().poll(200, TimeUnit.MILLISECONDS);
                 assertEquals(TypeDBException.of(REASONING_TERMINATED_WITH_CAUSE, e), receivedException);
             }


### PR DESCRIPTION
## Usage and product changes
We update the reasoner to explicitly check whether the cause of termination was a transaction close or an exception, and only log in the latter case.

## Implementation
* Refactor `ControllerRegistry.{close, terminate}` to be `ControllerRegistry.{close, exception}` which both call `terminate(@Nullable Throwable cause)`
* Add a check in terminate on root controllers to only call `ReasonerConsumer.exception` if the cause is non-null