### PR TITLE
Update APT maintainer to TypeDB Community

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -294,7 +294,7 @@ assemble_apt(
     empty_dirs_permission = "0777",
     files = assemble_files,
     installation_dir = apt_installation_dir,
-    maintainer = "Vaticle <community@vaticle.com>",
+    maintainer = "TypeDB Community <community@typedb.com>",
     symlinks = apt_symlinks,
     workspace_refs = "@vaticle_typedb_workspace_refs//:refs.json",
 )
@@ -329,7 +329,7 @@ assemble_apt(
     empty_dirs_permission = "0777",
     files = assemble_files,
     installation_dir = apt_installation_dir,
-    maintainer = "Vaticle <community@vaticle.com>",
+    maintainer = "TypeDB Community <community@typedb.com>",
     symlinks = apt_symlinks,
     workspace_refs = "@vaticle_typedb_workspace_refs//:refs.json",
 )


### PR DESCRIPTION
## Usage and product changes

The `maintainer` field of our APT package is now **TypeDB Community <community@typedb.com>**.

## Implementation

The former labels "Vaticle" and "community@vaticle.com" are no longer applicable and have been replaced.